### PR TITLE
Add URL-based routing for tabs

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "dev",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "dev"],
+      "port": 5173
+    }
+  ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -131,6 +131,7 @@
       "integrity": "sha512-H3mcG6ZDLTlYfaSNi0iOKkigqMFvkTKlGUYlD8GW7nNOYRrevuA46iTypPyv+06V3fEmvvazfntkBU34L0azAw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.28.6",
         "@babel/generator": "^7.28.6",
@@ -964,6 +965,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -987,6 +989,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -3727,6 +3730,7 @@
       "integrity": "sha512-8QqtOQT5ACVlmsvKOJNEaWmRPmcojMOzCz4Hs2BGG/toAp/K38LcsMRyLp349glq5AzJbCEeimEoxaX6v/fLrA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/core": "^7.21.3",
         "@svgr/babel-preset": "8.1.0",
@@ -4229,8 +4233,7 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -4418,6 +4421,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.9.tgz",
       "integrity": "sha512-ne4A0IpG3+2ETuREInjPNhUGis1SFjv1d5asp8MzEAGtOZeTeHVDOYqOgqfhvseqg/iXty2hjBf1zAOb7RNiNw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -4428,6 +4432,7 @@
       "integrity": "sha512-Lpo8kgb/igvMIPeNV2rsYKTgaORYdO1XGVZ4Qz3akwOj0ySGYMPlQWa8BaLn0G63D1aSaAQ5ldR06wCpChQCjA==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -4438,6 +4443,7 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -4518,6 +4524,7 @@
       "integrity": "sha512-nm3cvFN9SqZGXjmw5bZ6cGmvJSyJPn0wU9gHAZZHDnZl2wF9PhHv78Xf06E0MaNk4zLVHL8hb2/c32XvyJOLQg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.53.1",
         "@typescript-eslint/types": "8.53.1",
@@ -4795,6 +4802,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5190,6 +5198,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -5775,8 +5784,7 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/dot-case": {
       "version": "3.0.4",
@@ -5918,6 +5926,7 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -6929,6 +6938,7 @@
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -8819,6 +8829,7 @@
       "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssstyle": "^4.2.1",
         "data-urls": "^5.0.0",
@@ -9530,7 +9541,6 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -10127,6 +10137,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -10175,7 +10186,6 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -10191,7 +10201,6 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -10269,6 +10278,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -10278,6 +10288,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -10290,8 +10301,7 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/react-refresh": {
       "version": "0.18.0",
@@ -11127,6 +11137,7 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -11249,6 +11260,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -11414,6 +11426,7 @@
       "integrity": "sha512-u09tdk/huMiN8xwoiBbig197jKdCamQTtOruSalOzbqGje3jdHiV0njQlAW0YvzoahkirFePNQ4RYlfnRQpXZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@oxc-project/runtime": "0.97.0",
         "fdir": "^6.5.0",
