### PR TITLE
Add PMW3610 driver advanced settings to Trackball tab

### DIFF
--- a/src/components/AdvancedSettingsSection.tsx
+++ b/src/components/AdvancedSettingsSection.tsx
@@ -11,6 +11,8 @@ import {
 import {
   CUSTOM_SETTINGS_SOURCE_ALL,
   useCustomSettings,
+  type CustomSettingsSection,
+  type UseCustomSettingsReturn,
 } from "../hooks/useCustomSettings";
 import { useKeymap, type BehaviorDefinition } from "../hooks/useKeymap";
 import { useLanguage } from "../hooks/useLanguage";
@@ -586,6 +588,118 @@ function SettingRow({
   );
 }
 
+export interface CustomSettingsSectionCardProps {
+  section: CustomSettingsSection;
+  layers: { id: number; name: string }[];
+  behaviors: Map<number, BehaviorDefinition>;
+  customSettings: UseCustomSettingsReturn;
+  keymapLoading?: boolean;
+}
+
+export function CustomSettingsSectionCard({
+  section,
+  layers,
+  behaviors,
+  customSettings,
+  keymapLoading = false,
+}: CustomSettingsSectionCardProps) {
+  const { t } = useLanguage();
+  const hasUnsavedChanges = section.settings.some(
+    (setting) => setting.hasUnsavedValue,
+  );
+  const sortedSettings = [...section.settings].sort((a, b) =>
+    settingSortValue(a).localeCompare(settingSortValue(b)),
+  );
+
+  return (
+    <section className="rounded-lg border border-[var(--color-border)] bg-[var(--color-surface)]">
+      <div className="flex flex-col gap-3 border-b border-[var(--color-border)] p-4 md:flex-row md:items-center md:justify-between">
+        <div className="min-w-0">
+          <h4 className="truncate text-sm font-medium text-[var(--color-text)]">
+            {section.identifier}
+          </h4>
+          <p className="text-xs text-[var(--color-text-muted)]">
+            {t("{{count}} settings", {
+              count: section.settings.length,
+            })}
+            {keymapLoading ? t(" - loading layer and behavior names") : ""}
+          </p>
+        </div>
+        <div className="flex flex-wrap justify-end gap-2">
+          <button
+            type="button"
+            className="btn-electric flex items-center gap-2 px-3 py-2 text-sm"
+            disabled={customSettings.isLoading || !hasUnsavedChanges}
+            onClick={() =>
+              customSettings.saveSection(section.customSubsystemIndex)
+            }
+          >
+            <IconDeviceFloppy size={16} />
+            {t("Save")}
+          </button>
+          <button
+            type="button"
+            className="btn-ghost flex items-center gap-2 border border-[var(--color-border)] text-sm"
+            disabled={customSettings.isLoading}
+            onClick={() =>
+              customSettings.discardSection(section.customSubsystemIndex)
+            }
+          >
+            <IconRefresh size={16} />
+            {t("Discard")}
+          </button>
+          <button
+            type="button"
+            className="btn-ghost flex items-center gap-2 border border-red-500/30 text-sm text-red-400"
+            disabled={customSettings.isLoading}
+            onClick={() => {
+              if (
+                window.confirm(
+                  t("Reset all settings in {{identifier}}?", {
+                    identifier: section.identifier,
+                  }),
+                )
+              ) {
+                void customSettings.resetSection(section.customSubsystemIndex);
+              }
+            }}
+          >
+            <IconRotateClockwise size={16} />
+            {t("Reset")}
+          </button>
+        </div>
+      </div>
+
+      <div className="px-4">
+        <div className="hidden grid-cols-[minmax(0,1fr)_7rem_minmax(14rem,22rem)_8rem_7rem] gap-3 py-3 text-xs font-medium uppercase text-[var(--color-text-muted)] md:grid">
+          <span>{t("Setting")}</span>
+          <span>{t("Source")}</span>
+          <span>{t("Editor")}</span>
+          <span>{t("Status")}</span>
+          <span className="text-right">{t("Item")}</span>
+        </div>
+        {sortedSettings.map((setting) => (
+          <SettingRow
+            key={[
+              setting.customSubsystemIndex,
+              setting.key,
+              setting.source,
+              setting.value?.arrayValue?.index ?? "scalar",
+            ].join(":")}
+            setting={setting}
+            layers={layers}
+            behaviors={behaviors}
+            isLoading={customSettings.isLoading}
+            onWrite={customSettings.writeSettingToMemory}
+            onDiscard={customSettings.discardSetting}
+            onReset={customSettings.resetSetting}
+          />
+        ))}
+      </div>
+    </section>
+  );
+}
+
 export function AdvancedSettingsSection() {
   const { t } = useLanguage();
   const customSettings = useCustomSettings();
@@ -650,111 +764,16 @@ export function AdvancedSettingsSection() {
         </p>
       ) : (
         <div className="space-y-6">
-          {customSettings.sections.map((section) => {
-            const hasUnsavedChanges = section.settings.some(
-              (setting) => setting.hasUnsavedValue,
-            );
-            const sortedSettings = [...section.settings].sort((a, b) =>
-              settingSortValue(a).localeCompare(settingSortValue(b)),
-            );
-
-            return (
-              <section
-                key={section.customSubsystemIndex}
-                className="rounded-lg border border-[var(--color-border)] bg-[var(--color-surface)]"
-              >
-                <div className="flex flex-col gap-3 border-b border-[var(--color-border)] p-4 md:flex-row md:items-center md:justify-between">
-                  <div className="min-w-0">
-                    <h4 className="truncate text-sm font-medium text-[var(--color-text)]">
-                      {section.identifier}
-                    </h4>
-                    <p className="text-xs text-[var(--color-text-muted)]">
-                      {t("{{count}} settings", {
-                        count: section.settings.length,
-                      })}
-                      {keymapLoading
-                        ? t(" - loading layer and behavior names")
-                        : ""}
-                    </p>
-                  </div>
-                  <div className="flex flex-wrap justify-end gap-2">
-                    <button
-                      type="button"
-                      className="btn-electric flex items-center gap-2 px-3 py-2 text-sm"
-                      disabled={customSettings.isLoading || !hasUnsavedChanges}
-                      onClick={() =>
-                        customSettings.saveSection(section.customSubsystemIndex)
-                      }
-                    >
-                      <IconDeviceFloppy size={16} />
-                      {t("Save")}
-                    </button>
-                    <button
-                      type="button"
-                      className="btn-ghost flex items-center gap-2 border border-[var(--color-border)] text-sm"
-                      disabled={customSettings.isLoading}
-                      onClick={() =>
-                        customSettings.discardSection(
-                          section.customSubsystemIndex,
-                        )
-                      }
-                    >
-                      <IconRefresh size={16} />
-                      {t("Discard")}
-                    </button>
-                    <button
-                      type="button"
-                      className="btn-ghost flex items-center gap-2 border border-red-500/30 text-sm text-red-400"
-                      disabled={customSettings.isLoading}
-                      onClick={() => {
-                        if (
-                          window.confirm(
-                            t("Reset all settings in {{identifier}}?", {
-                              identifier: section.identifier,
-                            }),
-                          )
-                        ) {
-                          void customSettings.resetSection(
-                            section.customSubsystemIndex,
-                          );
-                        }
-                      }}
-                    >
-                      <IconRotateClockwise size={16} />
-                      {t("Reset")}
-                    </button>
-                  </div>
-                </div>
-
-                <div className="px-4">
-                  <div className="hidden grid-cols-[minmax(0,1fr)_7rem_minmax(14rem,22rem)_8rem_7rem] gap-3 py-3 text-xs font-medium uppercase text-[var(--color-text-muted)] md:grid">
-                    <span>{t("Setting")}</span>
-                    <span>{t("Source")}</span>
-                    <span>{t("Editor")}</span>
-                    <span>{t("Status")}</span>
-                    <span className="text-right">{t("Item")}</span>
-                  </div>
-                  {sortedSettings.map((setting) => (
-                    <SettingRow
-                      key={[
-                        setting.customSubsystemIndex,
-                        setting.key,
-                        setting.source,
-                        setting.value?.arrayValue?.index ?? "scalar",
-                      ].join(":")}
-                      setting={setting}
-                      layers={layers}
-                      behaviors={behaviors}
-                      isLoading={customSettings.isLoading}
-                      onWrite={customSettings.writeSettingToMemory}
-                      onDiscard={customSettings.discardSetting}
-                      onReset={customSettings.resetSetting}
-                    />
-                  ))}
-                </div>
-              </section>
-            );
-          })}
+          {customSettings.sections.map((section) => (
+            <CustomSettingsSectionCard
+              key={section.customSubsystemIndex}
+              section={section}
+              layers={layers}
+              behaviors={behaviors}
+              customSettings={customSettings}
+              keymapLoading={keymapLoading}
+            />
+          ))}
         </div>
       )}
 

--- a/src/components/TrackballAdvancedSettings.tsx
+++ b/src/components/TrackballAdvancedSettings.tsx
@@ -1,0 +1,144 @@
+import { useMemo, useState } from "react";
+import {
+  IconChevronDown,
+  IconChevronRight,
+  IconRefresh,
+} from "@tabler/icons-react";
+import { CustomSettingsSectionCard } from "./AdvancedSettingsSection";
+import { useCustomSettings } from "../hooks/useCustomSettings";
+import { useKeymap } from "../hooks/useKeymap";
+import { useLanguage } from "../hooks/useLanguage";
+
+// Custom subsystem identifier registered by the pmw3610 driver's settings
+// module (see src/settings/pmw3610_settings.c in the driver repository).
+// Frame capture/streaming lives in a separate, dedicated RPC subsystem and
+// is intentionally not surfaced here.
+const PMW3610_CUSTOM_SETTINGS_IDENTIFIER = "cormoran__pmw3610";
+
+export function TrackballAdvancedSettings() {
+  const { t } = useLanguage();
+  const [isExpanded, setIsExpanded] = useState(false);
+  const customSettings = useCustomSettings();
+  const { keymap, behaviors, isLoading: keymapLoading } = useKeymap();
+
+  const layers = useMemo(
+    () =>
+      keymap?.layers.map((layer) => ({
+        id: layer.id,
+        name: layer.name || t("Layer {{id}}", { id: layer.id }),
+      })) ?? [],
+    [keymap?.layers, t],
+  );
+
+  const pmw3610Sections = useMemo(
+    () =>
+      customSettings.sections.filter(
+        (section) => section.identifier === PMW3610_CUSTOM_SETTINGS_IDENTIFIER,
+      ),
+    [customSettings.sections],
+  );
+
+  const isSubsystemAvailable =
+    !customSettings.isLoading && pmw3610Sections.length > 0;
+
+  return (
+    <div className="glass-card overflow-hidden">
+      <button
+        type="button"
+        className="flex w-full items-center justify-between gap-3 p-6 text-left"
+        onClick={() => setIsExpanded((expanded) => !expanded)}
+        aria-expanded={isExpanded}
+      >
+        <div>
+          <h3 className="text-sm font-medium text-[var(--color-text)]">
+            {t("Advanced (PMW3610 Sensor Driver)")}
+          </h3>
+          <p className="text-xs text-[var(--color-text-muted)]">
+            {t(
+              "Sensor-level tuning exposed by the pmw3610 driver's custom Studio RPC",
+            )}
+          </p>
+        </div>
+        {isExpanded ? (
+          <IconChevronDown
+            size={20}
+            className="flex-shrink-0 text-[var(--color-text-muted)]"
+          />
+        ) : (
+          <IconChevronRight
+            size={20}
+            className="flex-shrink-0 text-[var(--color-text-muted)]"
+          />
+        )}
+      </button>
+
+      {isExpanded && (
+        <div className="space-y-4 border-t border-[var(--color-border)] p-6 pt-4">
+          <div className="flex items-center justify-between gap-3">
+            <p className="text-xs text-[var(--color-text-muted)]">
+              {t(
+                "Changes are written to keyboard memory after a short delay. Save a section to persist them.",
+              )}
+            </p>
+            <button
+              type="button"
+              className="btn-ghost flex flex-shrink-0 items-center gap-2 border border-[var(--color-border)] text-sm"
+              onClick={customSettings.loadSettings}
+              disabled={customSettings.isLoading}
+            >
+              <IconRefresh size={16} />
+              {t("Reload")}
+            </button>
+          </div>
+
+          {!customSettings.isAvailable ? (
+            <p className="text-sm text-[var(--color-text-muted)]">
+              {t(
+                "Custom settings subsystem is not available for this keyboard.",
+              )}
+            </p>
+          ) : customSettings.isLoading && pmw3610Sections.length === 0 ? (
+            <p className="text-sm text-[var(--color-text-muted)]">
+              {t("Loading advanced settings...")}
+            </p>
+          ) : !isSubsystemAvailable ? (
+            <p className="text-sm text-[var(--color-text-muted)]">
+              {t("No pmw3610 driver settings were reported by the keyboard.")}
+              <br />
+              {t("Make sure your firmware has the {{module}} enabled.", {
+                module: "cormoran/zmk-driver-pmw3610-with-custom-studio-rpc",
+              })}
+              <a
+                href="https://github.com/cormoran/zmk-driver-pmw3610-with-custom-studio-rpc"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-[var(--color-electric)] underline mx-1"
+              >
+                cormoran/zmk-driver-pmw3610-with-custom-studio-rpc
+              </a>
+            </p>
+          ) : (
+            <div className="space-y-6">
+              {pmw3610Sections.map((section) => (
+                <CustomSettingsSectionCard
+                  key={section.customSubsystemIndex}
+                  section={section}
+                  layers={layers}
+                  behaviors={behaviors}
+                  customSettings={customSettings}
+                  keymapLoading={keymapLoading}
+                />
+              ))}
+            </div>
+          )}
+
+          {customSettings.error && (
+            <div className="rounded-lg border border-red-500/30 bg-red-500/10 p-3">
+              <p className="text-sm text-red-400">{customSettings.error}</p>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/i18n/translations.ts
+++ b/src/i18n/translations.ts
@@ -145,6 +145,11 @@ const ja: Record<string, string> = {
   "Loading trackball settings...": "トラックボール設定を読み込み中...",
   "No runtime input processor found. Make sure your firmware has the runtime input processor module enabled.":
     "ランタイム入力プロセッサーが見つかりません。ファームウェアでランタイム入力プロセッサーモジュールが有効になっていることを確認してください。",
+  "Advanced (PMW3610 Sensor Driver)": "詳細設定（PMW3610 センサードライバー）",
+  "Sensor-level tuning exposed by the pmw3610 driver's custom Studio RPC":
+    "pmw3610 ドライバーのカスタム Studio RPC が公開するセンサーレベルの調整項目です",
+  "No pmw3610 driver settings were reported by the keyboard.":
+    "キーボードから pmw3610 ドライバーの設定が報告されませんでした。",
   "Select Processor": "プロセッサーを選択",
   "{{count}} processors detected": "{{count}} 個のプロセッサーを検出",
   "Active on Layers": "有効にするレイヤー",

--- a/src/pages/TrackballPage.tsx
+++ b/src/pages/TrackballPage.tsx
@@ -7,6 +7,7 @@ import {
 } from "@tabler/icons-react";
 import * as Switch from "@radix-ui/react-switch";
 import { useRuntimeInputProcessor } from "../hooks/useRuntimeInputProcessor";
+import { TrackballAdvancedSettings } from "../components/TrackballAdvancedSettings";
 import { AxisSnapMode } from "../proto/zmk/runtime_input_processor/runtime_input_processor";
 import { useDebouncedSave } from "../hooks/useDebouncedSave";
 import { useLanguage } from "../hooks/useLanguage";
@@ -1078,6 +1079,10 @@ export function TrackballPage() {
             </div>
           </div>
         )}
+
+        <div className="mt-6">
+          <TrackballAdvancedSettings />
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- Adds a collapsible "Advanced (PMW3610 Sensor Driver)" section to the Trackball page, exposing the settings registered by [cormoran/zmk-driver-pmw3610-with-custom-studio-rpc](https://github.com/cormoran/zmk-driver-pmw3610-with-custom-studio-rpc) (`cpi`, axis swap/invert, force-awake, smart algorithm, downshift/sample timers, min report interval) via the same generic `cormoran.zmk.custom_settings` RPC the app already supports.
- Frame capture/streaming is implemented by the driver as a separate, dedicated RPC subsystem — it is intentionally not surfaced here, per request.
- Extracted the per-subsystem settings card out of `AdvancedSettingsSection` into a reusable `CustomSettingsSectionCard` component so both the existing Settings page and the new Trackball section share the same editors (int32/bool/range-constrained fields, save/discard/reset), instead of duplicating that logic.
- Added Japanese translations for the new strings.

## Test plan
- [x] `tsc --noEmit`
- [x] `eslint`
- [x] `prettier --check`
- [x] Full Jest suite (24 suites / 226 passed, 1 pre-existing skip) via the repo's pre-commit hook
- [ ] Manual verification against real firmware (not available in this environment) — please confirm the section renders correctly against a keyboard running the pmw3610 driver's custom settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)