### PR TITLE
[codex] fix Japanese language key labels

### DIFF
--- a/src/lib/__tests__/keyboardLayouts.test.ts
+++ b/src/lib/__tests__/keyboardLayouts.test.ts
@@ -48,6 +48,13 @@ describe("keyboardLayouts", () => {
       expect(getLayoutDisplayName(0x35, "JIS")).toBe("半/全");
       // 0x2e (=): In US shows "=", in JIS shows "^"
       expect(getLayoutDisplayName(0x2e, "JIS")).toBe("^~");
+      expect(getLayoutDisplayName(0x90, "JIS")).toBe("かな");
+      expect(getLayoutDisplayName(0x91, "JIS")).toBe("英数");
+    });
+
+    it("should return US_JP display names for Japanese language keycodes", () => {
+      expect(getLayoutDisplayName(0x90, "US_JP")).toBe("かな");
+      expect(getLayoutDisplayName(0x91, "US_JP")).toBe("英数");
     });
 
     it("should return undefined for unmapped keycodes", () => {

--- a/src/lib/__tests__/keycodes.test.ts
+++ b/src/lib/__tests__/keycodes.test.ts
@@ -1,0 +1,21 @@
+import { getKeycodeByName, searchKeycodes } from "../keycodes";
+
+describe("keycodes", () => {
+  describe("Japanese language key aliases", () => {
+    it("maps kana aliases to Lang1 and eisu aliases to Lang2", () => {
+      expect(getKeycodeByName("KANA")?.code).toBe(0x90);
+      expect(getKeycodeByName("JA")?.code).toBe(0x90);
+      expect(getKeycodeByName("EISU")?.code).toBe(0x91);
+      expect(getKeycodeByName("EN")?.code).toBe(0x91);
+    });
+
+    it("searches Japanese language keys by their aliases", () => {
+      expect(
+        searchKeycodes("kana").some((keycode) => keycode.code === 0x90),
+      ).toBe(true);
+      expect(searchKeycodes("eisu")).toEqual([
+        expect.objectContaining({ code: 0x91 }),
+      ]);
+    });
+  });
+});

--- a/src/lib/keyboardLayouts.ts
+++ b/src/lib/keyboardLayouts.ts
@@ -150,11 +150,11 @@ const JIS_LAYOUT_MAPPINGS: KeycodeLayoutMapping[] = [
   },
   {
     code: 0x90,
-    displayName: "英数",
+    displayName: "かな",
   },
   {
     code: 0x91,
-    displayName: "かな",
+    displayName: "英数",
   },
   {
     code: 0x88,
@@ -177,11 +177,11 @@ const JIS_LAYOUT_MAPPINGS: KeycodeLayoutMapping[] = [
 const US_FOR_JP_LAYOUT_MAPPINGS: KeycodeLayoutMapping[] = [
   {
     code: 0x90,
-    displayName: "英数",
+    displayName: "かな",
   },
   {
     code: 0x91,
-    displayName: "かな",
+    displayName: "英数",
   },
   {
     code: 0x88,

--- a/src/lib/keycodes.ts
+++ b/src/lib/keycodes.ts
@@ -674,14 +674,14 @@ export const KEYBOARD_KEYCODES: KeycodeDefinition[] = [
     displayName: "Lang1",
     name: "Language1",
     category: "international",
-    aliases: ["LANG1", "HAEN", "EN", "EISU"],
+    aliases: ["LANG1", "HAEJ", "JA", "KANA"],
   },
   {
     code: 0x91,
     displayName: "Lang2",
     name: "Language2",
     category: "international",
-    aliases: ["LANG2", "HAEJ", "JA", "KANA"],
+    aliases: ["LANG2", "HAEN", "EN", "EISU"],
   },
 ];
 


### PR DESCRIPTION
## Summary

Fixes the Japanese display labels and search aliases for `LANG1` and `LANG2`.

## Root Cause

The Japanese layout override mapped `0x90` to `英数` and `0x91` to `かな`, but those labels were reversed for the layout display. The searchable aliases had the same mismatch, so `KANA`/`JA` and `EISU`/`EN` resolved to the opposite language keys.

## Validation

- `npm test -- keycodes.test.ts keyboardLayouts.test.ts --runInBand`
- `npm run lint`
- `npm run format:check`
- `npm run build`
