### PR TITLE
[codex] Support renamed physical layout subsystem

### DIFF
--- a/proto/zmk/physical_layouts/physical_layouts.proto
+++ b/proto/zmk/physical_layouts/physical_layouts.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package zmk.physical_layouts;
+package cormoran.zmk.physical_layouts;
 
 message GetPhysicalLayoutRequest {}
 

--- a/src/components/PhysicalLayoutModule.tsx
+++ b/src/components/PhysicalLayoutModule.tsx
@@ -1,7 +1,7 @@
 /**
  * PhysicalLayoutModule Component
  *
- * Renders a non-key physical module from zmk__physical_layouts.
+ * Renders a non-key physical module from the physical layouts subsystem.
  */
 import { useMemo } from "react";
 import * as Tooltip from "@radix-ui/react-tooltip";

--- a/src/hooks/__tests__/usePhysicalLayoutModules.test.tsx
+++ b/src/hooks/__tests__/usePhysicalLayoutModules.test.tsx
@@ -1,0 +1,117 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import {
+  ZMKAppContext,
+  ZMKCustomSubsystem,
+} from "@cormoran/zmk-studio-react-hook";
+import type { ReactNode } from "react";
+import {
+  PHYSICAL_LAYOUTS_IDENTIFIER,
+  LEGACY_PHYSICAL_LAYOUTS_IDENTIFIER,
+  usePhysicalLayoutModules,
+} from "../usePhysicalLayoutModules";
+import { Response } from "../../proto/zmk/physical_layouts/physical_layouts";
+
+const mockCallRPC = jest.fn();
+
+jest.mock("@cormoran/zmk-studio-react-hook", () => ({
+  ...jest.requireActual("@cormoran/zmk-studio-react-hook"),
+  ZMKCustomSubsystem: jest.fn().mockImplementation(() => ({
+    callRPC: mockCallRPC,
+  })),
+}));
+
+function createWrapper(zmkAppValue: {
+  state: {
+    connection: unknown;
+    customSubsystems: unknown[];
+  };
+  findSubsystem: (id: string) => { index: number; identifier: string } | null;
+}) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <ZMKAppContext.Provider value={zmkAppValue as never}>
+        {children}
+      </ZMKAppContext.Provider>
+    );
+  };
+}
+
+describe("usePhysicalLayoutModules", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockCallRPC.mockResolvedValue(
+      Response.encode(
+        Response.create({
+          physicalLayout: {
+            devices: [],
+            rotaryEncoders: [],
+          },
+        }),
+      ).finish(),
+    );
+  });
+
+  it("uses the current cormoran subsystem identifier when available", async () => {
+    const connection = { isConnected: true };
+    const findSubsystem = jest.fn((id: string) =>
+      id === PHYSICAL_LAYOUTS_IDENTIFIER
+        ? { index: 7, identifier: PHYSICAL_LAYOUTS_IDENTIFIER }
+        : null,
+    );
+
+    const wrapper = createWrapper({
+      state: {
+        connection,
+        customSubsystems: [
+          { index: 7, identifier: PHYSICAL_LAYOUTS_IDENTIFIER },
+        ],
+      },
+      findSubsystem,
+    });
+
+    const { result } = renderHook(() => usePhysicalLayoutModules(), {
+      wrapper,
+    });
+
+    await waitFor(() => expect(mockCallRPC).toHaveBeenCalled());
+
+    expect(result.current.isAvailable).toBe(true);
+    expect(ZMKCustomSubsystem).toHaveBeenCalledWith(connection, 7);
+    expect(findSubsystem).toHaveBeenCalledWith(PHYSICAL_LAYOUTS_IDENTIFIER);
+    expect(findSubsystem).not.toHaveBeenCalledWith(
+      LEGACY_PHYSICAL_LAYOUTS_IDENTIFIER,
+    );
+  });
+
+  it("falls back to the legacy zmk subsystem identifier", async () => {
+    const connection = { isConnected: true };
+    const findSubsystem = jest.fn((id: string) =>
+      id === LEGACY_PHYSICAL_LAYOUTS_IDENTIFIER
+        ? { index: 4, identifier: LEGACY_PHYSICAL_LAYOUTS_IDENTIFIER }
+        : null,
+    );
+
+    const wrapper = createWrapper({
+      state: {
+        connection,
+        customSubsystems: [
+          { index: 4, identifier: LEGACY_PHYSICAL_LAYOUTS_IDENTIFIER },
+        ],
+      },
+      findSubsystem,
+    });
+
+    const { result } = renderHook(() => usePhysicalLayoutModules(), {
+      wrapper,
+    });
+
+    await waitFor(() => expect(mockCallRPC).toHaveBeenCalled());
+
+    expect(result.current.isAvailable).toBe(true);
+    expect(ZMKCustomSubsystem).toHaveBeenCalledWith(connection, 4);
+    expect(findSubsystem).toHaveBeenCalledWith(PHYSICAL_LAYOUTS_IDENTIFIER);
+    expect(findSubsystem).toHaveBeenCalledWith(
+      LEGACY_PHYSICAL_LAYOUTS_IDENTIFIER,
+    );
+  });
+});

