### PR TITLE
Adopt latest react-zmk-studio: auto-reconnect on page load + refactoring

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -131,7 +131,6 @@
       "integrity": "sha512-H3mcG6ZDLTlYfaSNi0iOKkigqMFvkTKlGUYlD8GW7nNOYRrevuA46iTypPyv+06V3fEmvvazfntkBU34L0azAw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.28.6",
         "@babel/generator": "^7.28.6",
@@ -842,8 +841,8 @@
       }
     },
     "node_modules/@cormoran/zmk-studio-react-hook": {
-      "version": "0.0.1",
-      "resolved": "git+ssh://git@github.com/cormoran/react-zmk-studio.git#1b4b4a0912e93ff575f07b2400762950454aca16",
+      "version": "0.0.2",
+      "resolved": "git+ssh://git@github.com/cormoran/react-zmk-studio.git#b91561dcaf0ee940cda210a5a52729d55271ee4a",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -965,7 +964,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -989,7 +987,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -3730,7 +3727,6 @@
       "integrity": "sha512-8QqtOQT5ACVlmsvKOJNEaWmRPmcojMOzCz4Hs2BGG/toAp/K38LcsMRyLp349glq5AzJbCEeimEoxaX6v/fLrA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/core": "^7.21.3",
         "@svgr/babel-preset": "8.1.0",
@@ -4233,7 +4229,8 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -4421,7 +4418,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.9.tgz",
       "integrity": "sha512-ne4A0IpG3+2ETuREInjPNhUGis1SFjv1d5asp8MzEAGtOZeTeHVDOYqOgqfhvseqg/iXty2hjBf1zAOb7RNiNw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -4432,7 +4428,6 @@
       "integrity": "sha512-Lpo8kgb/igvMIPeNV2rsYKTgaORYdO1XGVZ4Qz3akwOj0ySGYMPlQWa8BaLn0G63D1aSaAQ5ldR06wCpChQCjA==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -4443,7 +4438,6 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -4524,7 +4518,6 @@
       "integrity": "sha512-nm3cvFN9SqZGXjmw5bZ6cGmvJSyJPn0wU9gHAZZHDnZl2wF9PhHv78Xf06E0MaNk4zLVHL8hb2/c32XvyJOLQg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.53.1",
         "@typescript-eslint/types": "8.53.1",
@@ -4802,7 +4795,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5198,7 +5190,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -5784,7 +5775,8 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dot-case": {
       "version": "3.0.4",
@@ -5926,7 +5918,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -6938,7 +6929,6 @@
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -8829,7 +8819,6 @@
       "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssstyle": "^4.2.1",
         "data-urls": "^5.0.0",
@@ -9541,6 +9530,7 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -10137,7 +10127,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -10186,6 +10175,7 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -10201,6 +10191,7 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -10278,7 +10269,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -10288,7 +10278,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -11138,7 +11127,6 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -11261,7 +11249,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -11427,7 +11414,6 @@
       "integrity": "sha512-u09tdk/huMiN8xwoiBbig197jKdCamQTtOruSalOzbqGje3jdHiV0njQlAW0YvzoahkirFePNQ4RYlfnRQpXZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@oxc-project/runtime": "0.97.0",
         "fdir": "^6.5.0",
@@ -11786,7 +11772,6 @@
       "integrity": "sha512-k7Nwx6vuWx1IJ9Bjuf4Zt1PEllcwe7cls3VNzm4CQ1/hgtFUK2bRNG3rvnpPUhFjmqJKAKtjV576KnUkHocg/g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,7 @@ import {
 } from "@tabler/icons-react";
 
 import { SplashScreen } from "./components/SplashScreen";