@@ -11772,6 +11785,7 @@
       "integrity": "sha512-k7Nwx6vuWx1IJ9Bjuf4Zt1PEllcwe7cls3VNzm4CQ1/hgtFUK2bRNG3rvnpPUhFjmqJKAKtjV576KnUkHocg/g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -147,32 +147,26 @@ function AppContent() {
   return (
     <>
       <AnimatePresence>
-        {!connection.isConnected && (
-          <motion.div
-            key="splash"
-            initial={{ opacity: 1 }}
-            exit={{ opacity: 0 }}
-            transition={{ duration: 0.3 }}
-            // Kept mounted (but non-interactive) behind the reconnecting
-            // overlay so the page doesn't flash to a blank screen while a
-            // page-load auto-reconnect attempt is in flight.
-            inert={connection.isReconnecting}
-          >
-            <SplashScreen
-              onConnect={connection.onConnect}
-              isConnecting={connection.isLoading}
-              error={connection.error}
-            />
-          </motion.div>
-        )}
-      </AnimatePresence>
-
-      <AnimatePresence>
-        {connection.isReconnecting && (
+        {connection.isReconnecting ? (
           <ReconnectingOverlay
             key="reconnecting"
             onCancel={connection.onCancelReconnect}
           />
+        ) : (
+          !connection.isConnected && (
+            <motion.div
+              key="splash"
+              initial={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              transition={{ duration: 0.3 }}
+            >
+              <SplashScreen
+                onConnect={connection.onConnect}
+                isConnecting={connection.isLoading}
+                error={connection.error}
+              />
+            </motion.div>
+          )
         )}
       </AnimatePresence>
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -147,26 +147,32 @@ function AppContent() {
   return (
     <>
       <AnimatePresence>
-        {connection.isReconnecting ? (
+        {!connection.isConnected && (
+          <motion.div
+            key="splash"
+            initial={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.3 }}
+            // Kept mounted (but non-interactive) behind the reconnecting
+            // overlay so the page doesn't flash to a blank screen while a
+            // page-load auto-reconnect attempt is in flight.
+            inert={connection.isReconnecting}
+          >
+            <SplashScreen
+              onConnect={connection.onConnect}
+              isConnecting={connection.isLoading}
+              error={connection.error}
+            />
+          </motion.div>
+        )}
+      </AnimatePresence>
+
+      <AnimatePresence>
+        {connection.isReconnecting && (
           <ReconnectingOverlay
             key="reconnecting"
             onCancel={connection.onCancelReconnect}
           />
-        ) : (
-          !connection.isConnected && (
-            <motion.div
-              key="splash"
-              initial={{ opacity: 1 }}
-              exit={{ opacity: 0 }}
-              transition={{ duration: 0.3 }}
-            >
-              <SplashScreen
-                onConnect={connection.onConnect}
-                isConnecting={connection.isLoading}
-                error={connection.error}
-              />
-            </motion.div>
-          )
         )}
       </AnimatePresence>
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState, useContext, useCallback, useEffect } from "react";
+import { useContext, useCallback, useEffect } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import {
   IconHome,
@@ -34,6 +34,7 @@ import { SettingsPage } from "./pages/SettingsPage";
 import { CustomSubsystemsPage } from "./pages/CustomSubsystemsPage";
 import { TroubleshootingPage } from "./pages/TroubleshootingPage";
 import { useLanguage } from "./hooks/useLanguage";
+import { useUrlTab, pathnameFromTabId } from "./hooks/useUrlTab";
 
 function getTabs(t: (key: string) => string): TabItem[] {
   return [
@@ -111,8 +112,16 @@ function App() {
 function AppContent() {
   const connection = useContext(ConnectionContext);
   const { t } = useLanguage();
-  const [activeTab, setActiveTab] = useState("home");
+  const [urlTab, navigateToTab] = useUrlTab();
   const tabs = getTabs(t);
+  const activeTab = tabs.some((tab) => tab.id === urlTab) ? urlTab : "home";
+
+  useEffect(() => {
+    // Canonicalize unknown paths (e.g. a stale/typo'd link) to the home tab.
+    if (urlTab !== activeTab && window.location.pathname !== "/") {
+      window.history.replaceState(null, "", "/");
+    }
+  }, [urlTab, activeTab]);
 
   const setActiveTabWithTracking = useCallback(
     (tabId: string) => {
@@ -120,12 +129,12 @@ function AppContent() {
       if (window.gtag) {
         window.gtag("event", "page_view", {
           page_title: tabs.find((tab) => tab.id === tabId)?.label || "Unknown",
-          page_path: `/${tabId}`,
+          page_path: pathnameFromTabId(tabId),
         });
       }
-      setActiveTab(tabId);
+      navigateToTab(tabId);
     },
-    [setActiveTab, tabs],
+    [navigateToTab, tabs],
   );
   useEffect(() => {
     if (connection.deviceName && window.gtag) {

--- a/src/components/ReconnectingOverlay.tsx
+++ b/src/components/ReconnectingOverlay.tsx
@@ -18,11 +18,7 @@ export function ReconnectingOverlay({ onCancel }: ReconnectingOverlayProps) {
 
   return (
     <motion.div
-      // pointer-events-none so the page underneath stays clickable even if
-      // the exit animation stalls (e.g. a throttled background tab) instead
-      // of leaving a full-viewport click-blocker behind; the cancel button
-      // opts back in below.
-      className="fixed inset-0 z-50 flex flex-col items-center justify-center pointer-events-none"
+      className="fixed inset-0 z-50 flex flex-col items-center justify-center"
       initial={{ opacity: 0 }}
       animate={{ opacity: 1 }}
       exit={{ opacity: 0 }}
@@ -49,7 +45,7 @@ export function ReconnectingOverlay({ onCancel }: ReconnectingOverlayProps) {
       <button
         onClick={onCancel}
         aria-label={t("Cancel")}
-        className="pointer-events-auto mt-4 text-xs text-[var(--color-text-muted)] underline underline-offset-4 hover:text-[var(--color-text-secondary)] transition-colors"
+        className="mt-4 text-xs text-[var(--color-text-muted)] underline underline-offset-4 hover:text-[var(--color-text-secondary)] transition-colors"
       >
         {t("Cancel")}
       </button>

--- a/src/components/ReconnectingOverlay.tsx
+++ b/src/components/ReconnectingOverlay.tsx
@@ -18,7 +18,11 @@ export function ReconnectingOverlay({ onCancel }: ReconnectingOverlayProps) {
 
   return (
     <motion.div
-      className="fixed inset-0 z-50 flex flex-col items-center justify-center"
+      // pointer-events-none so the page underneath stays clickable even if
+      // the exit animation stalls (e.g. a throttled background tab) instead
+      // of leaving a full-viewport click-blocker behind; the cancel button
+      // opts back in below.
+      className="fixed inset-0 z-50 flex flex-col items-center justify-center pointer-events-none"
       initial={{ opacity: 0 }}
       animate={{ opacity: 1 }}
       exit={{ opacity: 0 }}
@@ -45,7 +49,7 @@ export function ReconnectingOverlay({ onCancel }: ReconnectingOverlayProps) {
       <button
         onClick={onCancel}
         aria-label={t("Cancel")}
-        className="mt-4 text-xs text-[var(--color-text-muted)] underline underline-offset-4 hover:text-[var(--color-text-secondary)] transition-colors"
+        className="pointer-events-auto mt-4 text-xs text-[var(--color-text-muted)] underline underline-offset-4 hover:text-[var(--color-text-secondary)] transition-colors"
       >
         {t("Cancel")}
       </button>

--- a/src/hooks/useUrlTab.ts
+++ b/src/hooks/useUrlTab.ts
@@ -1,0 +1,37 @@
+import { useCallback, useEffect, useState } from "react";
+
+export function tabIdFromPathname(pathname: string): string {
+  const segment = pathname.replace(/^\/+/, "").split("/")[0];
+  return segment || "home";
+}
+
+export function pathnameFromTabId(tabId: string): string {
+  return tabId === "home" ? "/" : `/${tabId}`;
+}
+
+/**
+ * Keeps the active tab in sync with the URL path (e.g. /keymap) so tabs
+ * are reachable via direct links, browser back/forward, and sharing.
+ */
+export function useUrlTab(): [string, (tabId: string) => void] {
+  const [tabId, setTabId] = useState(() =>
+    tabIdFromPathname(window.location.pathname),
+  );
+
+  useEffect(() => {
+    const onPopState = () =>
+      setTabId(tabIdFromPathname(window.location.pathname));
+    window.addEventListener("popstate", onPopState);
+    return () => window.removeEventListener("popstate", onPopState);
+  }, []);
+
+  const navigate = useCallback((nextTabId: string) => {
+    const path = pathnameFromTabId(nextTabId);
+    if (window.location.pathname !== path) {
+      window.history.pushState(null, "", path);
+    }
+    setTabId(nextTabId);
+  }, []);
+
+  return [tabId, navigate];
+}

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,5 +1,5 @@
 compatibility_date = "2024-06-11"
-assets = { directory = "./dist" }
+assets = { directory = "./dist", not_found_handling = "single-page-application" }
 
 [env.dev]
 


### PR DESCRIPTION
## Description

Adds client-side routing so each tab has its own shareable, bookmarkable URL (e.g. `https://studio.dya.cormoran.works/keymap`), and makes the app behave as a proper SPA for direct opens.

- New [`useUrlTab`](src/hooks/useUrlTab.ts) hook syncs the active tab with `window.location.pathname`: reads the tab from the URL on load, listens for `popstate` (browser back/forward), and `pushState`s on tab changes (no full page reload).
- `AppContent` in [`App.tsx`](src/App.tsx) now derives `activeTab` from the URL instead of local-only `useState`. Unknown/stale paths are canonicalized back to `/` via `replaceState`. The GA `page_path` event now reuses the same path-mapping helper (fixes the previous `/home` vs `/` mismatch).
- [`wrangler.toml`](wrangler.toml): added `not_found_handling = "single-page-application"` to the Cloudflare Workers assets config so any path is served the app shell (needed for direct opens / shared links against the deployed Worker).
- Added `.claude/launch.json` so the dev server can be previewed by tooling.
- `package-lock.json` / `node_modules`: refreshed to match the already-pinned `@cormoran/zmk-studio-react-hook` version — the local install was stale (0.0.1 instead of the lockfile's 0.0.2), which broke the dev build and 53 tests unrelated to this change. Tests are now green (358 passed, 1 skipped) and `tsc -b` is clean.

## Test plan

- [x] `npx tsc -b` passes with no errors
- [x] `npx jest` — 40 suites / 358 tests passed, 1 skipped
- [x] Verified in the dev server via browser automation:
  - Clicking a tab updates the URL (e.g. `/keymap`)
  - Browser back/forward restores the previous/next tab
  - Reloading directly on `/keymap` (simulating a direct link/shared URL) restores the Keymap tab after reconnecting
  - An unknown path (`/does-not-exist`) canonicalizes to `/` (home)

## CLA (Contributor License Agreement)

By submitting this pull request, I agree that my contributions
are licensed under the project's current license.

I also grant the maintainer(s) of this project the right to relicense
my contributions under any license, for use in future versions of the project.
This does not affect the license of any previously released versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)