--- a/src/hooks/usePhysicalLayoutModules.ts
+++ b/src/hooks/usePhysicalLayoutModules.ts
@@ -1,7 +1,7 @@
 /**
  * usePhysicalLayoutModules Hook
  *
- * Loads non-key physical module geometry from the zmk__physical_layouts custom
+ * Loads non-key physical module geometry from the physical layouts custom
  * Studio RPC subsystem.
  */
 import { useCallback, useContext, useEffect, useMemo, useState } from "react";
@@ -18,7 +18,12 @@ import {
   type RotaryEncoder,
 } from "../proto/zmk/physical_layouts/physical_layouts";
 
-export const PHYSICAL_LAYOUTS_IDENTIFIER = "zmk__physical_layouts";
+export const PHYSICAL_LAYOUTS_IDENTIFIER = "cormoran__physical_layouts";
+export const LEGACY_PHYSICAL_LAYOUTS_IDENTIFIER = "zmk__physical_layouts";
+export const PHYSICAL_LAYOUTS_IDENTIFIERS = [
+  PHYSICAL_LAYOUTS_IDENTIFIER,
+  LEGACY_PHYSICAL_LAYOUTS_IDENTIFIER,
+] as const;
 
 export type PhysicalLayoutModuleKind =
   | "trackball"
@@ -131,11 +136,14 @@ export function usePhysicalLayoutModules(): UsePhysicalLayoutModulesReturn {
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const subsystem = useMemo(
-    () => zmkApp?.findSubsystem(PHYSICAL_LAYOUTS_IDENTIFIER),
+  const subsystem = useMemo(() => {
+    for (const identifier of PHYSICAL_LAYOUTS_IDENTIFIERS) {
+      const found = zmkApp?.findSubsystem(identifier);
+      if (found) return found;
+    }
+    return undefined;
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [zmkApp?.state.customSubsystems],
-  );
+  }, [zmkApp?.state.customSubsystems]);
   const subsystemIndex = subsystem?.index;
   const connection = zmkApp?.state.connection;
 

--- a/src/lib/transport/demo-physical-layouts.ts
+++ b/src/lib/transport/demo-physical-layouts.ts
@@ -3,7 +3,7 @@ import type {
   Response,
 } from "../../proto/zmk/physical_layouts/physical_layouts";
 
-export const PHYSICAL_LAYOUTS_IDENTIFIER = "zmk__physical_layouts";
+export const PHYSICAL_LAYOUTS_IDENTIFIER = "cormoran__physical_layouts";
 
 export class PhysicalLayoutsHandler {
   process(request: Request): Response {

--- a/src/pages/TrackballPage.tsx
+++ b/src/pages/TrackballPage.tsx
@@ -61,11 +61,7 @@ function scalingValueToFraction(value: number): {
 
 function scalingValueToButtonStep(value: number, direction: -1 | 1): number {
   const stepCount = Math.round(value / SCALING_BUTTON_STEP) + direction;
-  return clamp(
-    stepCount * SCALING_BUTTON_STEP,
-    SCALING_MIN,
-    SCALING_MAX,
-  );
+  return clamp(stepCount * SCALING_BUTTON_STEP, SCALING_MIN, SCALING_MAX);
 }
 
 function formatScalingValue(value: number): string {

--- a/src/proto/zmk/physical_layouts/physical_layouts.ts
+++ b/src/proto/zmk/physical_layouts/physical_layouts.ts
@@ -7,7 +7,7 @@
 /* eslint-disable */
 import { BinaryReader, BinaryWriter } from "@bufbuild/protobuf/wire";
 
-export const protobufPackage = "zmk.physical_layouts";
+export const protobufPackage = "cormoran.zmk.physical_layouts";
 
 export interface GetPhysicalLayoutRequest {
 }


### PR DESCRIPTION
## Summary

- Prefer the renamed `cormoran__physical_layouts` Studio RPC subsystem while falling back to legacy `zmk__physical_layouts` firmware.
- Update the physical layouts proto package/generation and demo transport to the renamed upstream namespace.
- Add hook coverage for current and legacy subsystem discovery.
- Apply Prettier's existing cleanup in `TrackballPage.tsx` so repo formatting checks pass.

## Validation

- `npm test -- usePhysicalLayoutModules.test.tsx --runInBand`
- `npm run lint`
- `npm test -- --runInBand`
- `npm run format:check`
- `npm run build`