+import { ReconnectingOverlay } from "./components/ReconnectingOverlay";
 import {
   DeviceConnectionProvider,
   ConnectionContext,
@@ -137,21 +138,26 @@ function AppContent() {
   return (
     <>
       <AnimatePresence>
-        {!connection.isConnected && (
-          <motion.div
-            key="splash"
-            initial={{ opacity: 1 }}
-            exit={{ opacity: 0 }}
-            transition={{ duration: 0.3 }}
-          >
-            <SplashScreen
-              onConnect={connection.onConnect}
-              isConnecting={connection.isLoading}
-              error={connection.error}
-              isReconnecting={connection.isReconnecting}
-              onCancelReconnect={connection.onCancelReconnect}
-            />
-          </motion.div>
+        {connection.isReconnecting ? (
+          <ReconnectingOverlay
+            key="reconnecting"
+            onCancel={connection.onCancelReconnect}
+          />
+        ) : (
+          !connection.isConnected && (
+            <motion.div
+              key="splash"
+              initial={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              transition={{ duration: 0.3 }}
+            >
+              <SplashScreen
+                onConnect={connection.onConnect}
+                isConnecting={connection.isLoading}
+                error={connection.error}
+              />
+            </motion.div>
+          )
         )}
       </AnimatePresence>
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -148,6 +148,8 @@ function AppContent() {
               onConnect={connection.onConnect}
               isConnecting={connection.isLoading}
               error={connection.error}
+              isReconnecting={connection.isReconnecting}
+              onCancelReconnect={connection.onCancelReconnect}
             />
           </motion.div>
         )}

--- a/src/components/DeviceConnection.tsx
+++ b/src/components/DeviceConnection.tsx
@@ -1,7 +1,7 @@
 import type { ReactNode } from "react";
 import { createContext, useCallback } from "react";
 import type { RpcTransport } from "@zmkfirmware/zmk-studio-ts-client/transport/index";
-import { useZMKApp, ZMKAppContext } from "@cormoran/zmk-studio-react-hook";
+import { useZMKApp, ZMKConnection } from "@cormoran/zmk-studio-react-hook";
 import { connect as connectBLE } from "@zmkfirmware/zmk-studio-ts-client/transport/gatt";
 import { connect as connectUSB } from "../lib/transport/usb";
 import { connect as connectDemo } from "../lib/transport/demo";
@@ -64,12 +64,19 @@ export function DeviceConnectionProvider({
     error: zmkApp.state.error,
   };
 
+  const content = (
+    <ConnectionContext.Provider value={connectionValue}>
+      {children}
+    </ConnectionContext.Provider>
+  );
+
   return (
-    <ZMKAppContext.Provider value={zmkApp}>
-      <ConnectionContext.Provider value={connectionValue}>
-        {children}
-      </ConnectionContext.Provider>
-    </ZMKAppContext.Provider>
+    <ZMKConnection
+      zmkApp={zmkApp}
+      autoReconnect
+      renderDisconnected={() => content}
+      renderConnected={() => content}
+    />
   );
 }
 

--- a/src/components/DeviceConnection.tsx
+++ b/src/components/DeviceConnection.tsx
@@ -1,12 +1,29 @@
 import type { ReactNode } from "react";
-import { createContext, useCallback } from "react";
+import { createContext, useCallback, useEffect, useRef, useState } from "react";
 import type { RpcTransport } from "@zmkfirmware/zmk-studio-ts-client/transport/index";
-import { useZMKApp, ZMKConnection } from "@cormoran/zmk-studio-react-hook";
+import {
+  useZMKApp,
+  ZMKAppContext,
+  getPairedSerialPorts,
+  connectToPairedSerial,
+} from "@cormoran/zmk-studio-react-hook";
 import { connect as connectBLE } from "@zmkfirmware/zmk-studio-ts-client/transport/gatt";
 import { connect as connectUSB } from "../lib/transport/usb";
 import { connect as connectDemo } from "../lib/transport/demo";
 
 export type ConnectionMethod = "serial" | "ble" | "demo";
+
+/**
+ * Minimum time (ms) the "reconnecting" indicator stays visible once shown,
+ * even if the underlying auto-reconnect attempt resolves near-instantly.
+ * Without this, a fast reconnect would flash the indicator so briefly the
+ * user couldn't tell what happened.
+ */
+export const AUTO_RECONNECT_MIN_DISPLAY_MS = 2500;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
 
 // Simple connection context for UI components
 interface ConnectionContextValue {
@@ -16,6 +33,10 @@ interface ConnectionContextValue {
   onDisconnect: () => void;
   isLoading: boolean;
   error: string | null;
+  /** True while the page-load auto-reconnect attempt is in flight. */
+  isReconnecting: boolean;
+  /** Cancels an in-flight page-load auto-reconnect attempt. */
+  onCancelReconnect: () => void;
 }
 
 const ConnectionContext = createContext<ConnectionContextValue>({
@@ -25,16 +46,97 @@ const ConnectionContext = createContext<ConnectionContextValue>({
   onDisconnect: () => {},
   isLoading: false,
   error: null,
+  isReconnecting: false,
+  onCancelReconnect: () => {},
 });
 
 interface DeviceConnectionProviderProps {
   children: ReactNode;
+  /**
+   * Minimum time (ms) to keep the reconnecting indicator visible once it's
+   * shown. Defaults to {@link AUTO_RECONNECT_MIN_DISPLAY_MS}. Overridable
+   * mainly so tests don't have to wait out the real-world default.
+   */
+  reconnectMinDisplayMs?: number;
 }
 
 export function DeviceConnectionProvider({
   children,
+  reconnectMinDisplayMs = AUTO_RECONNECT_MIN_DISPLAY_MS,
 }: DeviceConnectionProviderProps) {
   const zmkApp = useZMKApp();
+  const [isReconnecting, setIsReconnecting] = useState(false);
+
+  // Guards against React StrictMode's double-invoke of effects triggering
+  // the auto-reconnect attempt twice.
+  const autoReconnectAttemptedRef = useRef(false);
+  // Bridges the cancel button (outside the effect) to the in-flight attempt.
+  const cancelReconnectRef = useRef<() => void>(() => {});
+
+  useEffect(() => {
+    if (autoReconnectAttemptedRef.current) return;
+    autoReconnectAttemptedRef.current = true;
+
+    // Plain mutable flag (not a ref hook) local to this one-shot attempt,
+    // mirroring the library's own ZMKConnection auto-reconnect pattern.
+    // Set on unmount (cleanup below) or when the user clicks "Cancel".
+    const cancelledState = { current: false };
+    cancelReconnectRef.current = () => {
+      cancelledState.current = true;
+      setIsReconnecting(false);
+    };
+
+    (async () => {
+      const ports = await getPairedSerialPorts();
+      if (ports.length === 0 || cancelledState.current) {
+        // Nothing paired (or already cancelled): stay disconnected, show
+        // the normal connect screen immediately.
+        return;
+      }
+
+      setIsReconnecting(true);
+      let transport: RpcTransport | null = null;
+      try {
+        // Run the reconnect attempt and the minimum-display timer in
+        // parallel so the indicator never flashes shorter than intended,
+        // but also never waits longer than necessary once both settle.
+        [transport] = await Promise.all([
+          connectToPairedSerial(),
+          sleep(reconnectMinDisplayMs),
+        ]);
+
+        if (cancelledState.current) {
+          // User cancelled or component unmounted while we were
+          // reconnecting: release the transport instead of using it.
+          transport?.abortController.abort();
+          return;
+        }
+
+        if (!transport) {
+          // No paired port after all (race with getPairedSerialPorts
+          // above) -- fall back to the normal connect screen.
+          return;
+        }
+
+        await zmkApp.connect(() => Promise.resolve(transport as RpcTransport));
+      } catch (error) {
+        if (!cancelledState.current) {
+          console.warn("Auto-reconnect to paired serial port failed:", error);
+        }
+      } finally {
+        if (!cancelledState.current) {
+          setIsReconnecting(false);
+        }
+      }
+    })();
+
+    return () => {
+      cancelledState.current = true;
+    };
+    // One-shot on mount by design; reconnectMinDisplayMs/zmkApp are read
+    // from the closure captured at mount time.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const handleConnect = useCallback(
     async (method: ConnectionMethod) => {
@@ -55,6 +157,10 @@ export function DeviceConnectionProvider({
     zmkApp.disconnect();
   }, [zmkApp]);
 
+  const handleCancelReconnect = useCallback(() => {
+    cancelReconnectRef.current();
+  }, []);
+
   const connectionValue: ConnectionContextValue = {
     isConnected: zmkApp.isConnected,
     deviceName: zmkApp.state.deviceInfo?.name,
@@ -62,21 +168,16 @@ export function DeviceConnectionProvider({
     onDisconnect: handleDisconnect,
     isLoading: zmkApp.state.isLoading,
     error: zmkApp.state.error,
+    isReconnecting,
+    onCancelReconnect: handleCancelReconnect,
   };
 
-  const content = (
-    <ConnectionContext.Provider value={connectionValue}>
-      {children}
-    </ConnectionContext.Provider>
-  );
-
   return (
-    <ZMKConnection
-      zmkApp={zmkApp}
-      autoReconnect
-      renderDisconnected={() => content}
-      renderConnected={() => content}
-    />
+    <ZMKAppContext.Provider value={zmkApp}>
+      <ConnectionContext.Provider value={connectionValue}>
+        {children}
+      </ConnectionContext.Provider>
+    </ZMKAppContext.Provider>
   );
 }
 

--- a/src/components/DeviceConnection.tsx
+++ b/src/components/DeviceConnection.tsx
@@ -19,7 +19,7 @@ export type ConnectionMethod = "serial" | "ble" | "demo";
  * Without this, a fast reconnect would flash the indicator so briefly the
  * user couldn't tell what happened.
  */
-export const AUTO_RECONNECT_MIN_DISPLAY_MS = 2500;
+export const AUTO_RECONNECT_MIN_DISPLAY_MS = 600;
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));

--- a/src/components/ReconnectingOverlay.tsx
+++ b/src/components/ReconnectingOverlay.tsx
@@ -1,0 +1,54 @@
+import { motion } from "framer-motion";
+import { useLanguage } from "../hooks/useLanguage";
+
+interface ReconnectingOverlayProps {
+  /** Cancels an in-flight page-load auto-reconnect attempt. */
+  onCancel: () => void;
+}
+
+/**
+ * Minimal overlay shown while a page-load auto-reconnect attempt is in
+ * flight. Unlike the full SplashScreen, this keeps the backdrop fully
+ * transparent so the app doesn't appear to vanish behind an opaque splash
+ * every time a paired device is silently reconnected — only a small
+ * centered glass circle with a spinner and a cancel affordance is shown.
+ */
+export function ReconnectingOverlay({ onCancel }: ReconnectingOverlayProps) {
+  const { t } = useLanguage();
+
+  return (
+    <motion.div
+      className="fixed inset-0 z-50 flex flex-col items-center justify-center"
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      exit={{ opacity: 0 }}
+      transition={{ duration: 0.3 }}
+    >
+      {/* Centered glass circle - the only solid element on screen.
+          rounded-full needs `!`: .glass-card's own border-radius wins the
+          cascade otherwise and renders a rounded square. */}
+      <div className="glass-card rounded-full! w-44 h-44 flex flex-col items-center justify-center gap-3 p-6">
+        <motion.div
+          className="w-12 h-12 rounded-full border-2 border-transparent border-t-[var(--color-electric)] border-r-[var(--color-electric)]"
+          animate={{ rotate: 360 }}
+          transition={{
+            duration: 1,
+            repeat: Infinity,
+            ease: "linear",
+          }}
+        />
+        <p className="text-xs font-light tracking-wider text-[var(--color-text-secondary)] text-center px-2">
+          {t("Reconnecting to your keyboard...")}
+        </p>
+      </div>
+
+      <button
+        onClick={onCancel}
+        aria-label={t("Cancel")}
+        className="mt-4 text-xs text-[var(--color-text-muted)] underline underline-offset-4 hover:text-[var(--color-text-secondary)] transition-colors"
+      >
+        {t("Cancel")}
+      </button>
+    </motion.div>
+  );
+}

--- a/src/components/SplashScreen.tsx
+++ b/src/components/SplashScreen.tsx
@@ -1,4 +1,4 @@
-import { motion, AnimatePresence } from "framer-motion";
+import { motion } from "framer-motion";
 import {
   IconBluetooth,
   IconUsb,
@@ -16,13 +16,8 @@ interface SplashScreenProps {
   onConnect: (method: ConnectionMethod) => void;
   isConnecting: boolean;
   error: string | null;
-  /** True while a page-load auto-reconnect attempt is in flight. */
-  isReconnecting: boolean;
-  /** Cancels an in-flight page-load auto-reconnect attempt. */
-  onCancelReconnect: () => void;
 }
 
-// Reused for both the manual-connect dots and the reconnecting spinner.
 function LoadingDots() {
   return (
     <div className="flex gap-1.5">
@@ -58,8 +53,6 @@ export function SplashScreen({
   onConnect,
   isConnecting,
   error,
-  isReconnecting,
-  onCancelReconnect,
 }: SplashScreenProps) {
   const { t } = useLanguage();
   // Dialog state
@@ -164,124 +157,81 @@ export function SplashScreen({
           animate={{ opacity: 1 }}
           transition={{ delay: 0.8, duration: 2 }}
         >
-          <AnimatePresence mode="wait" initial={false}>
-            {isReconnecting ? (
-              <motion.div
-                key="reconnecting"
-                className="flex flex-col items-center gap-4"
-                initial={{ opacity: 0 }}
-                animate={{ opacity: 1 }}
-                exit={{ opacity: 0 }}
-                transition={{ duration: 0.3 }}
+          {/* Connect label */}
+          <p className="text-sm font-light tracking-wider text-[var(--color-text-secondary)] text-center uppercase">
+            {t("Connect")}
+          </p>
+
+          {/* Connection buttons */}
+          <div className="flex flex-col items-center gap-4">
+            {/* Device connection buttons */}
+            <div className="flex gap-6">
+              <button
+                onClick={() => handleConnectClick("serial")}
+                disabled={isConnecting}
+                className="relative w-16 h-16 rounded-full flex items-center justify-center border-2 transition-all disabled:opacity-30 disabled:cursor-not-allowed border-[var(--color-electric)] bg-[var(--color-electric)]/10 hover:bg-[var(--color-electric)]/20 hover:border-[var(--color-electric)] hover:shadow-[0_0_20px_rgba(0,212,255,0.3)]"
+                aria-label={t("Connect via USB")}
+                title={t("Connect via USB")}
               >
-                {/* Prominent spinner */}
-                <motion.div
-                  className="w-16 h-16 rounded-full border-2 border-transparent border-t-[var(--color-electric)] border-r-[var(--color-electric)]"
-                  animate={{ rotate: 360 }}
-                  transition={{
-                    duration: 1,
-                    repeat: Infinity,
-                    ease: "linear",
-                  }}
+                <IconUsb
+                  size={28}
+                  className="text-[var(--color-electric)] relative z-10"
+                  strokeWidth={1.5}
                 />
-                <p className="text-sm font-light tracking-wider text-[var(--color-text-secondary)] text-center">
-                  {t("Reconnecting to your keyboard...")}
-                </p>
-                <button
-                  onClick={onCancelReconnect}
-                  aria-label={t("Cancel")}
-                  className="text-xs text-[var(--color-text-muted)] underline underline-offset-4 hover:text-[var(--color-text-secondary)] transition-colors"
-                >
-                  {t("Cancel")}
-                </button>
-              </motion.div>
-            ) : (
-              <motion.div
-                key="connect"
-                className="flex flex-col items-center gap-4"
-                initial={{ opacity: 0 }}
-                animate={{ opacity: 1 }}
-                exit={{ opacity: 0 }}
-                transition={{ duration: 0.3 }}
+                {isConnecting && (
+                  <DisabledSlash color="bg-[var(--color-electric)]" />
+                )}
+              </button>
+              <button
+                onClick={() => handleConnectClick("ble")}
+                disabled={isConnecting}
+                className="relative w-16 h-16 rounded-full flex items-center justify-center border-2 transition-all disabled:opacity-30 disabled:cursor-not-allowed border-[var(--color-neon)] bg-[var(--color-neon)]/10 hover:bg-[var(--color-neon)]/20 hover:border-[var(--color-neon)] hover:shadow-[0_0_20px_rgba(0,255,204,0.3)]"
+                aria-label={t("Connect via Bluetooth")}
+                title={t("Connect via Bluetooth")}
               >
-                {/* Connect label */}
-                <p className="text-sm font-light tracking-wider text-[var(--color-text-secondary)] text-center uppercase">
-                  {t("Connect")}
-                </p>
+                <IconBluetooth
+                  size={28}
+                  className="text-[var(--color-neon)] relative z-10"
+                  strokeWidth={1.5}
+                />
+                {isConnecting && (
+                  <DisabledSlash color="bg-[var(--color-neon)]" />
+                )}
+              </button>
+              <button
+                onClick={() => handleConnectClick("demo")}
+                disabled={isConnecting}
+                className="relative w-16 h-16 rounded-full flex items-center justify-center border-2 transition-all disabled:opacity-30 disabled:cursor-not-allowed border-[var(--color-cyber)] bg-[var(--color-cyber)]/10 hover:bg-[var(--color-cyber)]/20 hover:border-[var(--color-cyber)] hover:shadow-[0_0_20px_rgba(139,92,246,0.3)]"
+                aria-label={t("Try Demo Mode")}
+                title={t("Try Demo Mode (no device required)")}
+              >
+                <IconDeviceDesktop
+                  size={28}
+                  className="text-[var(--color-cyber)] relative z-10"
+                  strokeWidth={1.5}
+                />
+                {isConnecting && (
+                  <DisabledSlash color="bg-[var(--color-cyber)]" />
+                )}
+              </button>
+            </div>
+          </div>
 
-                {/* Connection buttons */}
-                <div className="flex flex-col items-center gap-4">
-                  {/* Device connection buttons */}
-                  <div className="flex gap-6">
-                    <button
-                      onClick={() => handleConnectClick("serial")}
-                      disabled={isConnecting}
-                      className="relative w-16 h-16 rounded-full flex items-center justify-center border-2 transition-all disabled:opacity-30 disabled:cursor-not-allowed border-[var(--color-electric)] bg-[var(--color-electric)]/10 hover:bg-[var(--color-electric)]/20 hover:border-[var(--color-electric)] hover:shadow-[0_0_20px_rgba(0,212,255,0.3)]"
-                      aria-label={t("Connect via USB")}
-                      title={t("Connect via USB")}
-                    >
-                      <IconUsb
-                        size={28}
-                        className="text-[var(--color-electric)] relative z-10"
-                        strokeWidth={1.5}
-                      />
-                      {isConnecting && (
-                        <DisabledSlash color="bg-[var(--color-electric)]" />
-                      )}
-                    </button>
-                    <button
-                      onClick={() => handleConnectClick("ble")}
-                      disabled={isConnecting}
-                      className="relative w-16 h-16 rounded-full flex items-center justify-center border-2 transition-all disabled:opacity-30 disabled:cursor-not-allowed border-[var(--color-neon)] bg-[var(--color-neon)]/10 hover:bg-[var(--color-neon)]/20 hover:border-[var(--color-neon)] hover:shadow-[0_0_20px_rgba(0,255,204,0.3)]"
-                      aria-label={t("Connect via Bluetooth")}
-                      title={t("Connect via Bluetooth")}
-                    >
-                      <IconBluetooth
-                        size={28}
-                        className="text-[var(--color-neon)] relative z-10"
-                        strokeWidth={1.5}
-                      />
-                      {isConnecting && (
-                        <DisabledSlash color="bg-[var(--color-neon)]" />
-                      )}
-                    </button>
-                    <button
-                      onClick={() => handleConnectClick("demo")}
-                      disabled={isConnecting}
-                      className="relative w-16 h-16 rounded-full flex items-center justify-center border-2 transition-all disabled:opacity-30 disabled:cursor-not-allowed border-[var(--color-cyber)] bg-[var(--color-cyber)]/10 hover:bg-[var(--color-cyber)]/20 hover:border-[var(--color-cyber)] hover:shadow-[0_0_20px_rgba(139,92,246,0.3)]"
-                      aria-label={t("Try Demo Mode")}
-                      title={t("Try Demo Mode (no device required)")}
-                    >
-                      <IconDeviceDesktop
-                        size={28}
-                        className="text-[var(--color-cyber)] relative z-10"
-                        strokeWidth={1.5}
-                      />
-                      {isConnecting && (
-                        <DisabledSlash color="bg-[var(--color-cyber)]" />
-                      )}
-                    </button>
-                  </div>
-                </div>
-
-                {/* Demo mode hint */}
-                <motion.p
-                  className="text-xs text-[var(--color-text-muted)] mt-2 text-center leading-tight"
-                  initial={{ opacity: 0 }}
-                  animate={{ opacity: 1 }}
-                  transition={{ delay: 1.2 }}
-                >
-                  {t("Try demo mode without a keyboard")}
-                  <br />
-                  <IconArrowUp size={14} className="inline-block" />
-                </motion.p>
-              </motion.div>
-            )}
-          </AnimatePresence>
+          {/* Demo mode hint */}
+          <motion.p
+            className="text-xs text-[var(--color-text-muted)] mt-2 text-center leading-tight"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            transition={{ delay: 1.2 }}
+          >
+            {t("Try demo mode without a keyboard")}
+            <br />
+            <IconArrowUp size={14} className="inline-block" />
+          </motion.p>
         </motion.div>
       </motion.div>
-      {/* Loading indicator (manual connect only; reconnecting has its own spinner above) */}
-      {isConnecting && !isReconnecting && (
+      {/* Loading indicator */}
+      {isConnecting && (
         <motion.div
           className="flex gap-1 mt-4"
           initial={{ opacity: 0 }}

--- a/src/components/SplashScreen.tsx
+++ b/src/components/SplashScreen.tsx
@@ -1,4 +1,4 @@
-import { motion } from "framer-motion";
+import { motion, AnimatePresence } from "framer-motion";
 import {
   IconBluetooth,
   IconUsb,
@@ -16,6 +16,33 @@ interface SplashScreenProps {
   onConnect: (method: ConnectionMethod) => void;
   isConnecting: boolean;
   error: string | null;
+  /** True while a page-load auto-reconnect attempt is in flight. */
+  isReconnecting: boolean;
+  /** Cancels an in-flight page-load auto-reconnect attempt. */
+  onCancelReconnect: () => void;
+}
+
+// Reused for both the manual-connect dots and the reconnecting spinner.
+function LoadingDots() {
+  return (
+    <div className="flex gap-1.5">
+      {[0, 1, 2].map((i) => (
+        <motion.div
+          key={i}
+          className="w-1.5 h-1.5 rounded-full bg-[var(--color-electric)]"
+          animate={{
+            opacity: [0.3, 1, 0.3],
+            scale: [0.8, 1, 0.8],
+          }}
+          transition={{
+            duration: 1,
+            repeat: Infinity,
+            delay: i * 0.2,
+          }}
+        />
+      ))}
+    </div>
+  );
 }
 
 // Slash line component for disabled state
@@ -31,6 +58,8 @@ export function SplashScreen({
   onConnect,
   isConnecting,
   error,
+  isReconnecting,
+  onCancelReconnect,
 }: SplashScreenProps) {
   const { t } = useLanguage();
   // Dialog state
@@ -135,101 +164,130 @@ export function SplashScreen({
           animate={{ opacity: 1 }}
           transition={{ delay: 0.8, duration: 2 }}
         >
-          {/* Connect label */}
-          <p className="text-sm font-light tracking-wider text-[var(--color-text-secondary)] text-center uppercase">
-            {t("Connect")}
-          </p>
+          <AnimatePresence mode="wait" initial={false}>
+            {isReconnecting ? (
+              <motion.div
+                key="reconnecting"
+                className="flex flex-col items-center gap-4"
+                initial={{ opacity: 0 }}
+                animate={{ opacity: 1 }}
+                exit={{ opacity: 0 }}
+                transition={{ duration: 0.3 }}
+              >
+                {/* Prominent spinner */}
+                <motion.div
+                  className="w-16 h-16 rounded-full border-2 border-transparent border-t-[var(--color-electric)] border-r-[var(--color-electric)]"
+                  animate={{ rotate: 360 }}
+                  transition={{
+                    duration: 1,
+                    repeat: Infinity,
+                    ease: "linear",
+                  }}
+                />
+                <p className="text-sm font-light tracking-wider text-[var(--color-text-secondary)] text-center">
+                  {t("Reconnecting to your keyboard...")}
+                </p>
+                <button
+                  onClick={onCancelReconnect}
+                  aria-label={t("Cancel")}
+                  className="text-xs text-[var(--color-text-muted)] underline underline-offset-4 hover:text-[var(--color-text-secondary)] transition-colors"
+                >
+                  {t("Cancel")}
+                </button>
+              </motion.div>
+            ) : (
+              <motion.div
+                key="connect"
+                className="flex flex-col items-center gap-4"
+                initial={{ opacity: 0 }}
+                animate={{ opacity: 1 }}
+                exit={{ opacity: 0 }}
+                transition={{ duration: 0.3 }}
+              >
+                {/* Connect label */}
+                <p className="text-sm font-light tracking-wider text-[var(--color-text-secondary)] text-center uppercase">
+                  {t("Connect")}
+                </p>
 
-          {/* Connection buttons */}
-          <div className="flex flex-col items-center gap-4">
-            {/* Device connection buttons */}
-            <div className="flex gap-6">
-              <button
-                onClick={() => handleConnectClick("serial")}
-                disabled={isConnecting}
-                className="relative w-16 h-16 rounded-full flex items-center justify-center border-2 transition-all disabled:opacity-30 disabled:cursor-not-allowed border-[var(--color-electric)] bg-[var(--color-electric)]/10 hover:bg-[var(--color-electric)]/20 hover:border-[var(--color-electric)] hover:shadow-[0_0_20px_rgba(0,212,255,0.3)]"
-                aria-label={t("Connect via USB")}
-                title={t("Connect via USB")}
-              >
-                <IconUsb
-                  size={28}
-                  className="text-[var(--color-electric)] relative z-10"
-                  strokeWidth={1.5}
-                />
-                {isConnecting && (
-                  <DisabledSlash color="bg-[var(--color-electric)]" />
-                )}
-              </button>
-              <button
-                onClick={() => handleConnectClick("ble")}
-                disabled={isConnecting}
-                className="relative w-16 h-16 rounded-full flex items-center justify-center border-2 transition-all disabled:opacity-30 disabled:cursor-not-allowed border-[var(--color-neon)] bg-[var(--color-neon)]/10 hover:bg-[var(--color-neon)]/20 hover:border-[var(--color-neon)] hover:shadow-[0_0_20px_rgba(0,255,204,0.3)]"
-                aria-label={t("Connect via Bluetooth")}
-                title={t("Connect via Bluetooth")}
-              >
-                <IconBluetooth
-                  size={28}
-                  className="text-[var(--color-neon)] relative z-10"
-                  strokeWidth={1.5}
-                />
-                {isConnecting && (
-                  <DisabledSlash color="bg-[var(--color-neon)]" />
-                )}
-              </button>
-              <button
-                onClick={() => handleConnectClick("demo")}
-                disabled={isConnecting}
-                className="relative w-16 h-16 rounded-full flex items-center justify-center border-2 transition-all disabled:opacity-30 disabled:cursor-not-allowed border-[var(--color-cyber)] bg-[var(--color-cyber)]/10 hover:bg-[var(--color-cyber)]/20 hover:border-[var(--color-cyber)] hover:shadow-[0_0_20px_rgba(139,92,246,0.3)]"
-                aria-label={t("Try Demo Mode")}
-                title={t("Try Demo Mode (no device required)")}
-              >
-                <IconDeviceDesktop
-                  size={28}
-                  className="text-[var(--color-cyber)] relative z-10"
-                  strokeWidth={1.5}
-                />
-                {isConnecting && (
-                  <DisabledSlash color="bg-[var(--color-cyber)]" />
-                )}
-              </button>
-            </div>
-          </div>
+                {/* Connection buttons */}
+                <div className="flex flex-col items-center gap-4">
+                  {/* Device connection buttons */}
+                  <div className="flex gap-6">
+                    <button
+                      onClick={() => handleConnectClick("serial")}
+                      disabled={isConnecting}
+                      className="relative w-16 h-16 rounded-full flex items-center justify-center border-2 transition-all disabled:opacity-30 disabled:cursor-not-allowed border-[var(--color-electric)] bg-[var(--color-electric)]/10 hover:bg-[var(--color-electric)]/20 hover:border-[var(--color-electric)] hover:shadow-[0_0_20px_rgba(0,212,255,0.3)]"
+                      aria-label={t("Connect via USB")}
+                      title={t("Connect via USB")}
+                    >
+                      <IconUsb
+                        size={28}
+                        className="text-[var(--color-electric)] relative z-10"
+                        strokeWidth={1.5}
+                      />
+                      {isConnecting && (
+                        <DisabledSlash color="bg-[var(--color-electric)]" />
+                      )}
+                    </button>
+                    <button
+                      onClick={() => handleConnectClick("ble")}
+                      disabled={isConnecting}
+                      className="relative w-16 h-16 rounded-full flex items-center justify-center border-2 transition-all disabled:opacity-30 disabled:cursor-not-allowed border-[var(--color-neon)] bg-[var(--color-neon)]/10 hover:bg-[var(--color-neon)]/20 hover:border-[var(--color-neon)] hover:shadow-[0_0_20px_rgba(0,255,204,0.3)]"
+                      aria-label={t("Connect via Bluetooth")}
+                      title={t("Connect via Bluetooth")}
+                    >
+                      <IconBluetooth
+                        size={28}
+                        className="text-[var(--color-neon)] relative z-10"
+                        strokeWidth={1.5}
+                      />
+                      {isConnecting && (
+                        <DisabledSlash color="bg-[var(--color-neon)]" />
+                      )}
+                    </button>
+                    <button
+                      onClick={() => handleConnectClick("demo")}
+                      disabled={isConnecting}
+                      className="relative w-16 h-16 rounded-full flex items-center justify-center border-2 transition-all disabled:opacity-30 disabled:cursor-not-allowed border-[var(--color-cyber)] bg-[var(--color-cyber)]/10 hover:bg-[var(--color-cyber)]/20 hover:border-[var(--color-cyber)] hover:shadow-[0_0_20px_rgba(139,92,246,0.3)]"
+                      aria-label={t("Try Demo Mode")}
+                      title={t("Try Demo Mode (no device required)")}
+                    >
+                      <IconDeviceDesktop
+                        size={28}
+                        className="text-[var(--color-cyber)] relative z-10"
+                        strokeWidth={1.5}
+                      />
+                      {isConnecting && (
+                        <DisabledSlash color="bg-[var(--color-cyber)]" />
+                      )}
+                    </button>
+                  </div>
+                </div>
 
-          {/* Demo mode hint */}
-          <motion.p
-            className="text-xs text-[var(--color-text-muted)] mt-2 text-center leading-tight"
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            transition={{ delay: 1.2 }}
-          >
-            {t("Try demo mode without a keyboard")}
-            <br />
-            <IconArrowUp size={14} className="inline-block" />
-          </motion.p>
+                {/* Demo mode hint */}
+                <motion.p
+                  className="text-xs text-[var(--color-text-muted)] mt-2 text-center leading-tight"
+                  initial={{ opacity: 0 }}
+                  animate={{ opacity: 1 }}
+                  transition={{ delay: 1.2 }}
+                >
+                  {t("Try demo mode without a keyboard")}
+                  <br />
+                  <IconArrowUp size={14} className="inline-block" />
+                </motion.p>
+              </motion.div>
+            )}
+          </AnimatePresence>
         </motion.div>
       </motion.div>
-      {/* Loading indicator */}
-      {isConnecting && (
+      {/* Loading indicator (manual connect only; reconnecting has its own spinner above) */}
+      {isConnecting && !isReconnecting && (
         <motion.div
           className="flex gap-1 mt-4"
           initial={{ opacity: 0 }}
           animate={{ opacity: 1 }}
         >
-          {[0, 1, 2].map((i) => (
-            <motion.div
-              key={i}
-              className="w-1.5 h-1.5 rounded-full bg-[var(--color-electric)]"
-              animate={{
-                opacity: [0.3, 1, 0.3],
-                scale: [0.8, 1, 0.8],
-              }}
-              transition={{
-                duration: 1,
-                repeat: Infinity,
-                delay: i * 0.2,
-              }}
-            />
-          ))}
+          <LoadingDots />
         </motion.div>
       )}
 

--- a/src/components/__tests__/DeviceConnection.test.tsx
+++ b/src/components/__tests__/DeviceConnection.test.tsx
@@ -62,12 +62,20 @@ function TestComponent() {
   );
 }
 
+type NavigatorWithOptionalSerial = Navigator & { serial?: unknown };
+
 describe("DeviceConnection", () => {
   let mocks: ReturnType<typeof setupZMKMocks>;
 
   beforeEach(() => {
     // Reset mocks using the test helper
     mocks = setupZMKMocks();
+    // Auto-reconnect remembers ports in sessionStorage; start each test clean.
+    window.sessionStorage.clear();
+  });
+
+  afterEach(() => {
+    delete (navigator as NavigatorWithOptionalSerial).serial;
   });
 
   describe("Initial State", () => {
@@ -415,6 +423,64 @@ describe("DeviceConnection", () => {
           "My Keyboard",
         );
       });
+    });
+  });
+
+  describe("Auto-reconnect on mount", () => {
+    test("renders children in the disconnected state when there is no paired serial port", async () => {
+      // jsdom has no navigator.serial by default, so the silent auto-reconnect
+      // attempt inside ZMKConnection resolves to "nothing to reconnect to"
+      // and the app should fall back to the normal connect screen.
+      render(
+        <DeviceConnectionProvider>
+          <TestComponent />
+        </DeviceConnectionProvider>,
+      );
+
+      // Let the auto-reconnect effect (and its microtasks) settle.
+      await waitFor(() => {
+        expect(screen.getByTestId("connection-status")).toHaveTextContent(
+          "Disconnected",
+        );
+      });
+      expect(screen.getByTestId("connect-button")).toBeInTheDocument();
+      expect(screen.queryByTestId("device-name")).not.toBeInTheDocument();
+    });
+
+    test("transitions to connected when a previously paired serial port reconnects successfully", async () => {
+      mocks.mockSuccessfulConnection({
+        deviceName: "Auto Reconnected Keyboard",
+      });
+
+      const mockPort = {
+        open: jest.fn().mockResolvedValue(undefined),
+        close: jest.fn().mockResolvedValue(undefined),
+        getInfo: jest
+          .fn()
+          .mockReturnValue({ usbVendorId: 0x1234, usbProductId: 0x5678 }),
+        readable: {},
+        writable: { close: jest.fn().mockResolvedValue(undefined) },
+      };
+      Object.defineProperty(navigator, "serial", {
+        configurable: true,
+        value: { getPorts: jest.fn().mockResolvedValue([mockPort]) },
+      });
+
+      render(
+        <DeviceConnectionProvider>
+          <TestComponent />
+        </DeviceConnectionProvider>,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId("connection-status")).toHaveTextContent(
+          "Connected",
+        );
+      });
+      expect(screen.getByTestId("device-name")).toHaveTextContent(
+        "Auto Reconnected Keyboard",
+      );
+      expect(mockPort.open).toHaveBeenCalledWith({ baudRate: 12500 });
     });
   });
 });

--- a/src/components/__tests__/DeviceConnection.test.tsx
+++ b/src/components/__tests__/DeviceConnection.test.tsx
@@ -49,6 +49,9 @@ function TestComponent() {
       )}
       {connection.isLoading && <div data-testid="loading">Loading...</div>}
       {connection.error && <div data-testid="error">{connection.error}</div>}
+      {connection.isReconnecting && (
+        <div data-testid="reconnecting">Reconnecting...</div>
+      )}
       <button
         onClick={() => connection.onConnect("serial")}
         data-testid="connect-button"
@@ -58,8 +61,36 @@ function TestComponent() {
       <button onClick={connection.onDisconnect} data-testid="disconnect-button">
         Disconnect
       </button>
+      <button
+        onClick={connection.onCancelReconnect}
+        data-testid="cancel-reconnect-button"
+      >
+        Cancel Reconnect
+      </button>
     </div>
   );
+}
+
+/** Builds a mock `SerialPort`-like object suitable for the auto-reconnect flow. */
+function createMockSerialPort(overrides: Record<string, unknown> = {}) {
+  return {
+    open: jest.fn().mockResolvedValue(undefined),
+    close: jest.fn().mockResolvedValue(undefined),
+    getInfo: jest
+      .fn()
+      .mockReturnValue({ usbVendorId: 0x1234, usbProductId: 0x5678 }),
+    readable: { cancel: jest.fn().mockResolvedValue(undefined) },
+    writable: { close: jest.fn().mockResolvedValue(undefined) },
+    ...overrides,
+  };
+}
+
+/** Makes `navigator.serial.getPorts()` resolve to the given paired ports. */
+function setPairedSerialPorts(ports: unknown[]) {
+  Object.defineProperty(navigator, "serial", {
+    configurable: true,
+    value: { getPorts: jest.fn().mockResolvedValue(ports) },
+  });
 }
 
 type NavigatorWithOptionalSerial = Navigator & { serial?: unknown };
@@ -428,11 +459,12 @@ describe("DeviceConnection", () => {
 
   describe("Auto-reconnect on mount", () => {
     test("renders children in the disconnected state when there is no paired serial port", async () => {
-      // jsdom has no navigator.serial by default, so the silent auto-reconnect
-      // attempt inside ZMKConnection resolves to "nothing to reconnect to"
-      // and the app should fall back to the normal connect screen.
+      // jsdom has no navigator.serial by default, so the app-driven
+      // auto-reconnect attempt resolves to "nothing to reconnect to" and the
+      // normal connect screen shows immediately -- isReconnecting never
+      // becomes true.
       render(
-        <DeviceConnectionProvider>
+        <DeviceConnectionProvider reconnectMinDisplayMs={0}>
           <TestComponent />
         </DeviceConnectionProvider>,
       );
@@ -445,6 +477,7 @@ describe("DeviceConnection", () => {
       });
       expect(screen.getByTestId("connect-button")).toBeInTheDocument();
       expect(screen.queryByTestId("device-name")).not.toBeInTheDocument();
+      expect(screen.queryByTestId("reconnecting")).not.toBeInTheDocument();
     });
 
     test("transitions to connected when a previously paired serial port reconnects successfully", async () => {
@@ -452,22 +485,11 @@ describe("DeviceConnection", () => {
         deviceName: "Auto Reconnected Keyboard",
       });
 
-      const mockPort = {
-        open: jest.fn().mockResolvedValue(undefined),
-        close: jest.fn().mockResolvedValue(undefined),
-        getInfo: jest
-          .fn()
-          .mockReturnValue({ usbVendorId: 0x1234, usbProductId: 0x5678 }),
-        readable: {},
-        writable: { close: jest.fn().mockResolvedValue(undefined) },
-      };
-      Object.defineProperty(navigator, "serial", {
-        configurable: true,
-        value: { getPorts: jest.fn().mockResolvedValue([mockPort]) },
-      });
+      const mockPort = createMockSerialPort();
+      setPairedSerialPorts([mockPort]);
 
       render(
-        <DeviceConnectionProvider>
+        <DeviceConnectionProvider reconnectMinDisplayMs={0}>
           <TestComponent />
         </DeviceConnectionProvider>,
       );
@@ -481,6 +503,126 @@ describe("DeviceConnection", () => {
         "Auto Reconnected Keyboard",
       );
       expect(mockPort.open).toHaveBeenCalledWith({ baudRate: 12500 });
+      expect(screen.queryByTestId("reconnecting")).not.toBeInTheDocument();
+    });
+
+    test("exposes isReconnecting while the attempt is in flight, then clears it once connected", async () => {
+      mocks.mockSuccessfulConnection({ deviceName: "Slow Reconnect" });
+
+      // Keep `port.open()` pending until the test explicitly resolves it, so
+      // we can observe the in-between isReconnecting: true state.
+      let resolveOpen: () => void = () => {};
+      const openPromise = new Promise<void>((resolve) => {
+        resolveOpen = resolve;
+      });
+      const mockPort = createMockSerialPort({
+        open: jest.fn().mockReturnValue(openPromise),
+      });
+      setPairedSerialPorts([mockPort]);
+
+      render(
+        <DeviceConnectionProvider reconnectMinDisplayMs={0}>
+          <TestComponent />
+        </DeviceConnectionProvider>,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId("reconnecting")).toBeInTheDocument();
+      });
+      expect(screen.getByTestId("connection-status")).toHaveTextContent(
+        "Disconnected",
+      );
+
+      resolveOpen();
+
+      await waitFor(() => {
+        expect(screen.queryByTestId("reconnecting")).not.toBeInTheDocument();
+      });
+      await waitFor(() => {
+        expect(screen.getByTestId("connection-status")).toHaveTextContent(
+          "Connected",
+        );
+      });
+      expect(screen.getByTestId("device-name")).toHaveTextContent(
+        "Slow Reconnect",
+      );
+    });
+
+    test("cancelling a pending reconnect stays disconnected even if the transport later resolves", async () => {
+      const user = userEvent.setup();
+      mocks.mockSuccessfulConnection({ deviceName: "Should Not Connect" });
+
+      let resolveOpen: () => void = () => {};
+      const openPromise = new Promise<void>((resolve) => {
+        resolveOpen = resolve;
+      });
+      const mockPort = createMockSerialPort({
+        open: jest.fn().mockReturnValue(openPromise),
+      });
+      setPairedSerialPorts([mockPort]);
+
+      render(
+        <DeviceConnectionProvider reconnectMinDisplayMs={0}>
+          <TestComponent />
+        </DeviceConnectionProvider>,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId("reconnecting")).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByTestId("cancel-reconnect-button"));
+
+      // Cancelling returns to the non-reconnecting disconnected state
+      // immediately, without waiting for the transport.
+      expect(screen.queryByTestId("reconnecting")).not.toBeInTheDocument();
+      expect(screen.getByTestId("connection-status")).toHaveTextContent(
+        "Disconnected",
+      );
+
+      // Now let the (cancelled) transport resolve -- the app must not
+      // become connected even though a transport was obtained.
+      resolveOpen();
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      expect(screen.getByTestId("connection-status")).toHaveTextContent(
+        "Disconnected",
+      );
+      expect(screen.queryByTestId("device-name")).not.toBeInTheDocument();
+    });
+
+    test("keeps the reconnecting indicator visible for at least reconnectMinDisplayMs even on an instant success", async () => {
+      mocks.mockSuccessfulConnection({ deviceName: "Fast Reconnect" });
+      const mockPort = createMockSerialPort();
+      setPairedSerialPorts([mockPort]);
+
+      render(
+        <DeviceConnectionProvider reconnectMinDisplayMs={300}>
+          <TestComponent />
+        </DeviceConnectionProvider>,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId("reconnecting")).toBeInTheDocument();
+      });
+
+      // The underlying reconnect resolves almost instantly, but the
+      // indicator must still be showing well before the minimum elapses.
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      expect(screen.getByTestId("reconnecting")).toBeInTheDocument();
+      expect(screen.getByTestId("connection-status")).toHaveTextContent(
+        "Disconnected",
+      );
+
+      await waitFor(
+        () => {
+          expect(screen.queryByTestId("reconnecting")).not.toBeInTheDocument();
+        },
+        { timeout: 2000 },
+      );
+      expect(screen.getByTestId("connection-status")).toHaveTextContent(
+        "Connected",
+      );
     });
   });
 });

--- a/src/components/__tests__/ReconnectingOverlay.test.tsx
+++ b/src/components/__tests__/ReconnectingOverlay.test.tsx
@@ -1,0 +1,43 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ReconnectingOverlay } from "../ReconnectingOverlay";
+
+describe("ReconnectingOverlay", () => {
+  test("renders the reconnecting message", () => {
+    const onCancel = jest.fn();
+
+    render(<ReconnectingOverlay onCancel={onCancel} />);
+
+    expect(
+      screen.getByText("Reconnecting to your keyboard..."),
+    ).toBeInTheDocument();
+  });
+
+  test("renders a Cancel button that calls onCancel when clicked", async () => {
+    const user = userEvent.setup();
+    const onCancel = jest.fn();
+
+    render(<ReconnectingOverlay onCancel={onCancel} />);
+
+    const cancelButton = screen.getByLabelText("Cancel");
+    expect(cancelButton).toBeInTheDocument();
+
+    await user.click(cancelButton);
+
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  test("the fixed root has no opaque background fill", () => {
+    const onCancel = jest.fn();
+
+    const { container } = render(<ReconnectingOverlay onCancel={onCancel} />);
+
+    const root = container.firstElementChild;
+    expect(root).not.toBeNull();
+    expect(root?.className).toMatch(/fixed inset-0/);
+    // The backdrop itself must not carry any background/blur classes - only
+    // the inner circle is meant to be visually solid.
+    expect(root?.className).not.toMatch(/\bbg-/);
+    expect(root?.className).not.toMatch(/backdrop-blur/);
+  });
+});

--- a/src/components/__tests__/SplashScreen.test.tsx
+++ b/src/components/__tests__/SplashScreen.test.tsx
@@ -1,0 +1,114 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { SplashScreen } from "../SplashScreen";
+
+describe("SplashScreen", () => {
+  test("renders the normal connect state with three connect buttons", () => {
+    const onConnect = jest.fn();
+    const onCancelReconnect = jest.fn();
+
+    render(
+      <SplashScreen
+        onConnect={onConnect}
+        isConnecting={false}
+        error={null}
+        isReconnecting={false}
+        onCancelReconnect={onCancelReconnect}
+      />,
+    );
+
+    expect(screen.getByLabelText("Connect via USB")).toBeInTheDocument();
+    expect(screen.getByLabelText("Connect via Bluetooth")).toBeInTheDocument();
+    expect(screen.getByLabelText("Try Demo Mode")).toBeInTheDocument();
+    expect(
+      screen.queryByText("Reconnecting to your keyboard..."),
+    ).not.toBeInTheDocument();
+  });
+
+  test("shows the reconnecting message and cancel button, and hides the connect buttons, while reconnecting", () => {
+    const onConnect = jest.fn();
+    const onCancelReconnect = jest.fn();
+
+    render(
+      <SplashScreen
+        onConnect={onConnect}
+        isConnecting={false}
+        error={null}
+        isReconnecting={true}
+        onCancelReconnect={onCancelReconnect}
+      />,
+    );
+
+    expect(
+      screen.getByText("Reconnecting to your keyboard..."),
+    ).toBeInTheDocument();
+    expect(screen.getByLabelText("Cancel")).toBeInTheDocument();
+
+    expect(screen.queryByLabelText("Connect via USB")).not.toBeInTheDocument();
+    expect(
+      screen.queryByLabelText("Connect via Bluetooth"),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Try Demo Mode")).not.toBeInTheDocument();
+  });
+
+  test("calls onCancelReconnect when the cancel button is clicked", async () => {
+    const user = userEvent.setup();
+    const onConnect = jest.fn();
+    const onCancelReconnect = jest.fn();
+
+    render(
+      <SplashScreen
+        onConnect={onConnect}
+        isConnecting={false}
+        error={null}
+        isReconnecting={true}
+        onCancelReconnect={onCancelReconnect}
+      />,
+    );
+
+    await user.click(screen.getByLabelText("Cancel"));
+
+    expect(onCancelReconnect).toHaveBeenCalledTimes(1);
+    expect(onConnect).not.toHaveBeenCalled();
+  });
+
+  test("does not conflate isReconnecting with isConnecting (manual connect) state", () => {
+    const onConnect = jest.fn();
+    const onCancelReconnect = jest.fn();
+
+    render(
+      <SplashScreen
+        onConnect={onConnect}
+        isConnecting={true}
+        error={null}
+        isReconnecting={false}
+        onCancelReconnect={onCancelReconnect}
+      />,
+    );
+
+    // Manual "connecting" state still shows the connect buttons (disabled),
+    // not the reconnecting message.
+    expect(screen.getByLabelText("Connect via USB")).toBeInTheDocument();
+    expect(screen.getByLabelText("Connect via USB")).toBeDisabled();
+    expect(
+      screen.queryByText("Reconnecting to your keyboard..."),
+    ).not.toBeInTheDocument();
+  });
+
+  test("shows an error message when provided", () => {
+    const onConnect = jest.fn();
+    const onCancelReconnect = jest.fn();
+
+    render(
+      <SplashScreen
+        onConnect={onConnect}
+        isConnecting={false}
+        error="Something went wrong"
+        isReconnecting={false}
+        onCancelReconnect={onCancelReconnect}
+      />,
+    );
+
+    expect(screen.getByText("Something went wrong")).toBeInTheDocument();
+  });
+});

--- a/src/components/__tests__/SplashScreen.test.tsx
+++ b/src/components/__tests__/SplashScreen.test.tsx
@@ -1,111 +1,40 @@
 import { render, screen } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
 import { SplashScreen } from "../SplashScreen";
 
 describe("SplashScreen", () => {
   test("renders the normal connect state with three connect buttons", () => {
     const onConnect = jest.fn();
-    const onCancelReconnect = jest.fn();
 
     render(
-      <SplashScreen
-        onConnect={onConnect}
-        isConnecting={false}
-        error={null}
-        isReconnecting={false}
-        onCancelReconnect={onCancelReconnect}
-      />,
+      <SplashScreen onConnect={onConnect} isConnecting={false} error={null} />,
     );
 
     expect(screen.getByLabelText("Connect via USB")).toBeInTheDocument();
     expect(screen.getByLabelText("Connect via Bluetooth")).toBeInTheDocument();
     expect(screen.getByLabelText("Try Demo Mode")).toBeInTheDocument();
-    expect(
-      screen.queryByText("Reconnecting to your keyboard..."),
-    ).not.toBeInTheDocument();
   });
 
-  test("shows the reconnecting message and cancel button, and hides the connect buttons, while reconnecting", () => {
+  test("disables the connect buttons while isConnecting is true", () => {
     const onConnect = jest.fn();
-    const onCancelReconnect = jest.fn();
 
     render(
-      <SplashScreen
-        onConnect={onConnect}
-        isConnecting={false}
-        error={null}
-        isReconnecting={true}
-        onCancelReconnect={onCancelReconnect}
-      />,
+      <SplashScreen onConnect={onConnect} isConnecting={true} error={null} />,
     );
 
-    expect(
-      screen.getByText("Reconnecting to your keyboard..."),
-    ).toBeInTheDocument();
-    expect(screen.getByLabelText("Cancel")).toBeInTheDocument();
-
-    expect(screen.queryByLabelText("Connect via USB")).not.toBeInTheDocument();
-    expect(
-      screen.queryByLabelText("Connect via Bluetooth"),
-    ).not.toBeInTheDocument();
-    expect(screen.queryByLabelText("Try Demo Mode")).not.toBeInTheDocument();
-  });
-
-  test("calls onCancelReconnect when the cancel button is clicked", async () => {
-    const user = userEvent.setup();
-    const onConnect = jest.fn();
-    const onCancelReconnect = jest.fn();
-
-    render(
-      <SplashScreen
-        onConnect={onConnect}
-        isConnecting={false}
-        error={null}
-        isReconnecting={true}
-        onCancelReconnect={onCancelReconnect}
-      />,
-    );
-
-    await user.click(screen.getByLabelText("Cancel"));
-
-    expect(onCancelReconnect).toHaveBeenCalledTimes(1);
-    expect(onConnect).not.toHaveBeenCalled();
-  });
-
-  test("does not conflate isReconnecting with isConnecting (manual connect) state", () => {
-    const onConnect = jest.fn();
-    const onCancelReconnect = jest.fn();
-
-    render(
-      <SplashScreen
-        onConnect={onConnect}
-        isConnecting={true}
-        error={null}
-        isReconnecting={false}
-        onCancelReconnect={onCancelReconnect}
-      />,
-    );
-
-    // Manual "connecting" state still shows the connect buttons (disabled),
-    // not the reconnecting message.
     expect(screen.getByLabelText("Connect via USB")).toBeInTheDocument();
     expect(screen.getByLabelText("Connect via USB")).toBeDisabled();
-    expect(
-      screen.queryByText("Reconnecting to your keyboard..."),
-    ).not.toBeInTheDocument();
+    expect(screen.getByLabelText("Connect via Bluetooth")).toBeDisabled();
+    expect(screen.getByLabelText("Try Demo Mode")).toBeDisabled();
   });
 
   test("shows an error message when provided", () => {
     const onConnect = jest.fn();
-    const onCancelReconnect = jest.fn();
 
     render(
       <SplashScreen
         onConnect={onConnect}
         isConnecting={false}
         error="Something went wrong"
-        isReconnecting={false}
-        onCancelReconnect={onCancelReconnect}
       />,
     );
 

--- a/src/hooks/__tests__/useDefaultLayer.test.tsx
+++ b/src/hooks/__tests__/useDefaultLayer.test.tsx
@@ -13,12 +13,24 @@ import { Response } from "../../proto/cormoran/default_layer/default_layer";
 
 const mockCallRPC = jest.fn();
 
-jest.mock("@cormoran/zmk-studio-react-hook", () => ({
-  ...jest.requireActual("@cormoran/zmk-studio-react-hook"),
-  ZMKCustomSubsystem: jest.fn().mockImplementation(() => ({
+jest.mock("@cormoran/zmk-studio-react-hook", () => {
+  const actual = jest.requireActual("@cormoran/zmk-studio-react-hook");
+  const {
+    createUseCustomSubsystemMock,
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+  } = require("../testUtils/mockUseCustomSubsystem");
+  const ZMKCustomSubsystem = jest.fn().mockImplementation(() => ({
     callRPC: mockCallRPC,
-  })),
-}));
+  }));
+  return {
+    ...actual,
+    ZMKCustomSubsystem,
+    useCustomSubsystem: createUseCustomSubsystemMock(
+      actual.ZMKAppContext,
+      ZMKCustomSubsystem,
+    ),
+  };
+});
 
 function createWrapper(zmkAppValue: {
   state: { connection: unknown; customSubsystems: unknown[] };

--- a/src/hooks/__tests__/useInputStream.test.tsx
+++ b/src/hooks/__tests__/useInputStream.test.tsx
@@ -17,12 +17,24 @@ import {
 
 const mockCallRPC = jest.fn();
 
-jest.mock("@cormoran/zmk-studio-react-hook", () => ({
-  ...jest.requireActual("@cormoran/zmk-studio-react-hook"),
-  ZMKCustomSubsystem: jest.fn().mockImplementation(() => ({
+jest.mock("@cormoran/zmk-studio-react-hook", () => {
+  const actual = jest.requireActual("@cormoran/zmk-studio-react-hook");
+  const {
+    createUseCustomSubsystemMock,
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+  } = require("../testUtils/mockUseCustomSubsystem");
+  const ZMKCustomSubsystem = jest.fn().mockImplementation(() => ({
     callRPC: mockCallRPC,
-  })),
-}));
+  }));
+  return {
+    ...actual,
+    ZMKCustomSubsystem,
+    useCustomSubsystem: createUseCustomSubsystemMock(
+      actual.ZMKAppContext,
+      ZMKCustomSubsystem,
+    ),
+  };
+});
 
 function createWrapper(zmkAppValue: {
   state: {

--- a/src/hooks/__tests__/useKscanDiagnostics.test.tsx
+++ b/src/hooks/__tests__/useKscanDiagnostics.test.tsx
@@ -14,12 +14,24 @@ import {
 
 const mockCallRPC = jest.fn();
 
-jest.mock("@cormoran/zmk-studio-react-hook", () => ({
-  ...jest.requireActual("@cormoran/zmk-studio-react-hook"),
-  ZMKCustomSubsystem: jest.fn().mockImplementation(() => ({
+jest.mock("@cormoran/zmk-studio-react-hook", () => {
+  const actual = jest.requireActual("@cormoran/zmk-studio-react-hook");
+  const {
+    createUseCustomSubsystemMock,
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+  } = require("../testUtils/mockUseCustomSubsystem");
+  const ZMKCustomSubsystem = jest.fn().mockImplementation(() => ({
     callRPC: mockCallRPC,
-  })),
-}));
+  }));
+  return {
+    ...actual,
+    ZMKCustomSubsystem,
+    useCustomSubsystem: createUseCustomSubsystemMock(
+      actual.ZMKAppContext,
+      ZMKCustomSubsystem,
+    ),
+  };
+});
 
 function createWrapper() {
   const zmkAppValue = {

--- a/src/hooks/__tests__/useOsDetection.test.tsx
+++ b/src/hooks/__tests__/useOsDetection.test.tsx
@@ -12,12 +12,24 @@ import { Response, Os } from "../../proto/cormoran/os_detection/os_detection";
 
 const mockCallRPC = jest.fn();
 
-jest.mock("@cormoran/zmk-studio-react-hook", () => ({
-  ...jest.requireActual("@cormoran/zmk-studio-react-hook"),
-  ZMKCustomSubsystem: jest.fn().mockImplementation(() => ({
+jest.mock("@cormoran/zmk-studio-react-hook", () => {
+  const actual = jest.requireActual("@cormoran/zmk-studio-react-hook");
+  const {
+    createUseCustomSubsystemMock,
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+  } = require("../testUtils/mockUseCustomSubsystem");
+  const ZMKCustomSubsystem = jest.fn().mockImplementation(() => ({
     callRPC: mockCallRPC,
-  })),
-}));
+  }));
+  return {
+    ...actual,
+    ZMKCustomSubsystem,
+    useCustomSubsystem: createUseCustomSubsystemMock(
+      actual.ZMKAppContext,
+      ZMKCustomSubsystem,
+    ),
+  };
+});
 
 function createWrapper(zmkAppValue: {
   state: { connection: unknown; customSubsystems: unknown[] };

--- a/src/hooks/__tests__/usePmw3610.test.tsx
+++ b/src/hooks/__tests__/usePmw3610.test.tsx
@@ -15,12 +15,24 @@ import {
 
 const mockCallRPC = jest.fn();
 
-jest.mock("@cormoran/zmk-studio-react-hook", () => ({
-  ...jest.requireActual("@cormoran/zmk-studio-react-hook"),
-  ZMKCustomSubsystem: jest.fn().mockImplementation(() => ({
+jest.mock("@cormoran/zmk-studio-react-hook", () => {
+  const actual = jest.requireActual("@cormoran/zmk-studio-react-hook");
+  const {
+    createUseCustomSubsystemMock,
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+  } = require("../testUtils/mockUseCustomSubsystem");
+  const ZMKCustomSubsystem = jest.fn().mockImplementation(() => ({
     callRPC: mockCallRPC,
-  })),
-}));
+  }));
+  return {
+    ...actual,
+    ZMKCustomSubsystem,
+    useCustomSubsystem: createUseCustomSubsystemMock(
+      actual.ZMKAppContext,
+      ZMKCustomSubsystem,
+    ),
+  };
+});
 
 type NotificationCallback = (n: CustomNotification) => void;
 

--- a/src/hooks/__tests__/useRuntimeCombo.test.tsx
+++ b/src/hooks/__tests__/useRuntimeCombo.test.tsx
@@ -9,12 +9,24 @@ import {
 
 const mockCallRPC = jest.fn();
 
-jest.mock("@cormoran/zmk-studio-react-hook", () => ({
-  ...jest.requireActual("@cormoran/zmk-studio-react-hook"),
-  ZMKCustomSubsystem: jest.fn().mockImplementation(() => ({
+jest.mock("@cormoran/zmk-studio-react-hook", () => {
+  const actual = jest.requireActual("@cormoran/zmk-studio-react-hook");
+  const {
+    createUseCustomSubsystemMock,
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+  } = require("../testUtils/mockUseCustomSubsystem");
+  const ZMKCustomSubsystem = jest.fn().mockImplementation(() => ({
     callRPC: mockCallRPC,
-  })),
-}));
+  }));
+  return {
+    ...actual,
+    ZMKCustomSubsystem,
+    useCustomSubsystem: createUseCustomSubsystemMock(
+      actual.ZMKAppContext,
+      ZMKCustomSubsystem,
+    ),
+  };
+});
 
 function createWrapper(zmkAppValue: {
   state: {

--- a/src/hooks/__tests__/useRuntimeInputProcessor.test.tsx
+++ b/src/hooks/__tests__/useRuntimeInputProcessor.test.tsx
@@ -17,12 +17,24 @@ import {
 const mockCallRPC = jest.fn();
 const mockOnNotification = jest.fn();
 
-jest.mock("@cormoran/zmk-studio-react-hook", () => ({
-  ...jest.requireActual("@cormoran/zmk-studio-react-hook"),
-  ZMKCustomSubsystem: jest.fn().mockImplementation(() => ({
+jest.mock("@cormoran/zmk-studio-react-hook", () => {
+  const actual = jest.requireActual("@cormoran/zmk-studio-react-hook");
+  const {
+    createUseCustomSubsystemMock,
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+  } = require("../testUtils/mockUseCustomSubsystem");
+  const ZMKCustomSubsystem = jest.fn().mockImplementation(() => ({
     callRPC: mockCallRPC,
-  })),
-}));
+  }));
+  return {
+    ...actual,
+    ZMKCustomSubsystem,
+    useCustomSubsystem: createUseCustomSubsystemMock(
+      actual.ZMKAppContext,
+      ZMKCustomSubsystem,
+    ),
+  };
+});
 
 // Create a wrapper with ZMKAppContext
 function createWrapper(zmkAppValue: {

--- a/src/hooks/testUtils/mockUseCustomSubsystem.ts
+++ b/src/hooks/testUtils/mockUseCustomSubsystem.ts
@@ -1,0 +1,93 @@
+/**
+ * Test-only polyfill for `useCustomSubsystem` from
+ * `@cormoran/zmk-studio-react-hook`.
+ *
+ * Several hook tests mock the package's `ZMKCustomSubsystem` class directly
+ * (via `jest.mock("@cormoran/zmk-studio-react-hook", ...)`) so they can
+ * assert on `service.callRPC` calls. That worked when our hooks constructed
+ * `ZMKCustomSubsystem` themselves. Now that the hooks use the library's
+ * `useCustomSubsystem`, the constructor call happens inside the library,
+ * which imports `ZMKCustomSubsystem` from a private relative path rather
+ * than the package's public entry point — so mocking the public
+ * `ZMKCustomSubsystem` export alone no longer reaches the RPC call made by
+ * `useCustomSubsystem`.
+ *
+ * This polyfill mirrors the library's real `useCustomSubsystem`
+ * implementation (context -> findSubsystem -> `new ZMKCustomSubsystem(...)`)
+ * but against an injected (mocked) constructor, so existing `mockCallRPC`
+ * assertions keep working unchanged.
+ */
+import { useCallback, useContext, useMemo, type Context } from "react";
+import type { UseZMKAppReturn } from "@cormoran/zmk-studio-react-hook";
+
+interface SubsystemServiceLike {
+  callRPC: (
+    payload: Uint8Array,
+    options?: { timeout?: number },
+  ) => Promise<Uint8Array | null>;
+}
+
+interface Codec<TReq, TRes> {
+  encode: (request: TReq) => Uint8Array;
+  decode: (payload: Uint8Array) => TRes;
+}
+
+export function createUseCustomSubsystemMock(
+  zmkAppContext: Context<UseZMKAppReturn | null>,
+  ZMKCustomSubsystemCtor: new (
+    connection: unknown,
+    subsystemIndex: number,
+  ) => SubsystemServiceLike,
+) {
+  return function useCustomSubsystemMock<TReq, TRes>(
+    identifier: string,
+    codec?: Codec<TReq, TRes>,
+  ) {
+    const zmkApp = useContext(zmkAppContext);
+    const connection = zmkApp?.state.connection ?? null;
+    const subsystem = zmkApp?.findSubsystem(identifier) ?? null;
+    const subsystemIndex = subsystem?.index ?? null;
+
+    const service = useMemo(
+      () =>
+        connection !== null && subsystemIndex !== null
+          ? new ZMKCustomSubsystemCtor(connection, subsystemIndex)
+          : null,
+      [connection, subsystemIndex],
+    );
+    const ready = service !== null;
+
+    const callRPC = useCallback(
+      async (payload: Uint8Array, options?: { timeout?: number }) => {
+        if (!service) {
+          throw new Error(
+            `Custom subsystem "${identifier}" is not ready: ` +
+              (connection === null
+                ? "no active ZMK connection (is this rendered inside a ZMKAppContext provider with a connected device?)"
+                : "subsystem not found on the connected device"),
+          );
+        }
+        return service.callRPC(payload, options);
+      },
+      [service, identifier, connection],
+    );
+
+    const call = useCallback(
+      async (request: TReq, options?: { timeout?: number }) => {
+        if (!codec) {
+          throw new Error(
+            `useCustomSubsystem("${identifier}"): call() requires a codec; use callRPC() for raw payloads`,
+          );
+        }
+        const payload = await callRPC(codec.encode(request), options);
+        return payload === null ? null : codec.decode(payload);
+      },
+      [callRPC, identifier, codec],
+    );
+
+    if (codec) {
+      return { subsystem, ready, callRPC, call };
+    }
+    return { subsystem, ready, callRPC };
+  };
+}

--- a/src/hooks/useBLEProfiles.ts
+++ b/src/hooks/useBLEProfiles.ts
@@ -1,8 +1,5 @@
-import { useState, useEffect, useCallback, useContext, useMemo } from "react";
-import {
-  ZMKCustomSubsystem,
-  ZMKAppContext,
-} from "@cormoran/zmk-studio-react-hook";
+import { useState, useEffect, useCallback } from "react";
+import { useCustomSubsystem } from "@cormoran/zmk-studio-react-hook";
 import {
   Request,
   Response,
@@ -12,6 +9,11 @@ import {
 // Subsystem identifier for ZMK BLE management custom protocol
 // This matches the identifier registered in the ZMK firmware module
 const SUBSYSTEM_IDENTIFIER = "cormoran_ble";
+
+const CODEC = {
+  encode: (request: Request) => Request.encode(request).finish(),
+  decode: (payload: Uint8Array) => Response.decode(payload),
+};
 
 export interface BLEProfile {
   index: number;
@@ -38,7 +40,10 @@ export interface UseBLEProfilesReturn {
 }
 
 export function useBLEProfiles(): UseBLEProfilesReturn {
-  const zmkApp = useContext(ZMKAppContext);
+  const { subsystem, ready, call } = useCustomSubsystem(
+    SUBSYSTEM_IDENTIFIER,
+    CODEC,
+  );
   const [profiles, setProfiles] = useState<BLEProfile[]>([]);
   const [maxProfiles, setMaxProfiles] = useState<number>(0);
   const [isLoading, setIsLoading] = useState(false);
@@ -46,18 +51,8 @@ export function useBLEProfiles(): UseBLEProfilesReturn {
   const [outputPriority, setOutputPriorityState] =
     useState<OutputPriority | null>(null);
 
-  // Memoize subsystem to avoid unnecessary re-renders
-  const subsystem = useMemo(
-    () => zmkApp?.findSubsystem(SUBSYSTEM_IDENTIFIER),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [zmkApp?.state.customSubsystems],
-  );
-
-  // Extract subsystem index as a stable primitive value for dependencies
-  const subsystemIndex = subsystem?.index;
-
   const loadProfiles = useCallback(async () => {
-    if (!zmkApp?.state.connection || subsystemIndex === undefined) {
+    if (!ready) {
       setError("Not connected to device or subsystem not found");
       return;
     }
@@ -66,20 +61,9 @@ export function useBLEProfiles(): UseBLEProfilesReturn {
     setError(null);
 
     try {
-      const service = new ZMKCustomSubsystem(
-        zmkApp.state.connection,
-        subsystemIndex,
-      );
+      const resp = await call(Request.create({ getProfiles: {} }));
 
-      const request = Request.create({
-        getProfiles: {},
-      });
-
-      const payload = Request.encode(request).finish();
-      const responsePayload = await service.callRPC(payload);
-
-      if (responsePayload) {
-        const resp = Response.decode(responsePayload);
+      if (resp) {
         if (resp.getProfiles) {
           // The protobuf-generated ProfileInfo matches our BLEProfile interface
           const profiles = resp.getProfiles.profiles.map((p) => ({
@@ -104,30 +88,19 @@ export function useBLEProfiles(): UseBLEProfilesReturn {
     } finally {
       setIsLoading(false);
     }
-  }, [zmkApp?.state.connection, subsystemIndex]);
+  }, [ready, call]);
 
   const switchProfile = useCallback(
     async (index: number) => {
-      if (!zmkApp?.state.connection || subsystemIndex === undefined) return;
+      if (!ready) return;
 
       setIsLoading(true);
       setError(null);
 
       try {
-        const service = new ZMKCustomSubsystem(
-          zmkApp.state.connection,
-          subsystemIndex,
-        );
+        const resp = await call(Request.create({ switchProfile: { index } }));
 
-        const request = Request.create({
-          switchProfile: { index },
-        });
-
-        const payload = Request.encode(request).finish();
-        const responsePayload = await service.callRPC(payload);
-
-        if (responsePayload) {
-          const resp = Response.decode(responsePayload);
+        if (resp) {
           if (resp.switchProfile?.success) {
             await loadProfiles();
           } else if (resp.error) {
@@ -145,31 +118,20 @@ export function useBLEProfiles(): UseBLEProfilesReturn {
         setIsLoading(false);
       }
     },
-    [zmkApp?.state.connection, subsystemIndex, loadProfiles],
+    [ready, call, loadProfiles],
   );
 
   const unpairProfile = useCallback(
     async (index: number) => {
-      if (!zmkApp?.state.connection || subsystemIndex === undefined) return;
+      if (!ready) return;
 
       setIsLoading(true);
       setError(null);
 
       try {
-        const service = new ZMKCustomSubsystem(
-          zmkApp.state.connection,
-          subsystemIndex,
-        );
+        const resp = await call(Request.create({ unpairProfile: { index } }));
 
-        const request = Request.create({
-          unpairProfile: { index },
-        });
-
-        const payload = Request.encode(request).finish();
-        const responsePayload = await service.callRPC(payload);
-
-        if (responsePayload) {
-          const resp = Response.decode(responsePayload);
+        if (resp) {
           if (resp.unpairProfile?.success) {
             await loadProfiles();
           } else if (resp.error) {
@@ -187,31 +149,22 @@ export function useBLEProfiles(): UseBLEProfilesReturn {
         setIsLoading(false);
       }
     },
-    [zmkApp?.state.connection, subsystemIndex, loadProfiles],
+    [ready, call, loadProfiles],
   );
 
   const setProfileName = useCallback(
     async (index: number, name: string) => {
-      if (!zmkApp?.state.connection || subsystemIndex === undefined) return;
+      if (!ready) return;
 
       setIsLoading(true);
       setError(null);
 
       try {
-        const service = new ZMKCustomSubsystem(
-          zmkApp.state.connection,
-          subsystemIndex,
+        const resp = await call(
+          Request.create({ setProfileName: { index, name } }),
         );
 
-        const request = Request.create({
-          setProfileName: { index, name },
-        });
-
-        const payload = Request.encode(request).finish();
-        const responsePayload = await service.callRPC(payload);
-
-        if (responsePayload) {
-          const resp = Response.decode(responsePayload);
+        if (resp) {
           if (resp.setProfileName?.success) {
             await loadProfiles();
           } else if (resp.error) {
@@ -229,11 +182,11 @@ export function useBLEProfiles(): UseBLEProfilesReturn {
         setIsLoading(false);
       }
     },
-    [zmkApp?.state.connection, subsystemIndex, loadProfiles],
+    [ready, call, loadProfiles],
   );
 
   const getOutputPriority = useCallback(async () => {
-    if (!zmkApp?.state.connection || subsystemIndex === undefined) {
+    if (!ready) {
       setError("Not connected to device or subsystem not found");
       return;
     }
@@ -242,20 +195,9 @@ export function useBLEProfiles(): UseBLEProfilesReturn {
     setError(null);
 
     try {
-      const service = new ZMKCustomSubsystem(
-        zmkApp.state.connection,
-        subsystemIndex,
-      );
+      const resp = await call(Request.create({ getOutputPriority: {} }));
 
-      const request = Request.create({
-        getOutputPriority: {},
-      });
-
-      const payload = Request.encode(request).finish();
-      const responsePayload = await service.callRPC(payload);
-
-      if (responsePayload) {
-        const resp = Response.decode(responsePayload);
+      if (resp) {
         if (resp.getOutputPriority) {
           setOutputPriorityState(resp.getOutputPriority.priority);
         } else if (resp.error) {
@@ -270,30 +212,21 @@ export function useBLEProfiles(): UseBLEProfilesReturn {
     } finally {
       setIsLoading(false);
     }
-  }, [zmkApp?.state.connection, subsystemIndex]);
+  }, [ready, call]);
 
   const setOutputPriority = useCallback(
     async (priority: OutputPriority) => {
-      if (!zmkApp?.state.connection || subsystemIndex === undefined) return;
+      if (!ready) return;
 
       setIsLoading(true);
       setError(null);
 
       try {
-        const service = new ZMKCustomSubsystem(
-          zmkApp.state.connection,
-          subsystemIndex,
+        const resp = await call(
+          Request.create({ setOutputPriority: { priority } }),
         );
 
-        const request = Request.create({
-          setOutputPriority: { priority },
-        });
-
-        const payload = Request.encode(request).finish();
-        const responsePayload = await service.callRPC(payload);
-
-        if (responsePayload) {
-          const resp = Response.decode(responsePayload);
+        if (resp) {
           if (resp.setOutputPriority?.success) {
             await getOutputPriority();
           } else if (resp.error) {
@@ -311,20 +244,20 @@ export function useBLEProfiles(): UseBLEProfilesReturn {
         setIsLoading(false);
       }
     },
-    [zmkApp?.state.connection, subsystemIndex, getOutputPriority],
+    [ready, call, getOutputPriority],
   );
 
   // Load profiles and output priority when connection or subsystem changes
   useEffect(() => {
-    if (subsystemIndex !== undefined && zmkApp?.state.connection) {
+    if (ready) {
       loadProfiles();
       getOutputPriority();
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [subsystemIndex, zmkApp?.state.connection]);
+  }, [ready]);
 
   return {
-    isAvailable: subsystemIndex !== undefined,
+    isAvailable: subsystem !== null,
     profiles,
     maxProfiles,
     isLoading,

--- a/src/hooks/useCustomSettings.ts
+++ b/src/hooks/useCustomSettings.ts
@@ -1,7 +1,7 @@
 import { useCallback, useContext, useEffect, useMemo, useState } from "react";
 import {
   ZMKAppContext,
-  ZMKCustomSubsystem,
+  useCustomSubsystem,
 } from "@cormoran/zmk-studio-react-hook";
 import {
   Notification,
@@ -16,6 +16,11 @@ import {
 import { useLanguage } from "./useLanguage";
 
 export const CUSTOM_SETTINGS_IDENTIFIER = "cormoran_custom_settings";
+
+const CODEC = {
+  encode: (request: Request) => Request.encode(request).finish(),
+  decode: (payload: Uint8Array) => Response.decode(payload),
+};
 export const CUSTOM_SETTINGS_SOURCE_ALL = 0xffffffff;
 
 const LIST_NOTIFICATION_TIMEOUT_MS = 750;
@@ -111,15 +116,14 @@ async function withTimeout<T>(
 export function useCustomSettings(): UseCustomSettingsReturn {
   const { t } = useLanguage();
   const zmkApp = useContext(ZMKAppContext);
+  const { subsystem, ready, call } = useCustomSubsystem(
+    CUSTOM_SETTINGS_IDENTIFIER,
+    CODEC,
+  );
   const [settings, setSettings] = useState<Setting[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const subsystem = useMemo(
-    () => zmkApp?.findSubsystem(CUSTOM_SETTINGS_IDENTIFIER),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [zmkApp?.state.customSubsystems],
-  );
   const subsystemIndex = subsystem?.index;
 
   const subsystemIdentifierForIndex = useCallback(
@@ -131,32 +135,25 @@ export function useCustomSettings(): UseCustomSettingsReturn {
 
   const callCustomRequest = useCallback(
     async (request: Request): Promise<Response> => {
-      if (!zmkApp?.state.connection || subsystemIndex === undefined) {
+      if (!ready) {
         throw new Error(t("Custom settings subsystem is not available"));
       }
 
-      const service = new ZMKCustomSubsystem(
-        zmkApp.state.connection,
-        subsystemIndex,
-      );
-      const responsePayload = await service.callRPC(
-        Request.encode(request).finish(),
-      );
-      if (!responsePayload) {
+      const response = await call(request);
+      if (!response) {
         throw new Error(t("Empty custom settings response"));
       }
 
-      const response = Response.decode(responsePayload);
       if (response.error) {
         throw new Error(response.error.message || t("Custom settings failed"));
       }
       return response;
     },
-    [t, zmkApp?.state.connection, subsystemIndex],
+    [t, ready, call],
   );
 
   const collectListSettings = useCallback(async (): Promise<Setting[]> => {
-    if (!zmkApp || subsystemIndex === undefined) {
+    if (!ready || !zmkApp || subsystemIndex === undefined) {
       return [];
     }
 
@@ -235,10 +232,10 @@ export function useCustomSettings(): UseCustomSettingsReturn {
         clearTimeout(quietTimeout);
       }
     }
-  }, [callCustomRequest, subsystemIndex, t, zmkApp]);
+  }, [callCustomRequest, ready, subsystemIndex, t, zmkApp]);
 
   const loadSettings = useCallback(async () => {
-    if (subsystemIndex === undefined || !zmkApp?.state.connection) {
+    if (!ready) {
       setSettings([]);
       return;
     }
@@ -271,7 +268,7 @@ export function useCustomSettings(): UseCustomSettingsReturn {
     } finally {
       setIsLoading(false);
     }
-  }, [collectListSettings, subsystemIndex, t, zmkApp?.state.connection]);
+  }, [collectListSettings, ready, t]);
 
   const writeSettingToMemory = useCallback(
     async (setting: Setting, value: SettingValue) => {
@@ -371,7 +368,7 @@ export function useCustomSettings(): UseCustomSettingsReturn {
   }, [loadSettings]);
 
   return {
-    isAvailable: subsystemIndex !== undefined,
+    isAvailable: subsystem !== null,
     sections,
     isLoading,
     error,

--- a/src/hooks/useDefaultLayer.ts
+++ b/src/hooks/useDefaultLayer.ts
@@ -1,8 +1,5 @@
-import { useState, useEffect, useCallback, useContext, useMemo } from "react";
-import {
-  ZMKCustomSubsystem,
-  ZMKAppContext,
-} from "@cormoran/zmk-studio-react-hook";
+import { useState, useEffect, useCallback } from "react";
+import { useCustomSubsystem } from "@cormoran/zmk-studio-react-hook";
 import {
   Request,
   Response,
@@ -12,6 +9,11 @@ import {
 // Subsystem identifier for the ZMK default-layer custom protocol.
 // This matches the identifier registered in the zmk-feature-default-layer module.
 const SUBSYSTEM_IDENTIFIER = "cormoran__default_layer";
+
+const CODEC = {
+  encode: (request: Request) => Request.encode(request).finish(),
+  decode: (payload: Uint8Array) => Response.decode(payload),
+};
 
 export interface UseDefaultLayerReturn {
   isAvailable: boolean;
@@ -24,22 +26,16 @@ export interface UseDefaultLayerReturn {
 }
 
 export function useDefaultLayer(): UseDefaultLayerReturn {
-  const zmkApp = useContext(ZMKAppContext);
+  const { subsystem, ready, call } = useCustomSubsystem(
+    SUBSYSTEM_IDENTIFIER,
+    CODEC,
+  );
   const [state, setState] = useState<StateResponse | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const subsystem = useMemo(
-    () => zmkApp?.findSubsystem(SUBSYSTEM_IDENTIFIER),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [zmkApp?.state.customSubsystems],
-  );
-
-  const subsystemIndex = subsystem?.index;
-  const connection = zmkApp?.state.connection;
-
   const load = useCallback(async () => {
-    if (!connection || subsystemIndex === undefined) {
+    if (!ready) {
       return;
     }
 
@@ -47,13 +43,9 @@ export function useDefaultLayer(): UseDefaultLayerReturn {
     setError(null);
 
     try {
-      const service = new ZMKCustomSubsystem(connection, subsystemIndex);
-      const request = Request.create({ getState: {} });
-      const payload = Request.encode(request).finish();
-      const responsePayload = await service.callRPC(payload);
+      const resp = await call(Request.create({ getState: {} }));
 
-      if (responsePayload) {
-        const resp = Response.decode(responsePayload);
+      if (resp) {
         if (resp.state) {
           setState(resp.state);
         } else if (resp.error) {
@@ -68,25 +60,21 @@ export function useDefaultLayer(): UseDefaultLayerReturn {
     } finally {
       setIsLoading(false);
     }
-  }, [connection, subsystemIndex]);
+  }, [ready, call]);
 
   const setEndpointLayer = useCallback(
     async (endpointIndex: number, value: number) => {
-      if (!connection || subsystemIndex === undefined) return;
+      if (!ready) return;
 
       setIsLoading(true);
       setError(null);
 
       try {
-        const service = new ZMKCustomSubsystem(connection, subsystemIndex);
-        const request = Request.create({
-          setEndpointLayer: { endpointIndex, value },
-        });
-        const payload = Request.encode(request).finish();
-        const responsePayload = await service.callRPC(payload);
+        const resp = await call(
+          Request.create({ setEndpointLayer: { endpointIndex, value } }),
+        );
 
-        if (responsePayload) {
-          const resp = Response.decode(responsePayload);
+        if (resp) {
           if (resp.state) {
             // Response contains the full refreshed state - use it directly.
             setState(resp.state);
@@ -103,24 +91,20 @@ export function useDefaultLayer(): UseDefaultLayerReturn {
         setIsLoading(false);
       }
     },
-    [connection, subsystemIndex],
+    [ready, call],
   );
 
   const setOsLayer = useCallback(
     async (os: number, value: number) => {
-      if (!connection || subsystemIndex === undefined) return;
+      if (!ready) return;
 
       setIsLoading(true);
       setError(null);
 
       try {
-        const service = new ZMKCustomSubsystem(connection, subsystemIndex);
-        const request = Request.create({ setOsLayer: { os, value } });
-        const payload = Request.encode(request).finish();
-        const responsePayload = await service.callRPC(payload);
+        const resp = await call(Request.create({ setOsLayer: { os, value } }));
 
-        if (responsePayload) {
-          const resp = Response.decode(responsePayload);
+        if (resp) {
           if (resp.state) {
             // Response contains the full refreshed state - use it directly.
             setState(resp.state);
@@ -137,19 +121,19 @@ export function useDefaultLayer(): UseDefaultLayerReturn {
         setIsLoading(false);
       }
     },
-    [connection, subsystemIndex],
+    [ready, call],
   );
 
   // Load state when connection or subsystem changes.
   useEffect(() => {
-    if (subsystemIndex !== undefined && connection) {
+    if (ready) {
       load();
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [subsystemIndex, connection]);
+  }, [ready]);
 
   return {
-    isAvailable: subsystemIndex !== undefined,
+    isAvailable: subsystem !== null,
     state,
     isLoading,
     error,

--- a/src/hooks/useDeviceInfo.ts
+++ b/src/hooks/useDeviceInfo.ts
@@ -1,8 +1,5 @@
-import { useCallback, useContext, useEffect, useMemo, useState } from "react";
-import {
-  ZMKCustomSubsystem,
-  ZMKAppContext,
-} from "@cormoran/zmk-studio-react-hook";
+import { useCallback, useEffect, useState } from "react";
+import { useCustomSubsystem } from "@cormoran/zmk-studio-react-hook";
 import {
   Request,
   Response,
@@ -10,6 +7,11 @@ import {
 } from "../proto/zmk/device_info/device_info";
 
 export const DEVICE_INFO_SUBSYSTEM_IDENTIFIER = "zmk__device_info";
+
+const CODEC = {
+  encode: (request: Request) => Request.encode(request).finish(),
+  decode: (payload: Uint8Array) => Response.decode(payload),
+};
 
 export interface UseDeviceInfoReturn {
   isAvailable: boolean;
@@ -20,36 +22,26 @@ export interface UseDeviceInfoReturn {
 }
 
 export function useDeviceInfo(): UseDeviceInfoReturn {
-  const zmkApp = useContext(ZMKAppContext);
+  const { subsystem, ready, call } = useCustomSubsystem(
+    DEVICE_INFO_SUBSYSTEM_IDENTIFIER,
+    CODEC,
+  );
   const [info, setInfo] = useState<DeviceInfoResponse | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const subsystem = useMemo(
-    () => zmkApp?.findSubsystem(DEVICE_INFO_SUBSYSTEM_IDENTIFIER),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [zmkApp?.state.customSubsystems],
-  );
-  const subsystemIndex = subsystem?.index;
-  const connection = zmkApp?.state.connection;
-
   const refresh = useCallback(async () => {
-    if (!connection || subsystemIndex === undefined) {
+    if (!ready) {
       setError("Not connected to device or subsystem not found");
       return;
     }
     setIsLoading(true);
     setError(null);
     try {
-      const service = new ZMKCustomSubsystem(connection, subsystemIndex);
-      const payload = Request.encode(
-        Request.create({ getDeviceInfo: {} }),
-      ).finish();
-      const responsePayload = await service.callRPC(payload);
-      if (!responsePayload) {
+      const resp = await call(Request.create({ getDeviceInfo: {} }));
+      if (!resp) {
         throw new Error("No response from device");
       }
-      const resp = Response.decode(responsePayload);
       if (resp.error) {
         throw new Error(resp.error.message);
       }
@@ -59,17 +51,17 @@ export function useDeviceInfo(): UseDeviceInfoReturn {
     } finally {
       setIsLoading(false);
     }
-  }, [connection, subsystemIndex]);
+  }, [ready, call]);
 
   // Auto-fetch when the subsystem becomes available.
   useEffect(() => {
-    if (connection && subsystemIndex !== undefined) {
+    if (ready) {
       void refresh();
     }
-  }, [connection, subsystemIndex, refresh]);
+  }, [ready, refresh]);
 
   return {
-    isAvailable: subsystemIndex !== undefined,
+    isAvailable: subsystem !== null,
     info,
     isLoading,
     error,

--- a/src/hooks/useInputStream.ts
+++ b/src/hooks/useInputStream.ts
@@ -1,14 +1,7 @@
-import {
-  useCallback,
-  useContext,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from "react";
+import { useCallback, useContext, useEffect, useRef, useState } from "react";
 import {
   ZMKAppContext,
-  ZMKCustomSubsystem,
+  useCustomSubsystem,
 } from "@cormoran/zmk-studio-react-hook";
 import type { CustomNotification } from "@zmkfirmware/zmk-studio-ts-client/custom";
 import {
@@ -18,6 +11,11 @@ import {
 } from "../proto/zmk/input_stream/input_stream";
 
 export const INPUT_STREAM_IDENTIFIER = "zmk__input_stream";
+
+const CODEC = {
+  encode: (request: Request) => Request.encode(request).finish(),
+  decode: (payload: Uint8Array) => Response.decode(payload),
+};
 
 const BEEP_DURATION_SECONDS = 0.08;
 const BEEP_START_GAIN = 0.2;
@@ -87,6 +85,10 @@ function errorMessage(err: unknown): string {
 
 export function useInputStream(): UseInputStreamReturn {
   const zmkApp = useContext(ZMKAppContext);
+  const { subsystem, ready, call } = useCustomSubsystem(
+    INPUT_STREAM_IDENTIFIER,
+    CODEC,
+  );
   const [isEnabled, setIsEnabled] = useState(false);
   const [isToggling, setIsToggling] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -96,52 +98,39 @@ export function useInputStream(): UseInputStreamReturn {
   const [activeLayerIndex, setActiveLayerIndex] = useState<number | null>(null);
 
   const isEnabledRef = useRef(false);
-  const connectionRef = useRef(zmkApp?.state.connection);
-  const subsystemIndexRef = useRef<number | undefined>(undefined);
+  const readyRef = useRef(ready);
+  const callRef = useRef(call);
 
-  const subsystem = useMemo(
-    () => zmkApp?.findSubsystem(INPUT_STREAM_IDENTIFIER) ?? undefined,
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [zmkApp?.state.customSubsystems],
-  );
   const subsystemIndex = subsystem?.index;
-  const connection = zmkApp?.state.connection;
 
   useEffect(() => {
     isEnabledRef.current = isEnabled;
   }, [isEnabled]);
 
   useEffect(() => {
-    connectionRef.current = connection;
-  }, [connection]);
+    readyRef.current = ready;
+  }, [ready]);
 
   useEffect(() => {
-    subsystemIndexRef.current = subsystemIndex;
-  }, [subsystemIndex]);
+    callRef.current = call;
+  }, [call]);
 
   const callStreamRpc = useCallback(
     async (enabled: boolean) => {
-      if (!connection || subsystemIndex === undefined) return false;
+      if (!ready) return false;
 
-      const service = new ZMKCustomSubsystem(connection, subsystemIndex);
-      const request = Request.create(
-        enabled ? { enableStream: {} } : { disableStream: {} },
-      );
-      const responsePayload = await service.callRPC(
-        Request.encode(request).finish(),
+      const response = await call(
+        Request.create(enabled ? { enableStream: {} } : { disableStream: {} }),
       );
 
-      if (responsePayload) {
-        const response = Response.decode(responsePayload);
-        if (response.error) {
-          setError(response.error.message);
-          return false;
-        }
+      if (response?.error) {
+        setError(response.error.message);
+        return false;
       }
 
       return true;
     },
-    [connection, subsystemIndex],
+    [ready, call],
   );
 
   const setStreamEnabled = useCallback(
@@ -215,40 +204,27 @@ export function useInputStream(): UseInputStreamReturn {
   }, [zmkApp, subsystemIndex]);
 
   useEffect(() => {
-    if (connection && subsystemIndex !== undefined) return;
+    if (ready) return;
 
     setIsEnabled(false);
     setIsToggling(false);
     setError(null);
     setHighlightedKeys(new Set());
     setActiveLayerIndex(null);
-  }, [connection, subsystemIndex]);
+  }, [ready]);
 
   useEffect(() => {
     return () => {
-      const cleanupConnection = connectionRef.current;
-      const cleanupSubsystemIndex = subsystemIndexRef.current;
-      if (
-        !isEnabledRef.current ||
-        !cleanupConnection ||
-        cleanupSubsystemIndex === undefined
-      ) {
+      if (!isEnabledRef.current || !readyRef.current) {
         return;
       }
 
-      const service = new ZMKCustomSubsystem(
-        cleanupConnection,
-        cleanupSubsystemIndex,
-      );
-      const payload = Request.encode(
-        Request.create({ disableStream: {} }),
-      ).finish();
-      void service.callRPC(payload);
+      void callRef.current(Request.create({ disableStream: {} }));
     };
   }, []);
 
   return {
-    isAvailable: subsystemIndex !== undefined,
+    isAvailable: subsystem !== null,
     isEnabled,
     isToggling,
     error,

--- a/src/hooks/useKeymap.ts
+++ b/src/hooks/useKeymap.ts
@@ -12,8 +12,11 @@ import {
   useMemo,
   useRef,
 } from "react";
-import { ZMKAppContext } from "@cormoran/zmk-studio-react-hook";
-import { call_rpc, MetaError } from "@zmkfirmware/zmk-studio-ts-client";
+import {
+  ZMKAppContext,
+  isUnlockRequiredError,
+} from "@cormoran/zmk-studio-react-hook";
+import { call_rpc } from "@zmkfirmware/zmk-studio-ts-client";
 import type {
   Keymap,
   Layer,
@@ -237,14 +240,12 @@ export function useKeymap(): UseKeymapReturn {
         clearError();
         return result;
       } catch (err) {
-        if (err instanceof MetaError) {
-          if (err.condition === ErrorConditions.UNLOCK_REQUIRED) {
-            setUnlockRequired(true);
-            setError(
-              "Keyboard needs to be unlocked. Please unlock your keyboard.",
-            );
-            return null;
-          }
+        if (isUnlockRequiredError(err)) {
+          setUnlockRequired(true);
+          setError(
+            "Keyboard needs to be unlocked. Please unlock your keyboard.",
+          );
+          return null;
         }
         console.error("RPC call failed:", err);
         setErrorWithAutoClear(

--- a/src/hooks/useKscanDiagnostics.ts
+++ b/src/hooks/useKscanDiagnostics.ts
@@ -1,8 +1,6 @@
-import { useCallback, useContext, useEffect, useMemo, useState } from "react";
-import {
-  ZMKCustomSubsystem,
-  ZMKAppContext,
-} from "@cormoran/zmk-studio-react-hook";
+import { useCallback, useEffect, useState } from "react";
+import { useCustomSubsystem } from "@cormoran/zmk-studio-react-hook";
+import type { UseCustomSubsystemTypedReturn } from "@cormoran/zmk-studio-react-hook";
 import {
   GpioLineKind,
   Request,
@@ -16,6 +14,13 @@ import type { KscanDevice, KscanLayout, Topology } from "../lib/kscanTopology";
 
 export const KSCAN_DIAGNOSTICS_SUBSYSTEM_IDENTIFIER =
   "cormoran__kscan_diagnostics";
+
+const CODEC = {
+  encode: (request: Request) => Request.encode(request).finish(),
+  decode: (payload: Uint8Array) => Response.decode(payload),
+};
+
+type Caller = UseCustomSubsystemTypedReturn<Request, Response>["call"];
 
 // Safety valve against a misbehaving firmware paginating forever.
 const MAX_PAGES = 2000;
@@ -39,32 +44,22 @@ export interface UseKscanDiagnosticsReturn {
   loadTopology: () => Promise<void>;
 }
 
-async function callRpc(
-  service: ZMKCustomSubsystem,
-  request: Request,
-): Promise<Response> {
-  const payload = Request.encode(request).finish();
-  const responsePayload = await service.callRPC(payload);
-  if (!responsePayload) {
+async function callRpc(call: Caller, request: Request): Promise<Response> {
+  const resp = await call(request);
+  if (!resp) {
     throw new Error("No response from device");
   }
-  const resp = Response.decode(responsePayload);
   if (resp.error) {
     throw new Error(resp.error.message);
   }
   return resp;
 }
 
-async function fetchStats(
-  service: ZMKCustomSubsystem,
-): Promise<PositionStats[]> {
+async function fetchStats(call: Caller): Promise<PositionStats[]> {
   const entries: PositionStats[] = [];
   let offset = 0;
   for (let page = 0; page < MAX_PAGES; page++) {
-    const resp = await callRpc(
-      service,
-      Request.create({ getStats: { offset } }),
-    );
+    const resp = await callRpc(call, Request.create({ getStats: { offset } }));
     const chunk = resp.stats;
     if (!chunk) {
       throw new Error("Unexpected response to GetStats");
@@ -77,7 +72,7 @@ async function fetchStats(
 }
 
 async function fetchGpioPinsOfKind(
-  service: ZMKCustomSubsystem,
+  call: Caller,
   deviceIndex: number,
   kind: GpioLineKind,
 ): Promise<GpioPin[]> {
@@ -85,7 +80,7 @@ async function fetchGpioPinsOfKind(
   let offset = 0;
   for (let page = 0; page < MAX_PAGES; page++) {
     const resp = await callRpc(
-      service,
+      call,
       Request.create({ getGpioPins: { deviceIndex, kind, offset } }),
     );
     const chunk = resp.gpioPins;
@@ -107,7 +102,7 @@ async function fetchGpioPinsOfKind(
  * fetched per-kind.
  */
 async function fetchGpioLinesByKind(
-  service: ZMKCustomSubsystem,
+  call: Caller,
   deviceIndex: number,
 ): Promise<Record<GpioLineKind, GpioPin[]>> {
   const kinds: GpioLineKind[] = [
@@ -120,20 +115,20 @@ async function fetchGpioLinesByKind(
   const result = {} as Record<GpioLineKind, GpioPin[]>;
   result[GpioLineKind.KIND_UNKNOWN] = [];
   for (const kind of kinds) {
-    result[kind] = await fetchGpioPinsOfKind(service, deviceIndex, kind);
+    result[kind] = await fetchGpioPinsOfKind(call, deviceIndex, kind);
   }
   return result;
 }
 
 async function fetchPositionMap(
-  service: ZMKCustomSubsystem,
+  call: Caller,
   layoutIndex: number,
 ): Promise<(number | null)[]> {
   const cells: (number | null)[] = [];
   let offset = 0;
   for (let page = 0; page < MAX_PAGES; page++) {
     const resp = await callRpc(
-      service,
+      call,
       Request.create({ getPositionMap: { layoutIndex, offset } }),
     );
     const chunk = resp.positionMap;
@@ -151,18 +146,18 @@ async function fetchPositionMap(
 }
 
 async function fetchDevice(
-  service: ZMKCustomSubsystem,
+  call: Caller,
   deviceIndex: number,
 ): Promise<KscanDevice> {
   const resp = await callRpc(
-    service,
+    call,
     Request.create({ getDevice: { deviceIndex } }),
   );
   const d = resp.device;
   if (!d) {
     throw new Error("Unexpected response to GetDevice");
   }
-  const gpioLinesByKind = await fetchGpioLinesByKind(service, deviceIndex);
+  const gpioLinesByKind = await fetchGpioLinesByKind(call, deviceIndex);
   return {
     deviceIndex: d.deviceIndex,
     nodeName: d.nodeName,
@@ -181,18 +176,18 @@ async function fetchDevice(
 }
 
 async function fetchLayout(
-  service: ZMKCustomSubsystem,
+  call: Caller,
   layoutIndex: number,
 ): Promise<KscanLayout> {
   const resp = await callRpc(
-    service,
+    call,
     Request.create({ getLayout: { layoutIndex } }),
   );
   const l = resp.layout;
   if (!l) {
     throw new Error("Unexpected response to GetLayout");
   }
-  const positionMap = await fetchPositionMap(service, layoutIndex);
+  const positionMap = await fetchPositionMap(call, layoutIndex);
   return {
     layoutIndex: l.layoutIndex,
     displayName: l.displayName,
@@ -208,8 +203,8 @@ async function fetchLayout(
   };
 }
 
-async function fetchTopology(service: ZMKCustomSubsystem): Promise<Topology> {
-  const infoResp = await callRpc(service, Request.create({ getInfo: {} }));
+async function fetchTopology(call: Caller): Promise<Topology> {
+  const infoResp = await callRpc(call, Request.create({ getInfo: {} }));
   const info = infoResp.info;
   if (!info) {
     throw new Error("Unexpected response to GetInfo");
@@ -217,14 +212,14 @@ async function fetchTopology(service: ZMKCustomSubsystem): Promise<Topology> {
 
   const layouts: KscanLayout[] = [];
   for (let i = 0; i < info.layoutCount; i++) {
-    layouts.push(await fetchLayout(service, i));
+    layouts.push(await fetchLayout(call, i));
   }
 
   // Every device in device_count is fetched so the wiring overlay works even
   // for devices not attached to the active layout (multi-layout keyboards).
   const devices: KscanDevice[] = [];
   for (let i = 0; i < info.deviceCount; i++) {
-    devices.push(await fetchDevice(service, i));
+    devices.push(await fetchDevice(call, i));
   }
 
   return {
@@ -239,32 +234,22 @@ async function fetchTopology(service: ZMKCustomSubsystem): Promise<Topology> {
 }
 
 export function useKscanDiagnostics(): UseKscanDiagnosticsReturn {
-  const zmkApp = useContext(ZMKAppContext);
+  const { subsystem, ready, call } = useCustomSubsystem(
+    KSCAN_DIAGNOSTICS_SUBSYSTEM_IDENTIFIER,
+    CODEC,
+  );
   const [info, setInfo] = useState<Info | null>(null);
   const [devices, setDevices] = useState<Device[]>([]);
   const [stats, setStats] = useState<PositionStats[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const subsystem = useMemo(
-    () => zmkApp?.findSubsystem(KSCAN_DIAGNOSTICS_SUBSYSTEM_IDENTIFIER),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [zmkApp?.state.customSubsystems],
-  );
-  const subsystemIndex = subsystem?.index;
-  const connection = zmkApp?.state.connection;
-
-  const service = useMemo(() => {
-    if (!connection || subsystemIndex === undefined) return null;
-    return new ZMKCustomSubsystem(connection, subsystemIndex);
-  }, [connection, subsystemIndex]);
-
   const refresh = useCallback(async () => {
-    if (!service) return;
+    if (!ready) return;
     setIsLoading(true);
     setError(null);
     try {
-      const infoResp = await callRpc(service, Request.create({ getInfo: {} }));
+      const infoResp = await callRpc(call, Request.create({ getInfo: {} }));
       const nextInfo = infoResp.info;
       if (!nextInfo) {
         throw new Error("Unexpected response to GetInfo");
@@ -272,14 +257,14 @@ export function useKscanDiagnostics(): UseKscanDiagnosticsReturn {
       const nextDevices: Device[] = [];
       for (let i = 0; i < nextInfo.deviceCount; i++) {
         const resp = await callRpc(
-          service,
+          call,
           Request.create({ getDevice: { deviceIndex: i } }),
         );
         if (resp.device) {
           nextDevices.push(resp.device);
         }
       }
-      const nextStats = nextInfo.statsEnabled ? await fetchStats(service) : [];
+      const nextStats = nextInfo.statsEnabled ? await fetchStats(call) : [];
       setInfo(nextInfo);
       setDevices(nextDevices);
       setStats(nextStats);
@@ -288,49 +273,49 @@ export function useKscanDiagnostics(): UseKscanDiagnosticsReturn {
     } finally {
       setIsLoading(false);
     }
-  }, [service]);
+  }, [ready, call]);
 
   const resetStats = useCallback(async () => {
-    if (!service) return;
+    if (!ready) return;
     setIsLoading(true);
     setError(null);
     try {
-      await callRpc(service, Request.create({ resetStats: {} }));
-      setStats(await fetchStats(service));
+      await callRpc(call, Request.create({ resetStats: {} }));
+      setStats(await fetchStats(call));
     } catch (err) {
       setError(err instanceof Error ? err.message : "Unknown error");
     } finally {
       setIsLoading(false);
     }
-  }, [service]);
+  }, [ready, call]);
 
   // Auto-fetch when the subsystem becomes available.
   useEffect(() => {
-    if (service) {
+    if (ready) {
       void refresh();
     }
-  }, [service, refresh]);
+  }, [ready, refresh]);
 
   const [topology, setTopology] = useState<Topology | null>(null);
   const [isLoadingTopology, setIsLoadingTopology] = useState(false);
   const [topologyError, setTopologyError] = useState<string | null>(null);
 
   const loadTopology = useCallback(async () => {
-    if (!service) return;
+    if (!ready) return;
     setIsLoadingTopology(true);
     setTopologyError(null);
     try {
-      const t = await fetchTopology(service);
+      const t = await fetchTopology(call);
       setTopology(t);
     } catch (err) {
       setTopologyError(err instanceof Error ? err.message : "Unknown error");
     } finally {
       setIsLoadingTopology(false);
     }
-  }, [service]);
+  }, [ready, call]);
 
   return {
-    isAvailable: subsystemIndex !== undefined,
+    isAvailable: subsystem !== null,
     info,
     devices,
     stats,

--- a/src/hooks/useOfficialLayouts.ts
+++ b/src/hooks/useOfficialLayouts.ts
@@ -8,10 +8,12 @@
  * web/src/useOfficialKeymap.ts, trimmed to just physical layouts.
  */
 import { useCallback, useContext, useState } from "react";
-import { call_rpc, MetaError } from "@zmkfirmware/zmk-studio-ts-client";
-import { ErrorConditions } from "@zmkfirmware/zmk-studio-ts-client/meta";
+import { call_rpc } from "@zmkfirmware/zmk-studio-ts-client";
 import type { PhysicalLayouts } from "@zmkfirmware/zmk-studio-ts-client/keymap";
-import { ZMKAppContext } from "@cormoran/zmk-studio-react-hook";
+import {
+  ZMKAppContext,
+  isUnlockRequiredError,
+} from "@cormoran/zmk-studio-react-hook";
 
 export interface UseOfficialLayoutsReturn {
   physicalLayouts: PhysicalLayouts | null;
@@ -45,10 +47,7 @@ export function useOfficialLayouts(): UseOfficialLayoutsReturn {
         setPhysicalLayouts(resp.keymap.getPhysicalLayouts);
       }
     } catch (e) {
-      if (
-        e instanceof MetaError &&
-        e.condition === ErrorConditions.UNLOCK_REQUIRED
-      ) {
+      if (isUnlockRequiredError(e)) {
         setUnlockRequired(true);
       } else {
         setError(e instanceof Error ? e.message : "Unknown error");

--- a/src/hooks/useOsDetection.ts
+++ b/src/hooks/useOsDetection.ts
@@ -1,15 +1,5 @@
-import {
-  useState,
-  useEffect,
-  useCallback,
-  useContext,
-  useMemo,
-  useRef,
-} from "react";
-import {
-  ZMKCustomSubsystem,
-  ZMKAppContext,
-} from "@cormoran/zmk-studio-react-hook";
+import { useState, useEffect, useCallback, useRef } from "react";
+import { useCustomSubsystem } from "@cormoran/zmk-studio-react-hook";
 import {
   Request,
   Response,
@@ -20,6 +10,11 @@ import {
 // Subsystem identifier for the ZMK OS detection custom protocol.
 // This matches the identifier registered in the zmk-feature-os-detection module.
 const SUBSYSTEM_IDENTIFIER = "cormoran__os_detection";
+
+const CODEC = {
+  encode: (request: Request) => Request.encode(request).finish(),
+  decode: (payload: Uint8Array) => Response.decode(payload),
+};
 
 // Poll interval while connected: OS detection has no notifications, so we
 // have to poll to reflect state changes made on the device itself.
@@ -35,23 +30,17 @@ export interface UseOsDetectionReturn {
 }
 
 export function useOsDetection(): UseOsDetectionReturn {
-  const zmkApp = useContext(ZMKAppContext);
+  const { subsystem, ready, call } = useCustomSubsystem(
+    SUBSYSTEM_IDENTIFIER,
+    CODEC,
+  );
   const [state, setState] = useState<StateResponse | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const inFlightRef = useRef(false);
 
-  const subsystem = useMemo(
-    () => zmkApp?.findSubsystem(SUBSYSTEM_IDENTIFIER),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [zmkApp?.state.customSubsystems],
-  );
-
-  const subsystemIndex = subsystem?.index;
-  const connection = zmkApp?.state.connection;
-
   const load = useCallback(async () => {
-    if (!connection || subsystemIndex === undefined) {
+    if (!ready) {
       return;
     }
     if (inFlightRef.current) {
@@ -62,13 +51,9 @@ export function useOsDetection(): UseOsDetectionReturn {
     setError(null);
 
     try {
-      const service = new ZMKCustomSubsystem(connection, subsystemIndex);
-      const request = Request.create({ getState: {} });
-      const payload = Request.encode(request).finish();
-      const responsePayload = await service.callRPC(payload);
+      const resp = await call(Request.create({ getState: {} }));
 
-      if (responsePayload) {
-        const resp = Response.decode(responsePayload);
+      if (resp) {
         if (resp.state) {
           setState(resp.state);
         } else if (resp.error) {
@@ -84,25 +69,21 @@ export function useOsDetection(): UseOsDetectionReturn {
       inFlightRef.current = false;
       setIsLoading(false);
     }
-  }, [connection, subsystemIndex]);
+  }, [ready, call]);
 
   const setBleOverride = useCallback(
     async (profileIndex: number, os: Os) => {
-      if (!connection || subsystemIndex === undefined) return;
+      if (!ready) return;
 
       setIsLoading(true);
       setError(null);
 
       try {
-        const service = new ZMKCustomSubsystem(connection, subsystemIndex);
-        const request = Request.create({
-          setBleOverride: { profileIndex, os },
-        });
-        const payload = Request.encode(request).finish();
-        const responsePayload = await service.callRPC(payload);
+        const resp = await call(
+          Request.create({ setBleOverride: { profileIndex, os } }),
+        );
 
-        if (responsePayload) {
-          const resp = Response.decode(responsePayload);
+        if (resp) {
           if (resp.setBleOverride) {
             // Response only contains the single updated profile; refetch
             // the full state so the rest of the UI stays consistent.
@@ -120,30 +101,30 @@ export function useOsDetection(): UseOsDetectionReturn {
         setIsLoading(false);
       }
     },
-    [connection, subsystemIndex, load],
+    [ready, call, load],
   );
 
   // Auto-load on connect / subsystem discovery.
   useEffect(() => {
-    if (subsystemIndex !== undefined && connection) {
+    if (ready) {
       load();
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [subsystemIndex, connection]);
+  }, [ready]);
 
   // Poll while mounted and connected, since there are no notifications.
   useEffect(() => {
-    if (subsystemIndex === undefined || !connection) {
+    if (!ready) {
       return;
     }
     const interval = setInterval(() => {
       load();
     }, POLL_INTERVAL_MS);
     return () => clearInterval(interval);
-  }, [subsystemIndex, connection, load]);
+  }, [ready, load]);
 
   return {
-    isAvailable: subsystemIndex !== undefined,
+    isAvailable: subsystem !== null,
     state,
     isLoading,
     error,

--- a/src/hooks/usePmw3610.ts
+++ b/src/hooks/usePmw3610.ts
@@ -1,17 +1,9 @@
+import { useCallback, useContext, useEffect, useRef, useState } from "react";
 import {
-  useCallback,
-  useContext,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from "react";
-import {
-  ZMKCustomSubsystem,
   ZMKAppContext,
+  isUnlockRequiredError,
+  useCustomSubsystem,
 } from "@cormoran/zmk-studio-react-hook";
-import { MetaError } from "@zmkfirmware/zmk-studio-ts-client";
-import { ErrorConditions } from "@zmkfirmware/zmk-studio-ts-client/meta";
 import {
   Notification as Pmw3610Notification,
   PixelFormat,
@@ -29,6 +21,11 @@ import {
 } from "../lib/pmw3610Frame";
 
 export const PMW3610_SUBSYSTEM_IDENTIFIER = "cormoran__pmw3610";
+
+const CODEC = {
+  encode: (request: Request) => Request.encode(request).finish(),
+  decode: (payload: Uint8Array) => Response.decode(payload),
+};
 
 /** Result of a completed frame capture (one-shot or a completed streamed
  * frame), ready for the section to render to a canvas. */
@@ -72,6 +69,10 @@ export interface UsePmw3610Return {
 
 export function usePmw3610(): UsePmw3610Return {
   const zmkApp = useContext(ZMKAppContext);
+  const { subsystem, ready, call } = useCustomSubsystem(
+    PMW3610_SUBSYSTEM_IDENTIFIER,
+    CODEC,
+  );
   const [devices, setDevices] = useState<DeviceInfo[]>([]);
   const [diagnostics, setDiagnostics] =
     useState<ReadDiagnosticsResponse | null>(null);
@@ -79,42 +80,31 @@ export function usePmw3610(): UsePmw3610Return {
   const [error, setError] = useState<string | null>(null);
   const [unlockRequired, setUnlockRequired] = useState(false);
 
-  const subsystem = useMemo(
-    () => zmkApp?.findSubsystem(PMW3610_SUBSYSTEM_IDENTIFIER),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [zmkApp?.state.customSubsystems],
-  );
   const subsystemIndex = subsystem?.index;
-  const connection = zmkApp?.state.connection;
 
   const callRpc = useCallback(
     async (request: Request): Promise<Response | null> => {
-      if (!connection || subsystemIndex === undefined) return null;
-      const service = new ZMKCustomSubsystem(connection, subsystemIndex);
-      const payload = Request.encode(request).finish();
+      if (!ready) return null;
       try {
-        const responsePayload = await service.callRPC(payload);
-        if (!responsePayload) return null;
+        const resp = await call(request);
+        if (!resp) return null;
         setUnlockRequired(false);
-        return Response.decode(responsePayload);
+        return resp;
       } catch (err) {
         // The pmw3610 subsystem is SECURED: RPC fails with UNLOCK_REQUIRED
         // while ZMK Studio is locked.
-        if (
-          err instanceof MetaError &&
-          err.condition === ErrorConditions.UNLOCK_REQUIRED
-        ) {
+        if (isUnlockRequiredError(err)) {
           setUnlockRequired(true);
           return null;
         }
         throw err;
       }
     },
-    [connection, subsystemIndex],
+    [ready, call],
   );
 
   const refresh = useCallback(async () => {
-    if (!connection || subsystemIndex === undefined) return;
+    if (!ready) return;
     setIsLoading(true);
     setError(null);
     try {
@@ -129,7 +119,7 @@ export function usePmw3610(): UsePmw3610Return {
     } finally {
       setIsLoading(false);
     }
-  }, [connection, subsystemIndex, callRpc]);
+  }, [ready, callRpc]);
 
   const readDiagnostics = useCallback(
     async (deviceIndex: number) => {
@@ -152,10 +142,10 @@ export function usePmw3610(): UsePmw3610Return {
 
   // Auto-fetch sensor info when the subsystem becomes available.
   useEffect(() => {
-    if (connection && subsystemIndex !== undefined) {
+    if (ready) {
       void refresh();
     }
-  }, [connection, subsystemIndex, refresh]);
+  }, [ready, refresh]);
 
   // Retry automatically once the keyboard reports it was unlocked.
   useEffect(() => {
@@ -380,12 +370,12 @@ export function usePmw3610(): UsePmw3610Return {
     };
   }, []);
   useEffect(() => {
-    if (!connection && unsubscribeStreamRef.current) {
+    if (!zmkApp?.state.connection && unsubscribeStreamRef.current) {
       unsubscribeStreamRef.current();
       unsubscribeStreamRef.current = null;
       setIsStreaming(false);
     }
-  }, [connection]);
+  }, [zmkApp?.state.connection]);
 
   // Firmware silently stops the stream loop on lock (it does not, and
   // cannot, notify the client) — reset the UI's streaming state to match so
@@ -403,7 +393,7 @@ export function usePmw3610(): UsePmw3610Return {
   }, [unlockRequired]);
 
   return {
-    isAvailable: subsystemIndex !== undefined,
+    isAvailable: subsystem !== null,
     devices,
     diagnostics,
     isLoading,

--- a/src/hooks/useRuntimeCombo.ts
+++ b/src/hooks/useRuntimeCombo.ts
@@ -4,11 +4,8 @@
  * Provides access to cormoran/zmk-feature-runtime-combo through the custom ZMK
  * Studio RPC subsystem.
  */
-import { useCallback, useContext, useEffect, useMemo, useState } from "react";
-import {
-  ZMKAppContext,
-  ZMKCustomSubsystem,
-} from "@cormoran/zmk-studio-react-hook";
+import { useCallback, useEffect, useState } from "react";
+import { useCustomSubsystem } from "@cormoran/zmk-studio-react-hook";
 import {
   Request,
   Response,
@@ -21,6 +18,11 @@ import {
 export type { Combo, GlobalSettings, BehaviorBinding, StatusResponse };
 
 export const RUNTIME_COMBO_IDENTIFIER = "cormoran__runtime_combo";
+
+const CODEC = {
+  encode: (request: Request) => Request.encode(request).finish(),
+  decode: (payload: Uint8Array) => Response.decode(payload),
+};
 
 export interface ComboInput {
   index: number;
@@ -55,7 +57,10 @@ export interface UseRuntimeComboReturn {
 }
 
 export function useRuntimeCombo(): UseRuntimeComboReturn {
-  const zmkApp = useContext(ZMKAppContext);
+  const { subsystem, ready, call } = useCustomSubsystem(
+    RUNTIME_COMBO_IDENTIFIER,
+    CODEC,
+  );
   const [combos, setCombos] = useState<Combo[]>([]);
   const [globalSettings, setGlobalSettings] = useState<GlobalSettings | null>(
     null,
@@ -64,31 +69,18 @@ export function useRuntimeCombo(): UseRuntimeComboReturn {
   const [error, setError] = useState<string | null>(null);
   const [hasPendingChanges, setHasPendingChanges] = useState(false);
 
-  const subsystem = useMemo(
-    () => zmkApp?.findSubsystem(RUNTIME_COMBO_IDENTIFIER),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [zmkApp?.state.customSubsystems],
-  );
-  const subsystemIndex = subsystem?.index;
-
   const callRuntimeComboRPC = useCallback(
     async (request: Request): Promise<Response | null> => {
-      if (!zmkApp?.state.connection || subsystemIndex === undefined) {
+      if (!ready) {
         setError("Not connected to device or subsystem not found");
         return null;
       }
 
-      const service = new ZMKCustomSubsystem(
-        zmkApp.state.connection,
-        subsystemIndex,
-      );
-      const payload = Request.encode(request).finish();
-      const responsePayload = await service.callRPC(payload);
-      if (!responsePayload) {
+      const response = await call(request);
+      if (!response) {
         return null;
       }
 
-      const response = Response.decode(responsePayload);
       if (response.error) {
         setError(response.error.message);
         return response;
@@ -97,11 +89,11 @@ export function useRuntimeCombo(): UseRuntimeComboReturn {
       setError(null);
       return response;
     },
-    [zmkApp, subsystemIndex],
+    [ready, call],
   );
 
   const loadCombos = useCallback(async () => {
-    if (!zmkApp?.state.connection || subsystemIndex === undefined) {
+    if (!ready) {
       setCombos([]);
       return;
     }
@@ -127,10 +119,10 @@ export function useRuntimeCombo(): UseRuntimeComboReturn {
     } finally {
       setIsLoading(false);
     }
-  }, [callRuntimeComboRPC, subsystemIndex, zmkApp?.state.connection]);
+  }, [callRuntimeComboRPC, ready]);
 
   const loadGlobalSettings = useCallback(async () => {
-    if (!zmkApp?.state.connection || subsystemIndex === undefined) {
+    if (!ready) {
       setGlobalSettings(null);
       return;
     }
@@ -154,7 +146,7 @@ export function useRuntimeCombo(): UseRuntimeComboReturn {
     } finally {
       setIsLoading(false);
     }
-  }, [callRuntimeComboRPC, subsystemIndex, zmkApp?.state.connection]);
+  }, [callRuntimeComboRPC, ready]);
 
   const reload = useCallback(async () => {
     await Promise.all([loadCombos(), loadGlobalSettings()]);
@@ -414,7 +406,7 @@ export function useRuntimeCombo(): UseRuntimeComboReturn {
     }, [callRuntimeComboRPC, reload]);
 
   useEffect(() => {
-    if (subsystemIndex !== undefined && zmkApp?.state.connection) {
+    if (ready) {
       void reload();
     } else {
       setCombos([]);
@@ -422,10 +414,10 @@ export function useRuntimeCombo(): UseRuntimeComboReturn {
       setHasPendingChanges(false);
       setError(null);
     }
-  }, [reload, subsystemIndex, zmkApp?.state.connection]);
+  }, [reload, ready]);
 
   return {
-    isAvailable: subsystemIndex !== undefined,
+    isAvailable: subsystem !== null,
     combos,
     globalSettings,
     isLoading,

--- a/src/hooks/useRuntimeInputProcessor.ts
+++ b/src/hooks/useRuntimeInputProcessor.ts
@@ -1,7 +1,7 @@
-import { useState, useEffect, useCallback, useContext, useMemo } from "react";
+import { useState, useEffect, useCallback, useContext } from "react";
 import {
-  ZMKCustomSubsystem,
   ZMKAppContext,
+  useCustomSubsystem,
 } from "@cormoran/zmk-studio-react-hook";
 import {
   Request,
@@ -17,6 +17,11 @@ export { AxisSnapMode };
 // Subsystem identifier for ZMK runtime input processor custom protocol
 // This matches the identifier registered in the ZMK firmware module
 const SUBSYSTEM_IDENTIFIER = "cormoran_rip";
+
+const CODEC = {
+  encode: (request: Request) => Request.encode(request).finish(),
+  decode: (payload: Uint8Array) => Response.decode(payload),
+};
 
 // Time to wait for all notifications to arrive after requesting processors
 const NOTIFICATION_COLLECTION_TIMEOUT_MS = 500;
@@ -101,17 +106,14 @@ export interface UseRuntimeInputProcessorReturn {
 
 export function useRuntimeInputProcessor(): UseRuntimeInputProcessorReturn {
   const zmkApp = useContext(ZMKAppContext);
+  const { subsystem, ready, call } = useCustomSubsystem(
+    SUBSYSTEM_IDENTIFIER,
+    CODEC,
+  );
   const [processors, setProcessors] = useState<InputProcessor[]>([]);
   const [layers, setLayers] = useState<LayerInformation[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-
-  // Memoize subsystem to avoid unnecessary re-renders
-  const subsystem = useMemo(
-    () => zmkApp?.findSubsystem(SUBSYSTEM_IDENTIFIER),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [zmkApp?.state.customSubsystems],
-  );
 
   // Extract subsystem index as a stable primitive value for dependencies
   const subsystemIndex = subsystem?.index;
@@ -193,7 +195,7 @@ export function useRuntimeInputProcessor(): UseRuntimeInputProcessorReturn {
   );
 
   const loadProcessors = useCallback(async () => {
-    if (!zmkApp?.state.connection || subsystemIndex === undefined) {
+    if (!ready) {
       setError("Not connected to device or subsystem not found");
       return;
     }
@@ -202,22 +204,15 @@ export function useRuntimeInputProcessor(): UseRuntimeInputProcessorReturn {
     setError(null);
 
     try {
-      const service = new ZMKCustomSubsystem(
-        zmkApp.state.connection,
-        subsystemIndex,
-      );
-
       // Send request to list processors
       // The actual processor data will come via notifications handled by the useEffect above
       const request = Request.create({
         listProcessors: {},
       });
 
-      const payload = Request.encode(request).finish();
-      const responsePayload = await service.callRPC(payload);
+      const resp = await call(request);
 
-      if (responsePayload) {
-        const resp = Response.decode(responsePayload);
+      if (resp) {
         if (resp.error) {
           setError(resp.error.message);
         }
@@ -235,39 +230,29 @@ export function useRuntimeInputProcessor(): UseRuntimeInputProcessorReturn {
     } finally {
       setIsLoading(false);
     }
-  }, [zmkApp, subsystemIndex]);
+  }, [ready, call]);
 
   const setScaling = useCallback(
     async (id: number, multiplier: number, divisor: number) => {
-      if (!zmkApp?.state.connection || subsystemIndex === undefined) return;
+      if (!ready) return;
 
       setIsLoading(true);
       setError(null);
 
       try {
-        const service = new ZMKCustomSubsystem(
-          zmkApp.state.connection,
-          subsystemIndex,
-        );
-
         // Simplify the fraction to reduce risk of overflow
         const simplified = simplifyFraction(multiplier, divisor);
 
         // Set multiplier
-        const multiplierRequest = Request.create({
-          setScaleMultiplier: {
-            id,
-            value: simplified.multiplier,
-          },
-        });
-
-        const multiplierPayload = Request.encode(multiplierRequest).finish();
-        const multiplierResponse = await service.callRPC(multiplierPayload);
+        const multiplierResponse = await call(
+          Request.create({
+            setScaleMultiplier: { id, value: simplified.multiplier },
+          }),
+        );
 
         if (multiplierResponse) {
-          const resp = Response.decode(multiplierResponse);
-          if (resp.error) {
-            setError(resp.error.message);
+          if (multiplierResponse.error) {
+            setError(multiplierResponse.error.message);
             return;
           }
         }
@@ -278,20 +263,15 @@ export function useRuntimeInputProcessor(): UseRuntimeInputProcessorReturn {
         });
 
         // Set divisor
-        const divisorRequest = Request.create({
-          setScaleDivisor: {
-            id,
-            value: simplified.divisor,
-          },
-        });
-
-        const divisorPayload = Request.encode(divisorRequest).finish();
-        const divisorResponse = await service.callRPC(divisorPayload);
+        const divisorResponse = await call(
+          Request.create({
+            setScaleDivisor: { id, value: simplified.divisor },
+          }),
+        );
 
         if (divisorResponse) {
-          const resp = Response.decode(divisorResponse);
-          if (resp.error) {
-            setError(resp.error.message);
+          if (divisorResponse.error) {
+            setError(divisorResponse.error.message);
             return;
           }
         }
@@ -304,22 +284,17 @@ export function useRuntimeInputProcessor(): UseRuntimeInputProcessorReturn {
         setIsLoading(false);
       }
     },
-    [zmkApp?.state.connection, subsystemIndex, updateProcessorOptimistically],
+    [ready, call, updateProcessorOptimistically],
   );
 
   const setRotation = useCallback(
     async (id: number, degrees: number) => {
-      if (!zmkApp?.state.connection || subsystemIndex === undefined) return;
+      if (!ready) return;
 
       setIsLoading(true);
       setError(null);
 
       try {
-        const service = new ZMKCustomSubsystem(
-          zmkApp.state.connection,
-          subsystemIndex,
-        );
-
         updateProcessorOptimistically(id, { rotationDegrees: degrees });
 
         const request = Request.create({
@@ -329,11 +304,9 @@ export function useRuntimeInputProcessor(): UseRuntimeInputProcessorReturn {
           },
         });
 
-        const payload = Request.encode(request).finish();
-        const responsePayload = await service.callRPC(payload);
+        const resp = await call(request);
 
-        if (responsePayload) {
-          const resp = Response.decode(responsePayload);
+        if (resp) {
           if (resp.error) {
             setError(resp.error.message);
             return;
@@ -348,22 +321,17 @@ export function useRuntimeInputProcessor(): UseRuntimeInputProcessorReturn {
         setIsLoading(false);
       }
     },
-    [zmkApp?.state.connection, subsystemIndex, updateProcessorOptimistically],
+    [ready, call, updateProcessorOptimistically],
   );
 
   const setTempLayerEnabled = useCallback(
     async (id: number, enabled: boolean) => {
-      if (!zmkApp?.state.connection || subsystemIndex === undefined) return;
+      if (!ready) return;
 
       setIsLoading(true);
       setError(null);
 
       try {
-        const service = new ZMKCustomSubsystem(
-          zmkApp.state.connection,
-          subsystemIndex,
-        );
-
         updateProcessorOptimistically(id, { tempLayerEnabled: enabled });
 
         const request = Request.create({
@@ -373,11 +341,9 @@ export function useRuntimeInputProcessor(): UseRuntimeInputProcessorReturn {
           },
         });
 
-        const payload = Request.encode(request).finish();
-        const responsePayload = await service.callRPC(payload);
+        const resp = await call(request);
 
-        if (responsePayload) {
-          const resp = Response.decode(responsePayload);
+        if (resp) {
           if (resp.error) {
             setError(resp.error.message);
             return;
@@ -392,22 +358,17 @@ export function useRuntimeInputProcessor(): UseRuntimeInputProcessorReturn {
         setIsLoading(false);
       }
     },
-    [zmkApp?.state.connection, subsystemIndex, updateProcessorOptimistically],
+    [ready, call, updateProcessorOptimistically],
   );
 
   const setTempLayerLayer = useCallback(
     async (id: number, layer: number) => {
-      if (!zmkApp?.state.connection || subsystemIndex === undefined) return;
+      if (!ready) return;
 
       setIsLoading(true);
       setError(null);
 
       try {
-        const service = new ZMKCustomSubsystem(
-          zmkApp.state.connection,
-          subsystemIndex,
-        );
-
         updateProcessorOptimistically(id, { tempLayerLayer: layer });
 
         const request = Request.create({
@@ -417,11 +378,9 @@ export function useRuntimeInputProcessor(): UseRuntimeInputProcessorReturn {
           },
         });
 
-        const payload = Request.encode(request).finish();
-        const responsePayload = await service.callRPC(payload);
+        const resp = await call(request);
 
-        if (responsePayload) {
-          const resp = Response.decode(responsePayload);
+        if (resp) {
           if (resp.error) {
             setError(resp.error.message);
             return;
@@ -436,22 +395,17 @@ export function useRuntimeInputProcessor(): UseRuntimeInputProcessorReturn {
         setIsLoading(false);
       }
     },
-    [zmkApp?.state.connection, subsystemIndex, updateProcessorOptimistically],
+    [ready, call, updateProcessorOptimistically],
   );
 
   const setTempLayerActivationDelay = useCallback(
     async (id: number, delayMs: number) => {
-      if (!zmkApp?.state.connection || subsystemIndex === undefined) return;
+      if (!ready) return;
 
       setIsLoading(true);
       setError(null);
 
       try {
-        const service = new ZMKCustomSubsystem(
-          zmkApp.state.connection,
-          subsystemIndex,
-        );
-
         updateProcessorOptimistically(id, {
           tempLayerActivationDelayMs: delayMs,
         });
@@ -463,11 +417,9 @@ export function useRuntimeInputProcessor(): UseRuntimeInputProcessorReturn {
           },
         });
 
-        const payload = Request.encode(request).finish();
-        const responsePayload = await service.callRPC(payload);
+        const resp = await call(request);
 
-        if (responsePayload) {
-          const resp = Response.decode(responsePayload);
+        if (resp) {
           if (resp.error) {
             setError(resp.error.message);
             return;
@@ -482,22 +434,17 @@ export function useRuntimeInputProcessor(): UseRuntimeInputProcessorReturn {
         setIsLoading(false);
       }
     },
-    [zmkApp?.state.connection, subsystemIndex, updateProcessorOptimistically],
+    [ready, call, updateProcessorOptimistically],
   );
 
   const setTempLayerDeactivationDelay = useCallback(
     async (id: number, delayMs: number) => {
-      if (!zmkApp?.state.connection || subsystemIndex === undefined) return;
+      if (!ready) return;
 
       setIsLoading(true);
       setError(null);
 
       try {
-        const service = new ZMKCustomSubsystem(
-          zmkApp.state.connection,
-          subsystemIndex,
-        );
-
         updateProcessorOptimistically(id, {
           tempLayerDeactivationDelayMs: delayMs,
         });
@@ -509,11 +456,9 @@ export function useRuntimeInputProcessor(): UseRuntimeInputProcessorReturn {
           },
         });
 
-        const payload = Request.encode(request).finish();
-        const responsePayload = await service.callRPC(payload);
+        const resp = await call(request);
 
-        if (responsePayload) {
-          const resp = Response.decode(responsePayload);
+        if (resp) {
           if (resp.error) {
             setError(resp.error.message);
             return;
@@ -528,22 +473,17 @@ export function useRuntimeInputProcessor(): UseRuntimeInputProcessorReturn {
         setIsLoading(false);
       }
     },
-    [zmkApp?.state.connection, subsystemIndex, updateProcessorOptimistically],
+    [ready, call, updateProcessorOptimistically],
   );
 
   const setActiveLayers = useCallback(
     async (id: number, layersBitmask: number) => {
-      if (!zmkApp?.state.connection || subsystemIndex === undefined) return;
+      if (!ready) return;
 
       setIsLoading(true);
       setError(null);
 
       try {
-        const service = new ZMKCustomSubsystem(
-          zmkApp.state.connection,
-          subsystemIndex,
-        );
-
         updateProcessorOptimistically(id, { activeLayers: layersBitmask });
 
         const request = Request.create({
@@ -553,11 +493,9 @@ export function useRuntimeInputProcessor(): UseRuntimeInputProcessorReturn {
           },
         });
 
-        const payload = Request.encode(request).finish();
-        const responsePayload = await service.callRPC(payload);
+        const resp = await call(request);
 
-        if (responsePayload) {
-          const resp = Response.decode(responsePayload);
+        if (resp) {
           if (resp.error) {
             setError(resp.error.message);
             return;
@@ -572,22 +510,17 @@ export function useRuntimeInputProcessor(): UseRuntimeInputProcessorReturn {
         setIsLoading(false);
       }
     },
-    [zmkApp?.state.connection, subsystemIndex, updateProcessorOptimistically],
+    [ready, call, updateProcessorOptimistically],
   );
 
   const setAxisSnapMode = useCallback(
     async (id: number, mode: AxisSnapMode) => {
-      if (!zmkApp?.state.connection || subsystemIndex === undefined) return;
+      if (!ready) return;
 
       setIsLoading(true);
       setError(null);
 
       try {
-        const service = new ZMKCustomSubsystem(
-          zmkApp.state.connection,
-          subsystemIndex,
-        );
-
         updateProcessorOptimistically(id, { axisSnapMode: mode });
 
         const request = Request.create({
@@ -597,11 +530,9 @@ export function useRuntimeInputProcessor(): UseRuntimeInputProcessorReturn {
           },
         });
 
-        const payload = Request.encode(request).finish();
-        const responsePayload = await service.callRPC(payload);
+        const resp = await call(request);
 
-        if (responsePayload) {
-          const resp = Response.decode(responsePayload);
+        if (resp) {
           if (resp.error) {
             setError(resp.error.message);
             return;
@@ -616,22 +547,17 @@ export function useRuntimeInputProcessor(): UseRuntimeInputProcessorReturn {
         setIsLoading(false);
       }
     },
-    [zmkApp?.state.connection, subsystemIndex, updateProcessorOptimistically],
+    [ready, call, updateProcessorOptimistically],
   );
 
   const setAxisSnapThreshold = useCallback(
     async (id: number, threshold: number) => {
-      if (!zmkApp?.state.connection || subsystemIndex === undefined) return;
+      if (!ready) return;
 
       setIsLoading(true);
       setError(null);
 
       try {
-        const service = new ZMKCustomSubsystem(
-          zmkApp.state.connection,
-          subsystemIndex,
-        );
-
         updateProcessorOptimistically(id, { axisSnapThreshold: threshold });
 
         const request = Request.create({
@@ -641,11 +567,9 @@ export function useRuntimeInputProcessor(): UseRuntimeInputProcessorReturn {
           },
         });
 
-        const payload = Request.encode(request).finish();
-        const responsePayload = await service.callRPC(payload);
+        const resp = await call(request);
 
-        if (responsePayload) {
-          const resp = Response.decode(responsePayload);
+        if (resp) {
           if (resp.error) {
             setError(resp.error.message);
             return;
@@ -660,22 +584,17 @@ export function useRuntimeInputProcessor(): UseRuntimeInputProcessorReturn {
         setIsLoading(false);
       }
     },
-    [zmkApp?.state.connection, subsystemIndex, updateProcessorOptimistically],
+    [ready, call, updateProcessorOptimistically],
   );
 
   const setAxisSnapTimeout = useCallback(
     async (id: number, timeoutMs: number) => {
-      if (!zmkApp?.state.connection || subsystemIndex === undefined) return;
+      if (!ready) return;
 
       setIsLoading(true);
       setError(null);
 
       try {
-        const service = new ZMKCustomSubsystem(
-          zmkApp.state.connection,
-          subsystemIndex,
-        );
-
         updateProcessorOptimistically(id, { axisSnapTimeoutMs: timeoutMs });
 
         const request = Request.create({
@@ -685,11 +604,9 @@ export function useRuntimeInputProcessor(): UseRuntimeInputProcessorReturn {
           },
         });
 
-        const payload = Request.encode(request).finish();
-        const responsePayload = await service.callRPC(payload);
+        const resp = await call(request);
 
-        if (responsePayload) {
-          const resp = Response.decode(responsePayload);
+        if (resp) {
           if (resp.error) {
             setError(resp.error.message);
             return;
@@ -704,22 +621,17 @@ export function useRuntimeInputProcessor(): UseRuntimeInputProcessorReturn {
         setIsLoading(false);
       }
     },
-    [zmkApp?.state.connection, subsystemIndex, updateProcessorOptimistically],
+    [ready, call, updateProcessorOptimistically],
   );
 
   const setXInvert = useCallback(
     async (id: number, invert: boolean) => {
-      if (!zmkApp?.state.connection || subsystemIndex === undefined) return;
+      if (!ready) return;
 
       setIsLoading(true);
       setError(null);
 
       try {
-        const service = new ZMKCustomSubsystem(
-          zmkApp.state.connection,
-          subsystemIndex,
-        );
-
         updateProcessorOptimistically(id, { xInvert: invert });
 
         const request = Request.create({
@@ -729,11 +641,9 @@ export function useRuntimeInputProcessor(): UseRuntimeInputProcessorReturn {
           },
         });
 
-        const payload = Request.encode(request).finish();
-        const responsePayload = await service.callRPC(payload);
+        const resp = await call(request);
 
-        if (responsePayload) {
-          const resp = Response.decode(responsePayload);
+        if (resp) {
           if (resp.error) {
             setError(resp.error.message);
             return;
@@ -748,22 +658,17 @@ export function useRuntimeInputProcessor(): UseRuntimeInputProcessorReturn {
         setIsLoading(false);
       }
     },
-    [zmkApp?.state.connection, subsystemIndex, updateProcessorOptimistically],
+    [ready, call, updateProcessorOptimistically],
   );
 
   const setYInvert = useCallback(
     async (id: number, invert: boolean) => {
-      if (!zmkApp?.state.connection || subsystemIndex === undefined) return;
+      if (!ready) return;
 
       setIsLoading(true);
       setError(null);
 
       try {
-        const service = new ZMKCustomSubsystem(
-          zmkApp.state.connection,
-          subsystemIndex,
-        );
-
         updateProcessorOptimistically(id, { yInvert: invert });
 
         const request = Request.create({
@@ -773,11 +678,9 @@ export function useRuntimeInputProcessor(): UseRuntimeInputProcessorReturn {
           },
         });
 
-        const payload = Request.encode(request).finish();
-        const responsePayload = await service.callRPC(payload);
+        const resp = await call(request);
 
-        if (responsePayload) {
-          const resp = Response.decode(responsePayload);
+        if (resp) {
           if (resp.error) {
             setError(resp.error.message);
             return;
@@ -792,22 +695,17 @@ export function useRuntimeInputProcessor(): UseRuntimeInputProcessorReturn {
         setIsLoading(false);
       }
     },
-    [zmkApp?.state.connection, subsystemIndex, updateProcessorOptimistically],
+    [ready, call, updateProcessorOptimistically],
   );
 
   const setXyToScrollEnabled = useCallback(
     async (id: number, enabled: boolean) => {
-      if (!zmkApp?.state.connection || subsystemIndex === undefined) return;
+      if (!ready) return;
 
       setIsLoading(true);
       setError(null);
 
       try {
-        const service = new ZMKCustomSubsystem(
-          zmkApp.state.connection,
-          subsystemIndex,
-        );
-
         updateProcessorOptimistically(id, { xyToScrollEnabled: enabled });
 
         const request = Request.create({
@@ -817,11 +715,9 @@ export function useRuntimeInputProcessor(): UseRuntimeInputProcessorReturn {
           },
         });
 
-        const payload = Request.encode(request).finish();
-        const responsePayload = await service.callRPC(payload);
+        const resp = await call(request);
 
-        if (responsePayload) {
-          const resp = Response.decode(responsePayload);
+        if (resp) {
           if (resp.error) {
             setError(resp.error.message);
             return;
@@ -836,22 +732,17 @@ export function useRuntimeInputProcessor(): UseRuntimeInputProcessorReturn {
         setIsLoading(false);
       }
     },
-    [zmkApp?.state.connection, subsystemIndex, updateProcessorOptimistically],
+    [ready, call, updateProcessorOptimistically],
   );
 
   const setXySwapEnabled = useCallback(
     async (id: number, enabled: boolean) => {
-      if (!zmkApp?.state.connection || subsystemIndex === undefined) return;
+      if (!ready) return;
 
       setIsLoading(true);
       setError(null);
 
       try {
-        const service = new ZMKCustomSubsystem(
-          zmkApp.state.connection,
-          subsystemIndex,
-        );
-
         updateProcessorOptimistically(id, { xySwapEnabled: enabled });
 
         const request = Request.create({
@@ -861,11 +752,9 @@ export function useRuntimeInputProcessor(): UseRuntimeInputProcessorReturn {
           },
         });
 
-        const payload = Request.encode(request).finish();
-        const responsePayload = await service.callRPC(payload);
+        const resp = await call(request);
 
-        if (responsePayload) {
-          const resp = Response.decode(responsePayload);
+        if (resp) {
           if (resp.error) {
             setError(resp.error.message);
             return;
@@ -880,11 +769,11 @@ export function useRuntimeInputProcessor(): UseRuntimeInputProcessorReturn {
         setIsLoading(false);
       }
     },
-    [zmkApp?.state.connection, subsystemIndex, updateProcessorOptimistically],
+    [ready, call, updateProcessorOptimistically],
   );
 
   const loadLayers = useCallback(async () => {
-    if (!zmkApp?.state.connection || subsystemIndex === undefined) {
+    if (!ready) {
       setError("Not connected to device or subsystem not found");
       return;
     }
@@ -893,20 +782,13 @@ export function useRuntimeInputProcessor(): UseRuntimeInputProcessorReturn {
     setError(null);
 
     try {
-      const service = new ZMKCustomSubsystem(
-        zmkApp.state.connection,
-        subsystemIndex,
-      );
-
       const request = Request.create({
         getLayerInfo: {},
       });
 
-      const payload = Request.encode(request).finish();
-      const responsePayload = await service.callRPC(payload);
+      const resp = await call(request);
 
-      if (responsePayload) {
-        const resp = Response.decode(responsePayload);
+      if (resp) {
         if (resp.error) {
           setError(resp.error.message);
           return;
@@ -929,18 +811,18 @@ export function useRuntimeInputProcessor(): UseRuntimeInputProcessorReturn {
     } finally {
       setIsLoading(false);
     }
-  }, [zmkApp, subsystemIndex]);
+  }, [ready, call]);
 
   // Load processors and layers when connection or subsystem changes
   useEffect(() => {
-    if (subsystemIndex !== undefined && zmkApp?.state.connection) {
+    if (ready) {
       loadProcessors();
       loadLayers();
     }
-  }, [subsystemIndex, zmkApp?.state.connection, loadProcessors, loadLayers]);
+  }, [ready, loadProcessors, loadLayers]);
 
   return {
-    isAvailable: subsystemIndex !== undefined,
+    isAvailable: subsystem !== null,
     processors,
     layers,
     isLoading,

--- a/src/hooks/useRuntimeMacro.ts
+++ b/src/hooks/useRuntimeMacro.ts
@@ -1,8 +1,5 @@
-import { useState, useEffect, useCallback, useContext, useMemo } from "react";
-import {
-  ZMKCustomSubsystem,
-  ZMKAppContext,
-} from "@cormoran/zmk-studio-react-hook";
+import { useState, useEffect, useCallback } from "react";
+import { useCustomSubsystem } from "@cormoran/zmk-studio-react-hook";
 import {
   Request,
   Response,
@@ -16,6 +13,11 @@ import {
 export type { MacroGlobalSettings, MacroSlot, MacroStep, MacroSummary };
 
 export const RUNTIME_MACRO_SUBSYSTEM_IDENTIFIER = "cormoran__runtime_macro";
+
+const CODEC = {
+  encode: (request: Request) => Request.encode(request).finish(),
+  decode: (payload: Uint8Array) => Response.decode(payload),
+};
 
 export interface UseRuntimeMacroReturn {
   isAvailable: boolean;
@@ -52,7 +54,10 @@ export interface UseRuntimeMacroReturn {
 }
 
 export function useRuntimeMacro(): UseRuntimeMacroReturn {
-  const zmkApp = useContext(ZMKAppContext);
+  const { subsystem, ready, call } = useCustomSubsystem(
+    RUNTIME_MACRO_SUBSYSTEM_IDENTIFIER,
+    CODEC,
+  );
   const [macros, setMacros] = useState<MacroSummary[]>([]);
   const [globalSettings, setGlobalSettings] =
     useState<MacroGlobalSettings | null>(null);
@@ -62,11 +67,6 @@ export function useRuntimeMacro(): UseRuntimeMacroReturn {
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const subsystem = useMemo(
-    () => zmkApp?.findSubsystem(RUNTIME_MACRO_SUBSYSTEM_IDENTIFIER),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [zmkApp?.state.customSubsystems],
-  );
   const subsystemIndex = subsystem?.index;
 
   const clearError = useCallback(() => {
@@ -75,24 +75,18 @@ export function useRuntimeMacro(): UseRuntimeMacroReturn {
 
   const callRpc = useCallback(
     async (request: Request): Promise<Response | null> => {
-      if (!zmkApp?.state.connection || subsystemIndex === undefined) {
+      if (!ready) {
         setError("Not connected to device or subsystem not found");
         return null;
       }
 
-      const service = new ZMKCustomSubsystem(
-        zmkApp.state.connection,
-        subsystemIndex,
-      );
-      const payload = Request.encode(request).finish();
-      const responsePayload = await service.callRPC(payload);
+      const response = await call(request);
 
-      if (!responsePayload) {
+      if (!response) {
         setError("Runtime macro RPC returned an empty response");
         return null;
       }
 
-      const response = Response.decode(responsePayload);
       if (response.error) {
         setError(response.error.message);
         return null;
@@ -101,7 +95,7 @@ export function useRuntimeMacro(): UseRuntimeMacroReturn {
       setError(null);
       return response;
     },
-    [zmkApp, subsystemIndex],
+    [ready, call],
   );
 
   const runMutation = useCallback(
@@ -136,7 +130,7 @@ export function useRuntimeMacro(): UseRuntimeMacroReturn {
   );
 
   const loadMacros = useCallback(async () => {
-    if (!zmkApp?.state.connection || subsystemIndex === undefined) {
+    if (!ready) {
       setMacros([]);
       setGlobalSettings(null);
       return;
@@ -169,7 +163,7 @@ export function useRuntimeMacro(): UseRuntimeMacroReturn {
     } finally {
       setIsLoading(false);
     }
-  }, [callRpc, zmkApp?.state.connection, subsystemIndex]);
+  }, [callRpc, ready]);
 
   const getMacro = useCallback(
     async (index: number): Promise<MacroSlot | null> => {
@@ -302,7 +296,7 @@ export function useRuntimeMacro(): UseRuntimeMacroReturn {
   }, [loadMacros, subsystemIndex]);
 
   return {
-    isAvailable: subsystemIndex !== undefined,
+    isAvailable: subsystem !== null,
     macros,
     globalSettings,
     maxMacroBytes,

--- a/src/hooks/useRuntimeSensorRotate.ts
+++ b/src/hooks/useRuntimeSensorRotate.ts
@@ -4,11 +4,8 @@
  * This hook provides access to runtime sensor rotation configuration via a custom ZMK subsystem.
  * It allows configuring rotary encoder bindings per layer at runtime without reflashing.
  */
-import { useState, useEffect, useCallback, useContext, useMemo } from "react";
-import {
-  ZMKCustomSubsystem,
-  ZMKAppContext,
-} from "@cormoran/zmk-studio-react-hook";
+import { useState, useEffect, useCallback } from "react";
+import { useCustomSubsystem } from "@cormoran/zmk-studio-react-hook";
 import {
   Request,
   Response,
@@ -23,6 +20,11 @@ export type { SensorInfo, LayerBindings, Binding };
 // Subsystem identifier for ZMK runtime sensor rotate custom protocol
 // This should match the identifier registered in the ZMK firmware module
 const SUBSYSTEM_IDENTIFIER = "cormoran_rsr";
+
+const CODEC = {
+  encode: (request: Request) => Request.encode(request).finish(),
+  decode: (payload: Uint8Array) => Response.decode(payload),
+};
 
 /**
  * Sensor information
@@ -62,23 +64,16 @@ export interface UseRuntimeSensorRotateReturn {
 }
 
 export function useRuntimeSensorRotate(): UseRuntimeSensorRotateReturn {
-  const zmkApp = useContext(ZMKAppContext);
+  const { subsystem, ready, call } = useCustomSubsystem(
+    SUBSYSTEM_IDENTIFIER,
+    CODEC,
+  );
   const [sensors, setSensors] = useState<Sensor[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  // Memoize subsystem to avoid unnecessary re-renders
-  const subsystem = useMemo(
-    () => zmkApp?.findSubsystem(SUBSYSTEM_IDENTIFIER),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [zmkApp?.state.customSubsystems],
-  );
-
-  // Extract subsystem index as a stable primitive value for dependencies
-  const subsystemIndex = subsystem?.index;
-
   const loadSensors = useCallback(async () => {
-    if (!zmkApp?.state.connection || subsystemIndex === undefined) {
+    if (!ready) {
       setError("Not connected to device or subsystem not found");
       return;
     }
@@ -87,20 +82,9 @@ export function useRuntimeSensorRotate(): UseRuntimeSensorRotateReturn {
     setError(null);
 
     try {
-      const service = new ZMKCustomSubsystem(
-        zmkApp.state.connection,
-        subsystemIndex,
-      );
+      const resp = await call(Request.create({ getSensors: {} }));
 
-      const request = Request.create({
-        getSensors: {},
-      });
-
-      const payload = Request.encode(request).finish();
-      const responsePayload = await service.callRPC(payload);
-
-      if (responsePayload) {
-        const resp = Response.decode(responsePayload);
+      if (resp) {
         if (resp.error) {
           setError(resp.error.message);
           return;
@@ -123,11 +107,11 @@ export function useRuntimeSensorRotate(): UseRuntimeSensorRotateReturn {
     } finally {
       setIsLoading(false);
     }
-  }, [zmkApp, subsystemIndex]);
+  }, [ready, call]);
 
   const getAllLayerBindings = useCallback(
     async (sensorIndex: number): Promise<LayerBindings[]> => {
-      if (!zmkApp?.state.connection || subsystemIndex === undefined) {
+      if (!ready) {
         setError("Not connected to device or subsystem not found");
         return [];
       }
@@ -136,22 +120,11 @@ export function useRuntimeSensorRotate(): UseRuntimeSensorRotateReturn {
       setError(null);
 
       try {
-        const service = new ZMKCustomSubsystem(
-          zmkApp.state.connection,
-          subsystemIndex,
+        const resp = await call(
+          Request.create({ getAllLayerBindings: { sensorIndex } }),
         );
 
-        const request = Request.create({
-          getAllLayerBindings: {
-            sensorIndex,
-          },
-        });
-
-        const payload = Request.encode(request).finish();
-        const responsePayload = await service.callRPC(payload);
-
-        if (responsePayload) {
-          const resp = Response.decode(responsePayload);
+        if (resp) {
           if (resp.error) {
             setError(resp.error.message);
             return [];
@@ -171,7 +144,7 @@ export function useRuntimeSensorRotate(): UseRuntimeSensorRotateReturn {
         setIsLoading(false);
       }
     },
-    [zmkApp, subsystemIndex],
+    [ready, call],
   );
 
   const setLayerCwBindings = useCallback(
@@ -180,7 +153,7 @@ export function useRuntimeSensorRotate(): UseRuntimeSensorRotateReturn {
       layer: number,
       cwBinding: Binding,
     ): Promise<boolean> => {
-      if (!zmkApp?.state.connection || subsystemIndex === undefined) {
+      if (!ready) {
         setError("Not connected to device or subsystem not found");
         return false;
       }
@@ -189,24 +162,13 @@ export function useRuntimeSensorRotate(): UseRuntimeSensorRotateReturn {
       setError(null);
 
       try {
-        const service = new ZMKCustomSubsystem(
-          zmkApp.state.connection,
-          subsystemIndex,
+        const resp = await call(
+          Request.create({
+            setLayerCwBinding: { sensorIndex, layer, binding: cwBinding },
+          }),
         );
 
-        const request = Request.create({
-          setLayerCwBinding: {
-            sensorIndex,
-            layer,
-            binding: cwBinding,
-          },
-        });
-
-        const payload = Request.encode(request).finish();
-        const responsePayload = await service.callRPC(payload);
-
-        if (responsePayload) {
-          const resp = Response.decode(responsePayload);
+        if (resp) {
           if (resp.error) {
             setError(resp.error.message);
             return false;
@@ -226,7 +188,7 @@ export function useRuntimeSensorRotate(): UseRuntimeSensorRotateReturn {
         setIsLoading(false);
       }
     },
-    [zmkApp, subsystemIndex],
+    [ready, call],
   );
 
   const setLayerCcwBindings = useCallback(
@@ -235,7 +197,7 @@ export function useRuntimeSensorRotate(): UseRuntimeSensorRotateReturn {
       layer: number,
       ccwBinding: Binding,
     ): Promise<boolean> => {
-      if (!zmkApp?.state.connection || subsystemIndex === undefined) {
+      if (!ready) {
         setError("Not connected to device or subsystem not found");
         return false;
       }
@@ -244,24 +206,13 @@ export function useRuntimeSensorRotate(): UseRuntimeSensorRotateReturn {
       setError(null);
 
       try {
-        const service = new ZMKCustomSubsystem(
-          zmkApp.state.connection,
-          subsystemIndex,
+        const resp = await call(
+          Request.create({
+            setLayerCcwBinding: { sensorIndex, layer, binding: ccwBinding },
+          }),
         );
 
-        const request = Request.create({
-          setLayerCcwBinding: {
-            sensorIndex,
-            layer,
-            binding: ccwBinding,
-          },
-        });
-
-        const payload = Request.encode(request).finish();
-        const responsePayload = await service.callRPC(payload);
-
-        if (responsePayload) {
-          const resp = Response.decode(responsePayload);
+        if (resp) {
           if (resp.error) {
             setError(resp.error.message);
             return false;
@@ -281,21 +232,21 @@ export function useRuntimeSensorRotate(): UseRuntimeSensorRotateReturn {
         setIsLoading(false);
       }
     },
-    [zmkApp, subsystemIndex],
+    [ready, call],
   );
 
   // Load sensors when connection or subsystem changes
   useEffect(() => {
-    if (subsystemIndex !== undefined && zmkApp?.state.connection) {
+    if (ready) {
       loadSensors();
     } else {
       setSensors([]);
       setError(null);
     }
-  }, [subsystemIndex, zmkApp?.state.connection, loadSensors]);
+  }, [ready, loadSensors]);
 
   return {
-    isAvailable: subsystemIndex !== undefined,
+    isAvailable: subsystem !== null,
     sensors,
     isLoading,
     error,

--- a/src/hooks/useSettings.ts
+++ b/src/hooks/useSettings.ts
@@ -1,7 +1,7 @@
-import { useState, useEffect, useCallback, useContext, useMemo } from "react";
+import { useState, useEffect, useCallback, useContext } from "react";
 import {
-  ZMKCustomSubsystem,
   ZMKAppContext,
+  useCustomSubsystem,
 } from "@cormoran/zmk-studio-react-hook";
 import {
   Request,
@@ -12,6 +12,11 @@ import {
 
 // Subsystem identifier for ZMK settings RPC
 const SUBSYSTEM_IDENTIFIER = "zmk__settings";
+
+const CODEC = {
+  encode: (request: Request) => Request.encode(request).finish(),
+  decode: (payload: Uint8Array) => Response.decode(payload),
+};
 
 // Time to wait for all notifications to arrive after requesting settings
 const NOTIFICATION_COLLECTION_TIMEOUT_MS = 500;
@@ -35,22 +40,19 @@ export interface UseSettingsReturn {
 
 export function useSettings(): UseSettingsReturn {
   const zmkApp = useContext(ZMKAppContext);
+  const { subsystem, ready, call } = useCustomSubsystem(
+    SUBSYSTEM_IDENTIFIER,
+    CODEC,
+  );
   const [devices, setDevices] = useState<DeviceActivitySettings[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-
-  // Memoize subsystem to avoid unnecessary re-renders
-  const subsystem = useMemo(
-    () => zmkApp?.findSubsystem(SUBSYSTEM_IDENTIFIER),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [zmkApp?.state.customSubsystems],
-  );
 
   // Extract subsystem index as a stable primitive value for dependencies
   const subsystemIndex = subsystem?.index;
 
   const loadAllSettings = useCallback(async () => {
-    if (!zmkApp?.state.connection || subsystemIndex === undefined) {
+    if (!ready || !zmkApp || subsystemIndex === undefined) {
       setError("Not connected to device or subsystem not found");
       return;
     }
@@ -59,11 +61,6 @@ export function useSettings(): UseSettingsReturn {
     setError(null);
 
     try {
-      const service = new ZMKCustomSubsystem(
-        zmkApp.state.connection,
-        subsystemIndex,
-      );
-
       // Map to store settings by source ID
       const deviceMap = new Map<number, DeviceActivitySettings>();
 
@@ -112,20 +109,11 @@ export function useSettings(): UseSettingsReturn {
 
       try {
         // Send request to get all activity settings
-        const request = Request.create({
-          getAllActivitySettings: {},
-        });
-
-        const payload = Request.encode(request).finish();
-        const responsePayload = await service.callRPC(payload);
-
-        if (responsePayload) {
-          const resp = Response.decode(responsePayload);
-          if (resp.error) {
-            setError(resp.error.message);
-          }
-          // Note: The actual data comes via notifications, not the response
+        const resp = await call(Request.create({ getAllActivitySettings: {} }));
+        if (resp?.error) {
+          setError(resp.error.message);
         }
+        // Note: The actual data comes via notifications, not the response
       } finally {
         // Wait for all notifications to arrive from devices
         await new Promise((resolve) =>
@@ -141,11 +129,11 @@ export function useSettings(): UseSettingsReturn {
     } finally {
       setIsLoading(false);
     }
-  }, [zmkApp, subsystemIndex]);
+  }, [zmkApp, ready, subsystemIndex, call]);
 
   const setActivitySettings = useCallback(
     async (idleMs: number, sleepMs: number) => {
-      if (!zmkApp?.state.connection || subsystemIndex === undefined) {
+      if (!ready) {
         setError("Not connected to device or subsystem not found");
         return;
       }
@@ -154,26 +142,19 @@ export function useSettings(): UseSettingsReturn {
       setError(null);
 
       try {
-        const service = new ZMKCustomSubsystem(
-          zmkApp.state.connection,
-          subsystemIndex,
+        const resp = await call(
+          Request.create({
+            setActivitySettings: {
+              settings: {
+                idleMs,
+                sleepMs,
+                source: 0, // Not used for set operation
+              },
+            },
+          }),
         );
 
-        const request = Request.create({
-          setActivitySettings: {
-            settings: {
-              idleMs,
-              sleepMs,
-              source: 0, // Not used for set operation
-            },
-          },
-        });
-
-        const payload = Request.encode(request).finish();
-        const responsePayload = await service.callRPC(payload);
-
-        if (responsePayload) {
-          const resp = Response.decode(responsePayload);
+        if (resp) {
           if (resp.error) {
             setError(resp.error.message);
           } else if (resp.setActivitySettings?.success) {
@@ -190,7 +171,7 @@ export function useSettings(): UseSettingsReturn {
         setIsLoading(false);
       }
     },
-    [zmkApp, subsystemIndex, loadAllSettings],
+    [ready, call, loadAllSettings],
   );
 
   const resetToDefaults = useCallback(async () => {
@@ -202,13 +183,13 @@ export function useSettings(): UseSettingsReturn {
 
   // Load settings when connection or subsystem changes
   useEffect(() => {
-    if (subsystemIndex !== undefined && zmkApp?.state.connection) {
+    if (ready) {
       loadAllSettings();
     }
-  }, [subsystemIndex, zmkApp?.state.connection, loadAllSettings]);
+  }, [ready, loadAllSettings]);
 
   return {
-    isAvailable: subsystemIndex !== undefined,
+    isAvailable: subsystem !== null,
     devices,
     isLoading,
     error,

--- a/src/hooks/useWatchdog.ts
+++ b/src/hooks/useWatchdog.ts
@@ -1,7 +1,7 @@
-import { useCallback, useContext, useEffect, useMemo, useState } from "react";
+import { useCallback, useContext, useEffect, useState } from "react";
 import {
-  ZMKCustomSubsystem,
   ZMKAppContext,
+  useCustomSubsystem,
 } from "@cormoran/zmk-studio-react-hook";
 import {
   Request,
@@ -12,6 +12,11 @@ import {
 } from "../proto/cormoran/watchdog/watchdog";
 
 export const WATCHDOG_SUBSYSTEM_IDENTIFIER = "cormoran__watchdog";
+
+const CODEC = {
+  encode: (request: Request) => Request.encode(request).finish(),
+  decode: (payload: Uint8Array) => Response.decode(payload),
+};
 
 // How long to wait for a split peripheral to answer a relayed request
 // before giving up — there is no way to know which peripheral slots are
@@ -37,30 +42,24 @@ export interface UseWatchdogReturn {
 
 export function useWatchdog(): UseWatchdogReturn {
   const zmkApp = useContext(ZMKAppContext);
+  const { subsystem, ready, call } = useCustomSubsystem(
+    WATCHDOG_SUBSYSTEM_IDENTIFIER,
+    CODEC,
+  );
   const [source, setSource] = useState(0);
   const [status, setStatus] = useState<StatusResponse | null>(null);
   const [incidents, setIncidents] = useState<Incident[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const subsystem = useMemo(
-    () => zmkApp?.findSubsystem(WATCHDOG_SUBSYSTEM_IDENTIFIER),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [zmkApp?.state.customSubsystems],
-  );
   const subsystemIndex = subsystem?.index;
-  const connection = zmkApp?.state.connection;
 
   const callRpc = useCallback(
     async (request: Request): Promise<Response | null> => {
-      if (!connection || subsystemIndex === undefined) return null;
-      const service = new ZMKCustomSubsystem(connection, subsystemIndex);
-      const payload = Request.encode(request).finish();
-      const responsePayload = await service.callRPC(payload);
-      if (!responsePayload) return null;
-      return Response.decode(responsePayload);
+      if (!ready) return null;
+      return call(request);
     },
-    [connection, subsystemIndex],
+    [ready, call],
   );
 
   // Awaits the real Response for a request that came back as a
@@ -158,7 +157,7 @@ export function useWatchdog(): UseWatchdogReturn {
   }, [callRpcAwaitingRelay, source]);
 
   const refresh = useCallback(async () => {
-    if (!connection || subsystemIndex === undefined) return;
+    if (!ready) return;
     setIsLoading(true);
     setError(null);
     try {
@@ -169,14 +168,14 @@ export function useWatchdog(): UseWatchdogReturn {
     } finally {
       setIsLoading(false);
     }
-  }, [connection, subsystemIndex, refreshStatus, refreshIncidents]);
+  }, [ready, refreshStatus, refreshIncidents]);
 
   // Auto-load when the subsystem becomes available or the source changes.
   useEffect(() => {
-    if (connection && subsystemIndex !== undefined) {
+    if (ready) {
       void refresh();
     }
-  }, [connection, subsystemIndex, source, refresh]);
+  }, [ready, source, refresh]);
 
   // Live incident push: firmware notifies whenever a new incident is
   // persisted on the local (central) store.
@@ -238,7 +237,7 @@ export function useWatchdog(): UseWatchdogReturn {
   );
 
   return {
-    isAvailable: subsystemIndex !== undefined,
+    isAvailable: subsystem !== null,
     source,
     setSource,
     status,

--- a/src/i18n/translations.ts
+++ b/src/i18n/translations.ts
@@ -469,6 +469,7 @@ const ja: Record<string, string> = {
   "Try Demo Mode": "デモモードを試す",
   "Try Demo Mode (no device required)": "デモモードを試す（デバイス不要）",
   "Try demo mode without a keyboard": "キーボードなしでデモモードを試せます",
+  "Reconnecting to your keyboard...": "キーボードに再接続中...",
   "DYA Studio is maintained by": "DYA Studio のメンテナー",
   "Special thanks to": "Special thanks to",
   "ZMK community": "ZMK community",

--- a/src/lib/transport/__tests__/usb.test.ts
+++ b/src/lib/transport/__tests__/usb.test.ts
@@ -1,4 +1,4 @@
-import { connect as connectSerial } from "@zmkfirmware/zmk-studio-ts-client/transport/serial";
+import { connectSerial } from "@cormoran/zmk-studio-react-hook";
 import { connect as connectWebUsb } from "../webUsb";
 import {
   connect,
@@ -6,8 +6,9 @@ import {
   shouldUseWebUsbForUsbConnection,
 } from "../usb";
 
-jest.mock("@zmkfirmware/zmk-studio-ts-client/transport/serial", () => ({
-  connect: jest.fn(),
+jest.mock("@cormoran/zmk-studio-react-hook", () => ({
+  connectSerial: jest.fn(),
+  isWebSerialSupported: jest.fn(() => "serial" in navigator),
 }));
 
 jest.mock("../webUsb", () => ({
@@ -48,6 +49,15 @@ describe("USB transport selection", () => {
   test("detects Android Chrome user agents", () => {
     expect(shouldUseWebUsbForUsbConnection(androidChromeUserAgent)).toBe(true);
     expect(shouldUseWebUsbForUsbConnection(desktopChromeUserAgent)).toBe(false);
+  });
+
+  test("treats Web Serial support as USB-capable", () => {
+    Object.defineProperty(navigator, "serial", {
+      configurable: true,
+      value: { requestPort: jest.fn(), getPorts: jest.fn() },
+    });
+
+    expect(isUsbConnectionAvailable()).toBe(true);
   });
 
   test("treats Android Chrome WebUSB as USB-capable without Web Serial", () => {

--- a/src/lib/transport/usb.ts
+++ b/src/lib/transport/usb.ts
@@ -1,5 +1,8 @@
 import type { RpcTransport } from "@zmkfirmware/zmk-studio-ts-client/transport/index";
-import { connect as connectSerial } from "@zmkfirmware/zmk-studio-ts-client/transport/serial";
+import {
+  connectSerial,
+  isWebSerialSupported,
+} from "@cormoran/zmk-studio-react-hook";
 import { connect as connectWebUsb } from "./webUsb";
 
 export function shouldUseWebUsbForUsbConnection(
@@ -10,7 +13,7 @@ export function shouldUseWebUsbForUsbConnection(
 
 export function isUsbConnectionAvailable() {
   return (
-    "serial" in navigator ||
+    isWebSerialSupported() ||
     (shouldUseWebUsbForUsbConnection() && "usb" in navigator)
   );
 }


### PR DESCRIPTION
## Description

Adopt the improvements recently merged into [react-zmk-studio](https://github.com/cormoran/react-zmk-studio) (`1b4b4a0` → `b91561d`, all additive / no breaking changes).

### Auto-reconnect on page load (with visible indicator)
- On page load, if a previously-paired serial port exists, `DeviceConnectionProvider` drives an auto-reconnect using the library's `getPairedSerialPorts()` / `connectToPairedSerial()` primitives.
- While the attempt is in flight, a minimal `ReconnectingOverlay` is shown instead of the full splash screen: the backdrop is fully transparent, with only a centered circular glass indicator (spinner + "Reconnecting to your keyboard...") and a small Cancel link below it. The indicator stays visible for a minimum of 600ms (`AUTO_RECONNECT_MIN_DISPLAY_MS`) even when the connection succeeds instantly, to avoid an unreadable flash without making the user wait longer than necessary.
- Cancel aborts the in-flight attempt (releasing the transport via its `AbortController`) and returns to the normal connect screen immediately.
- If there is no paired port, or the attempt fails, the app stays disconnected and shows the connect screen exactly as before (no error surfaced).
- Manual USB connections go through the library's `connectSerial()`, which remembers the chosen port (sessionStorage) so the next reload reconnects to the same device. `isUsbConnectionAvailable()` now uses the library's `isWebSerialSupported()`.
- Notes: auto-reconnect covers Web Serial (desktop USB) only — Web Bluetooth requires a user gesture, and the Android WebUSB path is unaffected. Under React StrictMode in dev builds the one-shot reconnect is suppressed by the double-invoked effect (same semantics as the library's own `ZMKConnection autoReconnect`); production builds are unaffected.

### Replace hand-rolled code with library features
- Converted 14 hooks (`useDeviceInfo`, `useSettings`, `useCustomSettings`, `useKscanDiagnostics`, `useWatchdog`, `useBLEProfiles`, `useOsDetection`, `useDefaultLayer`, `useRuntimeMacro`, `useRuntimeCombo`, `useRuntimeSensorRotate`, `useRuntimeInputProcessor`, `useInputStream`, `usePmw3610`) from hand-rolled `findSubsystem` + `new ZMKCustomSubsystem(...)` + encode/decode boilerplate to the library's `useCustomSubsystem(identifier, codec)` (net −186 lines). Public hook APIs and error messages are unchanged.
  - Skipped `usePhysicalLayoutModules`: it falls back across two subsystem identifiers, and converting would change observable `findSubsystem` call behavior asserted by its tests.
- Replaced manual `MetaError`/`UNLOCK_REQUIRED` checks with the library's `isUnlockRequiredError()` in `useKeymap`, `useOfficialLayouts`, `usePmw3610`.
  - `useStudioLockState()` was deliberately NOT adopted: it issues an extra `core.getLockState` RPC on every connect and changes lock detection from reactive to proactive — an observable behavior change, not a pure simplification. Existing `lockStateChanged` subscriptions are kept.
- Free behavior improvement from the library update: cancelling the device picker no longer surfaces an error on the connect screen (`useZMKApp().connect()` now swallows user-cancelled errors).

### Not included
- `pnpm-lock.yaml` was left untouched: it was already substantially out of sync with `package.json` before this PR (CI uses `npm ci`), and refreshing it would add a large unrelated diff. Can be done as a follow-up.

### Verification
`npm run generate`, `tsc -b`, `eslint`, and `jest` (40 suites, 358 tests) all pass. Jest covers: auto-reconnect success, silent fallback with no paired port, `isReconnecting` exposure, cancel-while-pending (late transport is aborted, not connected), the minimum display duration, and the overlay's transparent backdrop. Additionally verified end-to-end with Playwright against the production build (faked `navigator.serial`): the circular reconnecting indicator renders on a transparent backdrop without the splash screen, and Cancel returns to the connect screen.

## CLA (Contributor License Agreement)

By submitting this pull request, I agree that my contributions
are licensed under the project's current license.

I also grant the maintainer(s) of this project the right to relicense
my contributions under any license, for use in future versions of the project.
This does not affect the license of any previously released versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TDTC8xSwdiCecRGe1x3JLL