### PR TITLE
[codex] Improve trackball scaling control

### DIFF
--- a/src/pages/TrackballPage.tsx
+++ b/src/pages/TrackballPage.tsx
@@ -60,10 +60,7 @@ function scalingValueToFraction(value: number): {
 }
 
 function scalingValueToButtonStep(value: number, direction: -1 | 1): number {
-  const stepCount =
-    direction > 0
-      ? Math.floor(value / SCALING_BUTTON_STEP) + 1
-      : Math.ceil(value / SCALING_BUTTON_STEP) - 1;
+  const stepCount = Math.round(value / SCALING_BUTTON_STEP) + direction;
   return clamp(
     stepCount * SCALING_BUTTON_STEP,
     SCALING_MIN,
@@ -72,9 +69,7 @@ function scalingValueToButtonStep(value: number, direction: -1 | 1): number {
 }
 
 function formatScalingValue(value: number): string {
-  if (value < 1) return value.toFixed(2);
-  if (value < 10) return value.toFixed(1);
-  return Math.round(value).toString();
+  return value.toFixed(2);
 }
 
 export function TrackballPage() {

--- a/src/pages/TrackballPage.tsx
+++ b/src/pages/TrackballPage.tsx
@@ -15,6 +15,9 @@ const SCALING_MAX = 10;
 const SCALING_STEPS = 100;
 const SCALING_BUTTON_STEP = 0.05;
 const SCALING_PRECISION = 1000;
+const ROTATION_MIN = -180;
+const ROTATION_MAX = 180;
+const ROTATION_STEP = 1;
 
 function clamp(value: number, min: number, max: number): number {
   return Math.min(max, Math.max(min, value));
@@ -234,7 +237,8 @@ export function TrackballPage() {
 
   const handleRotationChange = (degrees: number) => {
     if (!processor) return;
-    rotationSave.setPendingValue(degrees, async (value) => {
+    const clampedDegrees = clamp(degrees, ROTATION_MIN, ROTATION_MAX);
+    rotationSave.setPendingValue(clampedDegrees, async (value) => {
       await setRotation(processor.id, value);
     });
   };
@@ -608,39 +612,66 @@ export function TrackballPage() {
               </div>
 
               {rotationEnabled && (
-                <div>
-                  {/* Slider centered at 0, ranging from -180 to +180 */}
-                  <input
-                    type="range"
-                    min={-180}
-                    max={180}
-                    step={1}
-                    value={displayRotation}
-                    onChange={(e) =>
-                      handleRotationChange(Number(e.target.value))
+                <div className="flex items-center gap-3">
+                  <button
+                    type="button"
+                    aria-label="Decrease rotation"
+                    onClick={() =>
+                      handleRotationChange(displayRotation - ROTATION_STEP)
                     }
-                    className="w-full h-2 rounded-lg appearance-none cursor-pointer
-                      bg-[var(--color-border)]
-                      [&::-webkit-slider-thumb]:appearance-none
-                      [&::-webkit-slider-thumb]:w-4
-                      [&::-webkit-slider-thumb]:h-4
-                      [&::-webkit-slider-thumb]:rounded-full
-                      [&::-webkit-slider-thumb]:bg-[var(--color-electric)]
-                      [&::-webkit-slider-thumb]:cursor-pointer
-                      [&::-webkit-slider-thumb]:shadow-[0_0_8px_var(--color-electric)]
-                      [&::-moz-range-thumb]:w-4
-                      [&::-moz-range-thumb]:h-4
-                      [&::-moz-range-thumb]:rounded-full
-                      [&::-moz-range-thumb]:bg-[var(--color-electric)]
-                      [&::-moz-range-thumb]:border-0
-                      [&::-moz-range-thumb]:cursor-pointer
-                      [&::-moz-range-thumb]:shadow-[0_0_8px_var(--color-electric)]"
-                  />
-                  <div className="flex justify-between mt-2 text-xs text-[var(--color-text-muted)]">
-                    <span>-180°</span>
-                    <span>0°</span>
-                    <span>+180°</span>
+                    disabled={displayRotation <= ROTATION_MIN}
+                    className="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-lg bg-[var(--color-surface)] border border-[var(--color-border)] text-[var(--color-text-secondary)] hover:bg-[var(--color-border)] hover:text-[var(--color-text)] disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+                  >
+                    <IconChevronLeft size={18} />
+                  </button>
+
+                  {/* Slider centered at 0, ranging from -180 to +180 */}
+                  <div className="min-w-0 flex-1">
+                    <input
+                      type="range"
+                      aria-label="Rotation"
+                      min={ROTATION_MIN}
+                      max={ROTATION_MAX}
+                      step={ROTATION_STEP}
+                      value={displayRotation}
+                      onChange={(e) =>
+                        handleRotationChange(Number(e.target.value))
+                      }
+                      className="w-full h-2 rounded-lg appearance-none cursor-pointer
+                        bg-[var(--color-border)]
+                        [&::-webkit-slider-thumb]:appearance-none
+                        [&::-webkit-slider-thumb]:w-4
+                        [&::-webkit-slider-thumb]:h-4
+                        [&::-webkit-slider-thumb]:rounded-full
+                        [&::-webkit-slider-thumb]:bg-[var(--color-electric)]
+                        [&::-webkit-slider-thumb]:cursor-pointer
+                        [&::-webkit-slider-thumb]:shadow-[0_0_8px_var(--color-electric)]
+                        [&::-moz-range-thumb]:w-4
+                        [&::-moz-range-thumb]:h-4
+                        [&::-moz-range-thumb]:rounded-full
+                        [&::-moz-range-thumb]:bg-[var(--color-electric)]
+                        [&::-moz-range-thumb]:border-0
+                        [&::-moz-range-thumb]:cursor-pointer
+                        [&::-moz-range-thumb]:shadow-[0_0_8px_var(--color-electric)]"
+                    />
+                    <div className="flex justify-between mt-2 text-xs text-[var(--color-text-muted)]">
+                      <span>-180°</span>
+                      <span>0°</span>
+                      <span>+180°</span>
+                    </div>
                   </div>
+
+                  <button
+                    type="button"
+                    aria-label="Increase rotation"
+                    onClick={() =>
+                      handleRotationChange(displayRotation + ROTATION_STEP)
+                    }
+                    disabled={displayRotation >= ROTATION_MAX}
+                    className="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-lg bg-[var(--color-surface)] border border-[var(--color-border)] text-[var(--color-text-secondary)] hover:bg-[var(--color-border)] hover:text-[var(--color-text)] disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+                  >
+                    <IconChevronRight size={18} />
+                  </button>
                 </div>
               )}
             </div>

--- a/src/pages/TrackballPage.tsx
+++ b/src/pages/TrackballPage.tsx
@@ -11,7 +11,7 @@ import { AxisSnapMode } from "../proto/zmk/runtime_input_processor/runtime_input
 import { useDebouncedSave } from "../hooks/useDebouncedSave";
 
 const SCALING_MIN = 0.1;
-const SCALING_MAX = 300;
+const SCALING_MAX = 10;
 const SCALING_STEPS = 100;
 const SCALING_PRECISION = 1000;
 
@@ -494,7 +494,7 @@ export function TrackballPage() {
                     Scaling
                   </h3>
                   <p className="text-xs text-[var(--color-text-muted)]">
-                    Adjust sensitivity from 0.1x to 300x
+                    Adjust sensitivity from 0.1x to 10x
                   </p>
                 </div>
                 <span className="text-lg font-mono text-[var(--color-electric)]">
@@ -545,7 +545,7 @@ export function TrackballPage() {
                   />
                   <div className="mt-2 flex justify-between text-xs text-[var(--color-text-muted)]">
                     <span>0.1x</span>
-                    <span>300x</span>
+                    <span>10x</span>
                   </div>
                 </div>
 

--- a/src/pages/TrackballPage.tsx
+++ b/src/pages/TrackballPage.tsx
@@ -13,6 +13,7 @@ import { useDebouncedSave } from "../hooks/useDebouncedSave";
 const SCALING_MIN = 0.1;
 const SCALING_MAX = 10;
 const SCALING_STEPS = 100;
+const SCALING_BUTTON_STEP = 0.05;
 const SCALING_PRECISION = 1000;
 
 function clamp(value: number, min: number, max: number): number {
@@ -53,6 +54,18 @@ function scalingValueToFraction(value: number): {
     multiplier: multiplier / divisorValue,
     divisor: divisor / divisorValue,
   };
+}
+
+function scalingValueToButtonStep(value: number, direction: -1 | 1): number {
+  const stepCount =
+    direction > 0
+      ? Math.floor(value / SCALING_BUTTON_STEP) + 1
+      : Math.ceil(value / SCALING_BUTTON_STEP) - 1;
+  return clamp(
+    stepCount * SCALING_BUTTON_STEP,
+    SCALING_MIN,
+    SCALING_MAX,
+  );
 }
 
 function formatScalingValue(value: number): string {
@@ -187,11 +200,9 @@ export function TrackballPage() {
   const scalingSliderIndex = scalingValueToIndex(finalScalingValue);
 
   // Handler functions using useDebouncedSave
-  const handleScalingSliderChange = (index: number) => {
+  const handleScalingValueChange = (value: number) => {
     if (!processor) return;
-    const { multiplier, divisor } = scalingValueToFraction(
-      scalingIndexToValue(index),
-    );
+    const { multiplier, divisor } = scalingValueToFraction(value);
     scalingMultiplierSave.cancel();
     scalingDivisorSave.cancel();
     scalingMultiplierSave.setPendingValue(multiplier, async () => {
@@ -200,6 +211,16 @@ export function TrackballPage() {
     scalingDivisorSave.setPendingValue(divisor, async () => {
       // Multiplier save writes both values together.
     });
+  };
+
+  const handleScalingSliderChange = (index: number) => {
+    handleScalingValueChange(scalingIndexToValue(index));
+  };
+
+  const handleScalingStepChange = (direction: -1 | 1) => {
+    handleScalingValueChange(
+      scalingValueToButtonStep(finalScalingValue, direction),
+    );
   };
 
   const handleRotationEnabledChange = (enabled: boolean) => {
@@ -506,10 +527,8 @@ export function TrackballPage() {
                 <button
                   type="button"
                   aria-label="Decrease scaling"
-                  onClick={() =>
-                    handleScalingSliderChange(scalingSliderIndex - 1)
-                  }
-                  disabled={scalingSliderIndex <= 0}
+                  onClick={() => handleScalingStepChange(-1)}
+                  disabled={finalScalingValue <= SCALING_MIN}
                   className="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-lg bg-[var(--color-surface)] border border-[var(--color-border)] text-[var(--color-text-secondary)] hover:bg-[var(--color-border)] hover:text-[var(--color-text)] disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
                 >
                   <IconChevronLeft size={18} />
@@ -552,10 +571,8 @@ export function TrackballPage() {
                 <button
                   type="button"
                   aria-label="Increase scaling"
-                  onClick={() =>
-                    handleScalingSliderChange(scalingSliderIndex + 1)
-                  }
-                  disabled={scalingSliderIndex >= SCALING_STEPS}
+                  onClick={() => handleScalingStepChange(1)}
+                  disabled={finalScalingValue >= SCALING_MAX}
                   className="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-lg bg-[var(--color-surface)] border border-[var(--color-border)] text-[var(--color-text-secondary)] hover:bg-[var(--color-border)] hover:text-[var(--color-text)] disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
                 >
                   <IconChevronRight size={18} />

--- a/src/pages/TrackballPage.tsx
+++ b/src/pages/TrackballPage.tsx
@@ -1,28 +1,65 @@
 import { useState, useRef } from "react";
-import { IconAlertTriangleFilled, IconPointer } from "@tabler/icons-react";
+import {
+  IconAlertTriangleFilled,
+  IconChevronLeft,
+  IconChevronRight,
+  IconPointer,
+} from "@tabler/icons-react";
 import * as Switch from "@radix-ui/react-switch";
 import { useRuntimeInputProcessor } from "../hooks/useRuntimeInputProcessor";
 import { AxisSnapMode } from "../proto/zmk/runtime_input_processor/runtime_input_processor";
 import { useDebouncedSave } from "../hooks/useDebouncedSave";
 
-// Scaling preset types
-type ScalingPresetType = "wheel" | "scroll";
+const SCALING_MIN = 0.1;
+const SCALING_MAX = 300;
+const SCALING_STEPS = 100;
+const SCALING_PRECISION = 1000;
 
-// Wheel/mouse preset options (multipliers as percentage)
-const WHEEL_PRESETS = [
-  { multiplier: 50, divisor: 100, label: "0.5x" },
-  { multiplier: 75, divisor: 100, label: "0.75x" },
-  { multiplier: 1, divisor: 1, label: "1.0x" },
-  { multiplier: 3, divisor: 2, label: "1.5x" },
-  { multiplier: 2, divisor: 1, label: "2.0x" },
-];
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}
 
-// Scroll preset options (shown as fractions)
-const SCROLL_PRESETS = [
-  { multiplier: 1, divisor: 30, label: "1/30" },
-  { multiplier: 1, divisor: 60, label: "1/60" },
-  { multiplier: 1, divisor: 120, label: "1/120" },
-];
+function gcd(a: number, b: number): number {
+  a = Math.abs(a);
+  b = Math.abs(b);
+  while (b !== 0) {
+    const temp = b;
+    b = a % b;
+    a = temp;
+  }
+  return a;
+}
+
+function scalingIndexToValue(index: number): number {
+  const normalized = clamp(index, 0, SCALING_STEPS) / SCALING_STEPS;
+  return SCALING_MIN * (SCALING_MAX / SCALING_MIN) ** normalized;
+}
+
+function scalingValueToIndex(value: number): number {
+  const clampedValue = clamp(value, SCALING_MIN, SCALING_MAX);
+  const normalized =
+    Math.log(clampedValue / SCALING_MIN) / Math.log(SCALING_MAX / SCALING_MIN);
+  return Math.round(normalized * SCALING_STEPS);
+}
+
+function scalingValueToFraction(value: number): {
+  multiplier: number;
+  divisor: number;
+} {
+  const multiplier = Math.round(value * SCALING_PRECISION);
+  const divisor = SCALING_PRECISION;
+  const divisorValue = gcd(multiplier, divisor);
+  return {
+    multiplier: multiplier / divisorValue,
+    divisor: divisor / divisorValue,
+  };
+}
+
+function formatScalingValue(value: number): string {
+  if (value < 1) return value.toFixed(2);
+  if (value < 10) return value.toFixed(1);
+  return Math.round(value).toString();
+}
 
 export function TrackballPage() {
   const {
@@ -49,10 +86,6 @@ export function TrackballPage() {
 
   // Selected processor index
   const [selectedProcessorIndex, setSelectedProcessorIndex] = useState(0);
-
-  // Scaling preset type selector
-  const [scalingPresetType, setScalingPresetType] =
-    useState<ScalingPresetType>("wheel");
 
   // Rotation enabled state
   const [rotationEnabled, setRotationEnabled] = useState(false);
@@ -151,37 +184,21 @@ export function TrackballPage() {
     displayScalingDivisor !== 0
       ? displayScalingMultiplier / displayScalingDivisor
       : 1;
+  const scalingSliderIndex = scalingValueToIndex(finalScalingValue);
 
   // Handler functions using useDebouncedSave
-  const handleScalingMultiplierChange = (multiplier: number) => {
+  const handleScalingSliderChange = (index: number) => {
     if (!processor) return;
-    scalingMultiplierSave.setPendingValue(multiplier, async (value) => {
-      const divisor = scalingDivisorSave.pendingValue ?? processor.scaleDivisor;
-      await setScaling(processor.id, value, divisor);
-    });
-  };
-
-  const handleScalingDivisorChange = (divisor: number) => {
-    if (!processor) return;
-    scalingDivisorSave.setPendingValue(divisor, async (value) => {
-      const multiplier =
-        scalingMultiplierSave.pendingValue ?? processor.scaleMultiplier;
-      await setScaling(processor.id, multiplier, value);
-    });
-  };
-
-  const handleScalingPreset = (multiplier: number, divisor: number) => {
-    if (!processor) return;
-    // Cancel any pending individual saves to avoid conflicts
+    const { multiplier, divisor } = scalingValueToFraction(
+      scalingIndexToValue(index),
+    );
     scalingMultiplierSave.cancel();
     scalingDivisorSave.cancel();
-    // Set both values together with a single save call
     scalingMultiplierSave.setPendingValue(multiplier, async () => {
       await setScaling(processor.id, multiplier, divisor);
     });
-    // Update the divisor display value without triggering another save
     scalingDivisorSave.setPendingValue(divisor, async () => {
-      // No-op: multiplier save already handles both values
+      // Multiplier save writes both values together.
     });
   };
 
@@ -477,93 +494,72 @@ export function TrackballPage() {
                     Scaling
                   </h3>
                   <p className="text-xs text-[var(--color-text-muted)]">
-                    Adjust sensitivity multiplier and divisor
+                    Adjust sensitivity from 0.1x to 300x
                   </p>
                 </div>
                 <span className="text-lg font-mono text-[var(--color-electric)]">
-                  {finalScalingValue.toFixed(2)}x
+                  {formatScalingValue(finalScalingValue)}x
                 </span>
               </div>
 
-              {/* Multiplier and Divisor Controls */}
-              <div className="grid grid-cols-2 gap-4 mb-4">
-                <div>
-                  <label className="text-sm text-[var(--color-text-secondary)] mb-2 block">
-                    Multiplier
-                  </label>
-                  <input
-                    type="number"
-                    min={1}
-                    max={1000}
-                    value={displayScalingMultiplier}
-                    onChange={(e) =>
-                      handleScalingMultiplierChange(Number(e.target.value))
-                    }
-                    className="w-full px-3 py-2 rounded-lg bg-[var(--color-surface)] border border-[var(--color-border)] text-[var(--color-text)] text-sm focus:outline-none focus:border-[var(--color-electric)] transition-colors"
-                  />
-                </div>
-                <div>
-                  <label className="text-sm text-[var(--color-text-secondary)] mb-2 block">
-                    Divisor
-                  </label>
-                  <input
-                    type="number"
-                    min={1}
-                    max={1000}
-                    value={displayScalingDivisor}
-                    onChange={(e) =>
-                      handleScalingDivisorChange(Number(e.target.value))
-                    }
-                    className="w-full px-3 py-2 rounded-lg bg-[var(--color-surface)] border border-[var(--color-border)] text-[var(--color-text)] text-sm focus:outline-none focus:border-[var(--color-electric)] transition-colors"
-                  />
-                </div>
-              </div>
-
-              {/* Preset Type Tabs */}
-              <div className="flex gap-2 mb-4">
+              <div className="flex items-center gap-3">
                 <button
-                  onClick={() => setScalingPresetType("wheel")}
-                  className={`flex-1 px-4 py-2 rounded-lg text-sm font-medium transition-colors ${
-                    scalingPresetType === "wheel"
-                      ? "bg-[var(--color-electric)] text-white"
-                      : "bg-[var(--color-surface)] text-[var(--color-text-secondary)] hover:bg-[var(--color-border)]"
-                  }`}
+                  type="button"
+                  aria-label="Decrease scaling"
+                  onClick={() =>
+                    handleScalingSliderChange(scalingSliderIndex - 1)
+                  }
+                  disabled={scalingSliderIndex <= 0}
+                  className="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-lg bg-[var(--color-surface)] border border-[var(--color-border)] text-[var(--color-text-secondary)] hover:bg-[var(--color-border)] hover:text-[var(--color-text)] disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
                 >
-                  Wheel/Mouse
+                  <IconChevronLeft size={18} />
                 </button>
-                <button
-                  onClick={() => setScalingPresetType("scroll")}
-                  className={`flex-1 px-4 py-2 rounded-lg text-sm font-medium transition-colors ${
-                    scalingPresetType === "scroll"
-                      ? "bg-[var(--color-electric)] text-white"
-                      : "bg-[var(--color-surface)] text-[var(--color-text-secondary)] hover:bg-[var(--color-border)]"
-                  }`}
-                >
-                  Scroll
-                </button>
-              </div>
 
-              {/* Preset Buttons */}
-              <div className="grid grid-cols-5 gap-2">
-                {(scalingPresetType === "wheel"
-                  ? WHEEL_PRESETS
-                  : SCROLL_PRESETS
-                ).map((preset) => (
-                  <button
-                    key={preset.label}
-                    onClick={() =>
-                      handleScalingPreset(preset.multiplier, preset.divisor)
+                <div className="min-w-0 flex-1">
+                  <input
+                    type="range"
+                    aria-label="Scaling"
+                    min={0}
+                    max={SCALING_STEPS}
+                    step={1}
+                    value={scalingSliderIndex}
+                    onChange={(e) =>
+                      handleScalingSliderChange(Number(e.target.value))
                     }
-                    className={`px-2 sm:px-4 py-2 rounded-lg text-sm font-medium transition-colors ${
-                      displayScalingMultiplier / displayScalingDivisor ===
-                      preset.multiplier / preset.divisor
-                        ? "bg-[var(--color-electric)] text-white"
-                        : "bg-[var(--color-surface)] text-[var(--color-text-secondary)] hover:bg-[var(--color-border)]"
-                    }`}
-                  >
-                    {preset.label}
-                  </button>
-                ))}
+                    className="w-full h-2 rounded-lg appearance-none cursor-pointer
+                      bg-[var(--color-border)]
+                      [&::-webkit-slider-thumb]:appearance-none
+                      [&::-webkit-slider-thumb]:w-4
+                      [&::-webkit-slider-thumb]:h-4
+                      [&::-webkit-slider-thumb]:rounded-full
+                      [&::-webkit-slider-thumb]:bg-[var(--color-electric)]
+                      [&::-webkit-slider-thumb]:cursor-pointer
+                      [&::-webkit-slider-thumb]:shadow-[0_0_8px_var(--color-electric)]
+                      [&::-moz-range-thumb]:w-4
+                      [&::-moz-range-thumb]:h-4
+                      [&::-moz-range-thumb]:rounded-full
+                      [&::-moz-range-thumb]:bg-[var(--color-electric)]
+                      [&::-moz-range-thumb]:cursor-pointer
+                      [&::-moz-range-thumb]:border-0
+                      [&::-moz-range-thumb]:shadow-[0_0_8px_var(--color-electric)]"
+                  />
+                  <div className="mt-2 flex justify-between text-xs text-[var(--color-text-muted)]">
+                    <span>0.1x</span>
+                    <span>300x</span>
+                  </div>
+                </div>
+
+                <button
+                  type="button"
+                  aria-label="Increase scaling"
+                  onClick={() =>
+                    handleScalingSliderChange(scalingSliderIndex + 1)
+                  }
+                  disabled={scalingSliderIndex >= SCALING_STEPS}
+                  className="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-lg bg-[var(--color-surface)] border border-[var(--color-border)] text-[var(--color-text-secondary)] hover:bg-[var(--color-border)] hover:text-[var(--color-text)] disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+                >
+                  <IconChevronRight size={18} />
+                </button>
               </div>
             </div>
 

--- a/src/pages/__tests__/TrackballPage.test.tsx
+++ b/src/pages/__tests__/TrackballPage.test.tsx
@@ -228,6 +228,35 @@ describe("TrackballPage", () => {
     jest.useRealTimers();
   });
 
+  it("should call setRotation when rotation step button is clicked", async () => {
+    jest.useFakeTimers();
+    const user = userEvent.setup({ delay: null });
+    const mockSetRotation = jest.fn();
+
+    mockUseRuntimeInputProcessor.mockReturnValue(
+      createMockHookReturn({
+        processors: [
+          createMockProcessor({
+            rotationDegrees: 90,
+          }),
+        ],
+        setRotation: mockSetRotation,
+      }),
+    );
+
+    render(<TrackballPage />);
+
+    await user.click(screen.getByLabelText("Increase rotation"));
+
+    await act(async () => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    expect(mockSetRotation).toHaveBeenCalledWith(0, 91);
+
+    jest.useRealTimers();
+  });
+
   it("should display current configuration details", () => {
     mockUseRuntimeInputProcessor.mockReturnValue(
       createMockHookReturn({

--- a/src/pages/__tests__/TrackballPage.test.tsx
+++ b/src/pages/__tests__/TrackballPage.test.tsx
@@ -142,7 +142,7 @@ describe("TrackballPage", () => {
 
     expect(screen.getByText("Scaling")).toBeInTheDocument();
     // Check for the displayed scaling value
-    expect(screen.getByText("2.00x")).toBeInTheDocument();
+    expect(screen.getByText("2.0x")).toBeInTheDocument();
   });
 
   it("should display rotation settings", () => {
@@ -165,7 +165,7 @@ describe("TrackballPage", () => {
     expect(switches[0]).toBeInTheDocument();
   });
 
-  it("should call setScaling when speed button is clicked", async () => {
+  it("should call setScaling when scaling step button is clicked", async () => {
     jest.useFakeTimers();
     const user = userEvent.setup({ delay: null });
     const mockSetScaling = jest.fn();
@@ -179,16 +179,14 @@ describe("TrackballPage", () => {
 
     render(<TrackballPage />);
 
-    // Click on 2.0x speed preset button
-    const speedButton = screen.getByText("2.0x");
-    await user.click(speedButton);
+    await user.click(screen.getByLabelText("Increase scaling"));
 
     // Fast-forward time to trigger debounced auto-save (1000ms)
     await act(async () => {
       jest.advanceTimersByTime(1000);
     });
 
-    expect(mockSetScaling).toHaveBeenCalledWith(0, 2, 1);
+    expect(mockSetScaling).toHaveBeenCalledWith(0, 138, 125);
 
     jest.useRealTimers();
   });
@@ -248,6 +246,6 @@ describe("TrackballPage", () => {
     // Test that the scaling section shows the calculated value
     expect(screen.getByText("Scaling")).toBeInTheDocument();
     // The final scaling value should be displayed (3/2 = 1.50x)
-    expect(screen.getByText("1.50x")).toBeInTheDocument();
+    expect(screen.getByText("1.5x")).toBeInTheDocument();
   });
 });

--- a/src/pages/__tests__/TrackballPage.test.tsx
+++ b/src/pages/__tests__/TrackballPage.test.tsx
@@ -186,7 +186,7 @@ describe("TrackballPage", () => {
       jest.advanceTimersByTime(1000);
     });
 
-    expect(mockSetScaling).toHaveBeenCalledWith(0, 1047, 1000);
+    expect(mockSetScaling).toHaveBeenCalledWith(0, 21, 20);
 
     jest.useRealTimers();
   });

--- a/src/pages/__tests__/TrackballPage.test.tsx
+++ b/src/pages/__tests__/TrackballPage.test.tsx
@@ -142,7 +142,7 @@ describe("TrackballPage", () => {
 
     expect(screen.getByText("Scaling")).toBeInTheDocument();
     // Check for the displayed scaling value
-    expect(screen.getByText("2.0x")).toBeInTheDocument();
+    expect(screen.getByText("2.00x")).toBeInTheDocument();
   });
 
   it("should display rotation settings", () => {
@@ -187,6 +187,36 @@ describe("TrackballPage", () => {
     });
 
     expect(mockSetScaling).toHaveBeenCalledWith(0, 21, 20);
+
+    jest.useRealTimers();
+  });
+
+  it("should increase scaling from decimal step values", async () => {
+    jest.useFakeTimers();
+    const user = userEvent.setup({ delay: null });
+    const mockSetScaling = jest.fn();
+
+    mockUseRuntimeInputProcessor.mockReturnValue(
+      createMockHookReturn({
+        processors: [
+          createMockProcessor({
+            scaleMultiplier: 23,
+            scaleDivisor: 20,
+          }),
+        ],
+        setScaling: mockSetScaling,
+      }),
+    );
+
+    render(<TrackballPage />);
+
+    await user.click(screen.getByLabelText("Increase scaling"));
+
+    await act(async () => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    expect(mockSetScaling).toHaveBeenCalledWith(0, 6, 5);
 
     jest.useRealTimers();
   });
@@ -275,6 +305,6 @@ describe("TrackballPage", () => {
     // Test that the scaling section shows the calculated value
     expect(screen.getByText("Scaling")).toBeInTheDocument();
     // The final scaling value should be displayed (3/2 = 1.50x)
-    expect(screen.getByText("1.5x")).toBeInTheDocument();
+    expect(screen.getByText("1.50x")).toBeInTheDocument();
   });
 });

--- a/src/pages/__tests__/TrackballPage.test.tsx
+++ b/src/pages/__tests__/TrackballPage.test.tsx
@@ -186,7 +186,7 @@ describe("TrackballPage", () => {
       jest.advanceTimersByTime(1000);
     });
 
-    expect(mockSetScaling).toHaveBeenCalledWith(0, 138, 125);
+    expect(mockSetScaling).toHaveBeenCalledWith(0, 1047, 1000);
 
     jest.useRealTimers();
   });


### PR DESCRIPTION
## Summary
- Replace the trackball scaling multiplier/divisor inputs and presets with a 100-step slider from 0.1x to 10x.
- Add left/right step buttons that move scaling in fixed 0.05x increments for fine adjustment, with integer step math to avoid skipped/stuck values.
- Show scaling values with a fixed two-decimal display such as `3.05x`.
- Add left/right step buttons to Sensor Rotation that move rotation in fixed 1° increments.
- Keep saving through the existing multiplier/divisor and rotation runtime processor APIs.

## Validation
- `npm test -- --runInBand src/pages/__tests__/TrackballPage.test.tsx`
- `npm run lint`
- `npm run build`
- Checked the Trackball page in demo mode at desktop width.