### PR TITLE
[codex] Prevent indexing development builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,7 @@ jobs:
         env:
           VITE_BASE: /
           VITE_GOOGLE_ANALYTICS_ID: ${{ secrets.VITE_GOOGLE_ANALYTICS_ID }}
+          VITE_ROBOTS: index, follow
       - name: Deploy to Cloudflare Pages
         id: deploy
         uses: cloudflare/wrangler-action@v3

--- a/index.html
+++ b/index.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html lang="en">
   <head>
+    <meta name="robots" content="%VITE_ROBOTS%" />
     <meta property="og:title" content="DYA Studio" />
     <meta
       property="og:description"

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -29,6 +29,7 @@ export default defineConfig(({ mode }) => {
       htmlEnvVarReplacePlugin({
         VITE_GOOGLE_ANALYTICS_ID:
           env.VITE_GOOGLE_ANALYTICS_ID || "G-32NGG9Y4BQ",
+        VITE_ROBOTS: env.VITE_ROBOTS || "noindex, nofollow",
       }),
     ],
   };


### PR DESCRIPTION
## Description

Development and preview builds now emit a robots meta tag with `noindex, nofollow` by default so search engines do not index them.

The release workflow explicitly sets `VITE_ROBOTS` to `index, follow`, preserving indexing for the production release build.

## CLA (Contributor License Agreement)

By submitting this pull request, I agree that my contributions
are licensed under the project's current license.

I also grant the maintainer(s) of this project the right to relicense
my contributions under any license, for use in future versions of the project.
This does not affect the license of any previously released versions.

## Validation

- `npm run lint`
- `npm test`
- `npm run build`
- `env VITE_ROBOTS='index, follow' npm run build`
- Confirmed `dist/index.html` contains `noindex, nofollow` by default and `index, follow` when `VITE_ROBOTS` is set.