### PR TITLE
feat: reflect ZMK custom-settings/macro/combo protocol updates

### DIFF
--- a/proto/cormoran/runtime_combo/runtime_combo.proto
+++ b/proto/cormoran/runtime_combo/runtime_combo.proto
@@ -8,6 +8,26 @@ message BehaviorBinding {
     uint32 param2 = 3;
 }
 
+// Tri-state override for the global slow-release setting.
+enum SlowReleaseOverride {
+    SLOW_RELEASE_OVERRIDE_INHERIT = 0;
+    SLOW_RELEASE_OVERRIDE_ON = 1;
+    SLOW_RELEASE_OVERRIDE_OFF = 2;
+}
+
+// Where a combo's currently effective configuration comes from.
+enum ComboSource {
+    // No stored value and no compile-time default.
+    COMBO_SOURCE_EMPTY = 0;
+    // A compile-time default, not overridden at runtime.
+    COMBO_SOURCE_DEFAULT = 1;
+    // A compile-time default exists, but a stored runtime value takes
+    // precedence (which may itself be a disabled tombstone).
+    COMBO_SOURCE_OVERRIDDEN = 2;
+    // A stored runtime value with no compile-time default.
+    COMBO_SOURCE_RUNTIME = 3;
+}
+
 message Combo {
     uint32 index = 1;
     string name = 2;
@@ -15,12 +35,20 @@ message Combo {
     BehaviorBinding behavior = 4;
     uint32 layer_mask = 6;
     bool enabled = 8;
+    // 0 means inherit the global timeout.
+    uint32 timeout_ms = 9;
+    // 0 means inherit the global require-prior-idle setting.
+    uint32 require_prior_idle_ms = 10;
+    SlowReleaseOverride slow_release_override = 11;
+    ComboSource source = 12;
 }
 
 message GlobalSettings {
     uint32 timeout_ms = 1;
     bool slow_release = 2;
     uint32 max_combo = 3;
+    // 0 disables the require-prior-idle guard.
+    uint32 require_prior_idle_ms = 4;
 }
 
 message ListCombosRequest {}
@@ -34,6 +62,11 @@ message SetComboRequest {
     uint32 layer_mask = 5;
     bool enabled = 7;
     bool persist = 8;
+    // 0 means inherit the global timeout.
+    uint32 timeout_ms = 9;
+    // 0 means inherit the global require-prior-idle setting.
+    uint32 require_prior_idle_ms = 10;
+    SlowReleaseOverride slow_release_override = 11;
 }
 
 message SetComboNameRequest {
@@ -47,6 +80,10 @@ message DeleteComboRequest {
     bool persist = 2;
 }
 
+// Erases a stored runtime override, restoring the compile-time default (or an
+// empty slot, if there is none).
+message ResetComboRequest { uint32 index = 1; }
+
 message GetGlobalSettingsRequest {}
 
 message SetTimeoutMsRequest {
@@ -56,6 +93,11 @@ message SetTimeoutMsRequest {
 
 message SetSlowReleaseRequest {
     bool slow_release = 1;
+    bool persist = 2;
+}
+
+message SetRequirePriorIdleMsRequest {
+    uint32 require_prior_idle_ms = 1;
     bool persist = 2;
 }
 
@@ -75,6 +117,8 @@ message Request {
         SetSlowReleaseRequest set_slow_release = 8;
         SaveRequest save = 9;
         DiscardRequest discard = 10;
+        SetRequirePriorIdleMsRequest set_require_prior_idle_ms = 11;
+        ResetComboRequest reset_combo = 12;
     }
 }
 

--- a/proto/cormoran/runtime_macro/runtime_macro.proto
+++ b/proto/cormoran/runtime_macro/runtime_macro.proto
@@ -2,78 +2,82 @@ syntax = "proto3";
 
 package cormoran.runtime_macro;
 
+// Raw create/delete/rename of a macro entry is intentionally NOT duplicated
+// here: it is already covered by the generic zmk-feature-custom-settings
+// Studio RPC (CreateSetting/DeleteSetting, subsystem "cormoran__runtime_macro",
+// key "macro/<name>"). This subsystem only carries macro-domain operations
+// that the generic RPC cannot express: structured step-level editing, slot
+// resolution, and playback-adjacent global settings.
+//
+// Every operational RPC below (get/set-step-count/set-step/append-step)
+// addresses a macro by its `slot` number, not its name - the same numeric
+// index the keymap behavior binding uses to play it. A macro's slot is only
+// known for certain by reading its `slot` field from ListMacrosResponse or
+// MacroDetail (e.g. right after creating it via the generic CreateSetting
+// RPC). Renaming/creating/deleting a macro still goes through the
+// name-keyed generic CreateSetting/DeleteSetting RPC, unaffected by this.
+
 message ListMacrosRequest {}
 
-message GetMacroRequest {
-  uint32 index = 1;
-}
+message GetMacroRequest { uint32 slot = 1; }
 
 message GetMacroGlobalSettingsRequest {}
 
 message MacroSummary {
-  uint32 index = 1;
-  string name = 2;
-  uint32 encoded_size = 3;
+    uint32 slot = 1;
+    string name = 2;
+    uint32 encoded_size = 3;
 }
 
 message BehaviorBinding {
-  uint32 behavior_id = 1;
-  uint32 param1 = 2;
-  uint32 param2 = 3;
+    uint32 behavior_id = 1;
+    uint32 param1 = 2;
+    uint32 param2 = 3;
 }
 
-message DelayStep {
-  uint32 delay_ms = 1;
-}
+message DelayStep { uint32 delay_ms = 1; }
 
-message KeyTapSequenceStep {
-  bytes packed_keys = 1;
-}
+message KeyTapSequenceStep { bytes packed_keys = 1; }
 
 message MacroStep {
-  oneof step {
-    BehaviorBinding down = 1;
-    BehaviorBinding up = 2;
-    BehaviorBinding tap = 3;
-    DelayStep delay = 4;
-    KeyTapSequenceStep key_tap_sequence = 5;
-  }
+    oneof step {
+        BehaviorBinding down = 1;
+        BehaviorBinding up = 2;
+        BehaviorBinding tap = 3;
+        DelayStep delay = 4;
+        KeyTapSequenceStep key_tap_sequence = 5;
+    }
 }
 
-message MacroSlot {
-  uint32 index = 1;
-  string name = 2;
-  repeated MacroStep steps = 3;
-  uint32 encoded_size = 4;
-}
-
-message SetMacroNameRequest {
-  uint32 index = 1;
-  string name = 2;
-  bool persist = 3;
+message MacroDetail {
+    uint32 slot = 1;
+    string name = 2;
+    repeated MacroStep steps = 3;
+    uint32 encoded_size = 4;
 }
 
 message SetMacroStepCountRequest {
-  uint32 index = 1;
-  uint32 step_count = 2;
-  bool persist = 3;
+    uint32 slot = 1;
+    uint32 step_count = 2;
+    bool persist = 3;
 }
 
 message SetMacroStepRequest {
-  uint32 index = 1;
-  uint32 step_index = 2;
-  MacroStep step = 3;
-  bool persist = 4;
+    uint32 slot = 1;
+    uint32 step_index = 2;
+    MacroStep step = 3;
+    bool persist = 4;
+}
+
+message AppendMacroStepRequest {
+    uint32 slot = 1;
+    MacroStep step = 2;
+    bool persist = 3;
 }
 
 message SetTapMsRequest {
-  uint32 tap_ms = 1;
-  bool persist = 2;
-}
-
-message DeleteMacroRequest {
-  uint32 index = 1;
-  bool persist = 2;
+    uint32 tap_ms = 1;
+    bool persist = 2;
 }
 
 message SaveMacrosRequest {}
@@ -81,55 +85,54 @@ message SaveMacrosRequest {}
 message DiscardMacrosRequest {}
 
 message Request {
-  oneof request_type {
-    ListMacrosRequest list_macros = 1;
-    GetMacroRequest get_macro = 2;
-    SetMacroNameRequest set_macro_name = 3;
-    SetMacroStepCountRequest set_macro_step_count = 4;
-    GetMacroGlobalSettingsRequest get_macro_global_settings = 5;
-    SetTapMsRequest set_tap_ms = 6;
-    SetMacroStepRequest set_macro_step = 7;
-    DeleteMacroRequest delete_macro = 8;
-    SaveMacrosRequest save_macros = 9;
-    DiscardMacrosRequest discard_macros = 10;
-  }
+    reserved 3,
+        8; // formerly set_macro_name, delete_macro - see generic CreateSetting/DeleteSetting
+    oneof request_type {
+        ListMacrosRequest list_macros = 1;
+        GetMacroRequest get_macro = 2;
+        SetMacroStepCountRequest set_macro_step_count = 4;
+        GetMacroGlobalSettingsRequest get_macro_global_settings = 5;
+        SetTapMsRequest set_tap_ms = 6;
+        SetMacroStepRequest set_macro_step = 7;
+        SaveMacrosRequest save_macros = 9;
+        DiscardMacrosRequest discard_macros = 10;
+        AppendMacroStepRequest append_macro_step = 11;
+    }
 }
 
-message ErrorResponse {
-  string message = 1;
-}
+message ErrorResponse { string message = 1; }
 
 message StatusResponse {
-  uint32 affected_count = 1;
-  string message = 2;
+    uint32 affected_count = 1;
+    string message = 2;
 }
 
 message ListMacrosResponse {
-  repeated MacroSummary macros = 1;
-  uint32 max_macro_bytes = 2;
-  uint32 max_name_length = 3;
+    repeated MacroSummary macros = 1;
+    uint32 max_macro_bytes = 2;
+    uint32 max_name_length = 3;
 }
 
-message GetMacroResponse {
-  MacroSlot macro = 1;
-}
+message GetMacroResponse { MacroDetail macro = 1; }
 
 message MacroGlobalSettings {
-  uint32 tap_ms = 1;
-  uint32 max_macro = 2;
-  uint32 key_press_behavior_id = 3;
+    uint32 tap_ms = 1;
+    uint32 max_entries = 2;
+    uint32 key_press_behavior_id = 3;
+    // Shared macro name+body pool budget (CONFIG_ZMK_RUNTIME_MACRO_POOL_BYTES)
+    // and the bytes currently occupied by every macro combined.
+    uint32 pool_bytes_total = 4;
+    uint32 pool_bytes_used = 5;
 }
 
-message GetMacroGlobalSettingsResponse {
-  MacroGlobalSettings settings = 1;
-}
+message GetMacroGlobalSettingsResponse { MacroGlobalSettings settings = 1; }
 
 message Response {
-  oneof response_type {
-    ErrorResponse error = 1;
-    StatusResponse status = 2;
-    ListMacrosResponse list_macros = 3;
-    GetMacroResponse get_macro = 4;
-    GetMacroGlobalSettingsResponse get_macro_global_settings = 5;
-  }
+    oneof response_type {
+        ErrorResponse error = 1;
+        StatusResponse status = 2;
+        ListMacrosResponse list_macros = 3;
+        GetMacroResponse get_macro = 4;
+        GetMacroGlobalSettingsResponse get_macro_global_settings = 5;
+    }
 }

--- a/proto/cormoran/zmk/custom_settings/custom_settings.proto
+++ b/proto/cormoran/zmk/custom_settings/custom_settings.proto
@@ -31,12 +31,21 @@ enum SettingNotificationKind {
     SETTING_NOTIFICATION_KIND_RESET = 4;
 }
 
+// A ZMK behavior binding: the behavior's local ID (see
+// CONFIG_ZMK_BEHAVIOR_LOCAL_IDS) plus its two binding parameters.
+message SettingBehaviorValue {
+    uint32 behavior_id = 1;
+    uint32 param1 = 2;
+    uint32 param2 = 3;
+}
+
 message SettingScalarValue {
     oneof value_type {
         bytes bytes_value = 1;
         int32 int32_value = 2;
         bool bool_value = 3;
         string string_value = 4;
+        SettingBehaviorValue behavior_value = 5;
     }
 }
 
@@ -56,6 +65,7 @@ message SettingValue {
         bool bool_value = 3;
         string string_value = 4;
         SettingArrayValue array_value = 5;
+        SettingBehaviorValue behavior_value = 6;
     }
 }
 
@@ -158,13 +168,49 @@ message PopBackArrayRequest {
     SettingWriteMode mode = 2;
 }
 
+// Create one entry in an RPC-creatable keyspace (see
+// ZMK_CUSTOM_SETTING_KEYSPACE_DEFINE). setting.key must start with the
+// target keyspace's key_prefix and fit its max_key_len; setting.array_index
+// is unused. Fails with an ErrorResponse if the keyspace is full, the key is
+// already in use, or the key does not match any registered keyspace prefix.
+message CreateSettingRequest {
+    SettingRef setting = 1;
+    SettingValue value = 2;
+    SettingWriteMode mode = 3;
+}
+
+// Delete one entry previously created by CreateSettingRequest (or persisted
+// by one in an earlier session). Fails with an ErrorResponse if setting.key
+// has no live entry.
+message DeleteSettingRequest { SettingRef setting = 1; }
+
 message SaveSettingsRequest { SettingScope scope = 1; }
 
 message DiscardSettingsRequest { SettingScope scope = 1; }
 
 message ResetSettingsRequest { SettingScope scope = 1; }
 
+// Write one chunk of a bytes/string setting value. The first chunk (offset =
+// 0) opens a transfer session and declares total_size; subsequent chunks for
+// the same setting must arrive in order (offset must equal the number of
+// bytes received so far). Set commit = true on the final chunk to validate
+// and apply the assembled value; the write only takes effect on commit, so a
+// half-transferred value is never observable.
+message WriteValueChunkRequest {
+    SettingRef setting = 1;
+    uint32 total_size = 2;
+    uint32 offset = 3;
+    bytes data = 4;
+    bool commit = 5;
+    SettingWriteMode mode = 6;
+}
+
 message Request {
+    // GetSetting / ListSettings stream a value of any size directly (see
+    // SettingValue.bytes_value / string_value in the .options file), so there
+    // is no read-chunk request.
+    reserved 9;
+
     oneof request_type {
         ListSettingsRequest list_settings = 1;
         GetSettingRequest get_setting = 2;
@@ -174,6 +220,9 @@ message Request {
         ResetSettingsRequest reset_settings = 6;
         PushBackArrayRequest push_back_array = 7;
         PopBackArrayRequest pop_back_array = 8;
+        WriteValueChunkRequest write_value_chunk = 10;
+        CreateSettingRequest create_setting = 11;
+        DeleteSettingRequest delete_setting = 12;
     }
 }
 
@@ -187,6 +236,10 @@ message StatusResponse {
 message GetSettingResponse { Setting setting = 1; }
 
 message Response {
+    // WriteValueChunk's ack is a plain StatusResponse (see
+    // handle_private_write_value_chunk); there is no dedicated chunk response.
+    reserved 4;
+
     oneof response_type {
         ErrorResponse error = 1;
         StatusResponse status = 2;

--- a/src/components/AdvancedSettingsSection.tsx
+++ b/src/components/AdvancedSettingsSection.tsx
@@ -18,12 +18,13 @@ import { useKeymap, type BehaviorDefinition } from "../hooks/useKeymap";
 import { useLanguage } from "../hooks/useLanguage";
 import {
   type Setting,
+  type SettingBehaviorValue,
   type SettingConstraint,
   type SettingScalarValue,
   type SettingValue,
 } from "../proto/cormoran/zmk/custom_settings/custom_settings";
 
-type ValueKind = "bytes" | "int32" | "bool" | "string" | "unknown";
+type ValueKind = "bytes" | "int32" | "bool" | "string" | "behavior" | "unknown";
 
 const MEMORY_WRITE_DEBOUNCE_MS = 500;
 
@@ -38,7 +39,19 @@ function valueKind(setting: Setting): ValueKind {
   if (scalar.int32Value !== undefined) return "int32";
   if (scalar.boolValue !== undefined) return "bool";
   if (scalar.stringValue !== undefined) return "string";
+  if (scalar.behaviorValue !== undefined) return "behavior";
   return "unknown";
+}
+
+function parseBehaviorValue(value: string): SettingBehaviorValue {
+  const [behaviorId = 0, param1 = 0, param2 = 0] = value
+    .split(",")
+    .map((token) => Number.parseInt(token.trim(), 10) || 0);
+  return { behaviorId, param1, param2 };
+}
+
+function formatBehaviorValue(value: SettingBehaviorValue): string {
+  return `${value.behaviorId},${value.param1},${value.param2}`;
 }
 
 function scalarToSettingValue(kind: ValueKind, value: unknown): SettingValue {
@@ -51,6 +64,9 @@ function scalarToSettingValue(kind: ValueKind, value: unknown): SettingValue {
   if (kind === "string") {
     return { stringValue: String(value) };
   }
+  if (kind === "behavior") {
+    return { behaviorValue: parseBehaviorValue(String(value)) };
+  }
   return { int32Value: Number(value) || 0 };
 }
 
@@ -62,6 +78,8 @@ function scalarToInputValue(setting: Setting): string {
   if (scalar.boolValue !== undefined)
     return scalar.boolValue ? "true" : "false";
   if (scalar.stringValue !== undefined) return scalar.stringValue;
+  if (scalar.behaviorValue !== undefined)
+    return formatBehaviorValue(scalar.behaviorValue);
   return "";
 }
 
@@ -121,6 +139,8 @@ function scalarOptionValue(value: SettingScalarValue): string {
   if (value.boolValue !== undefined) return value.boolValue ? "true" : "false";
   if (value.stringValue !== undefined) return value.stringValue;
   if (value.bytesValue !== undefined) return bytesToHex(value.bytesValue);
+  if (value.behaviorValue !== undefined)
+    return formatBehaviorValue(value.behaviorValue);
   return "";
 }
 
@@ -130,6 +150,8 @@ function scalarOptionToSettingValue(value: SettingScalarValue): SettingValue {
   if (value.stringValue !== undefined)
     return { stringValue: value.stringValue };
   if (value.bytesValue !== undefined) return { bytesValue: value.bytesValue };
+  if (value.behaviorValue !== undefined)
+    return { behaviorValue: value.behaviorValue };
   return {};
 }
 
@@ -469,6 +491,70 @@ function SettingEditor({
           )
         }
       />
+    );
+  }
+
+  if (kind === "behavior") {
+    // This is the SettingValue.behavior_value VALUE type (behaviorId +
+    // param1 + param2), distinct from SettingConstraintBehaviorId above
+    // (an INT32-typed value constrained to a behavior selector).
+    const behaviorValue = scalarValue(setting)?.behaviorValue ?? {
+      behaviorId: 0,
+      param1: 0,
+      param2: 0,
+    };
+    const behaviorList = Array.from(behaviors.values()).sort((a, b) =>
+      a.displayName.localeCompare(b.displayName),
+    );
+    const emitBehaviorValue = (next: Partial<SettingBehaviorValue>) =>
+      onChange({ behaviorValue: { ...behaviorValue, ...next } });
+    return (
+      <div className="flex flex-wrap items-center gap-2">
+        <select
+          className="input-field max-w-[10rem] text-sm"
+          value={behaviorValue.behaviorId}
+          onChange={(event) =>
+            emitBehaviorValue({
+              behaviorId: Number.parseInt(event.target.value, 10),
+            })
+          }
+        >
+          {behaviorList.map((behavior) => (
+            <option key={behavior.id} value={behavior.id}>
+              {behavior.displayName} ({behavior.id})
+            </option>
+          ))}
+          {behaviorList.length === 0 && (
+            <option value={behaviorValue.behaviorId}>
+              {behaviorValue.behaviorId}
+            </option>
+          )}
+        </select>
+        <input
+          className="input-field w-20 text-sm"
+          type="number"
+          title={t("Param 1")}
+          placeholder={t("Param 1")}
+          value={behaviorValue.param1}
+          onChange={(event) =>
+            emitBehaviorValue({
+              param1: Number.parseInt(event.target.value, 10) || 0,
+            })
+          }
+        />
+        <input
+          className="input-field w-20 text-sm"
+          type="number"
+          title={t("Param 2")}
+          placeholder={t("Param 2")}
+          value={behaviorValue.param2}
+          onChange={(event) =>
+            emitBehaviorValue({
+              param2: Number.parseInt(event.target.value, 10) || 0,
+            })
+          }
+        />
+      </div>
     );
   }
 

--- a/src/components/KeyboardLayout.tsx
+++ b/src/components/KeyboardLayout.tsx
@@ -56,7 +56,7 @@ interface KeyboardLayoutProps {
   /** Key positions currently highlighted in the preview */
   highlightedKeys?: ReadonlySet<number>;
   /** Runtime macro summaries for macro behavior display */
-  runtimeMacros?: Array<{ index: number; name?: string }>;
+  runtimeMacros?: Array<{ slot: number; name?: string }>;
 }
 
 type LayoutGeometry = Pick<

--- a/src/components/KeycodeSelector.tsx
+++ b/src/components/KeycodeSelector.tsx
@@ -56,7 +56,7 @@ interface KeycodeSelectorProps {
   layers: Array<{ id: number; name: string }>;
   keyboardLayout?: KeyboardLayoutType;
   behaviorQuickSelects?: string[]; // Optional list of behavior displayNameVariants for quick select
-  runtimeMacros?: Array<{ index: number; name?: string }>;
+  runtimeMacros?: Array<{ slot: number; name?: string }>;
 }
 
 // =============================================================================
@@ -146,7 +146,7 @@ function formatParamValue(
   paramNumber: 1 | 2,
   layers: Array<{ id: number; name: string }>,
   keyboardLayout?: KeyboardLayoutType,
-  runtimeMacros?: Array<{ index: number; name?: string }>,
+  runtimeMacros?: Array<{ slot: number; name?: string }>,
 ): string {
   const behavior = behaviorInfo.behavior;
   // From DYA Studio override metadata
@@ -480,8 +480,8 @@ export function KeycodeSelector({
             return runtimeMacros.length > 0 ? (
               <ButtonListSelector
                 options={runtimeMacros.map((macro) => ({
-                  value: macro.index,
-                  label: macro.name || `Macro ${macro.index}`,
+                  value: macro.slot,
+                  label: macro.name || `Macro ${macro.slot}`,
                 }))}
                 value={value}
                 onChange={onChange}

--- a/src/hooks/__tests__/useRuntimeCombo.test.tsx
+++ b/src/hooks/__tests__/useRuntimeCombo.test.tsx
@@ -1,9 +1,11 @@
-import { renderHook, waitFor } from "@testing-library/react";
+import { act, renderHook, waitFor } from "@testing-library/react";
 import { ZMKAppContext } from "@cormoran/zmk-studio-react-hook";
 import type { ReactNode } from "react";
 import { useRuntimeCombo } from "../useRuntimeCombo";
 import {
+  ComboSource,
   Response,
+  SlowReleaseOverride,
   type Combo,
 } from "../../proto/cormoran/runtime_combo/runtime_combo";
 
@@ -57,6 +59,10 @@ describe("useRuntimeCombo", () => {
       behavior: { behaviorId: 10, param1: 0x29, param2: 0 },
       layerMask: 0,
       enabled: true,
+      timeoutMs: 0,
+      requirePriorIdleMs: 0,
+      slowReleaseOverride: SlowReleaseOverride.SLOW_RELEASE_OVERRIDE_INHERIT,
+      source: ComboSource.COMBO_SOURCE_EMPTY,
     };
 
     mockCallRPC
@@ -95,6 +101,7 @@ describe("useRuntimeCombo", () => {
       timeoutMs: 50,
       slowRelease: false,
       maxCombo: 16,
+      requirePriorIdleMs: 0,
     });
     expect(result.current.error).toBe(null);
   });
@@ -109,5 +116,132 @@ describe("useRuntimeCombo", () => {
 
     expect(result.current.isAvailable).toBe(false);
     expect(result.current.combos).toEqual([]);
+  });
+
+  it("resets a combo to its default and reloads combos from the device", async () => {
+    const resetCombo: Combo = {
+      index: 0,
+      name: "Escape chord",
+      keyPositions: [0, 1],
+      behavior: { behaviorId: 10, param1: 0x29, param2: 0 },
+      layerMask: 0,
+      enabled: true,
+      timeoutMs: 0,
+      requirePriorIdleMs: 0,
+      slowReleaseOverride: SlowReleaseOverride.SLOW_RELEASE_OVERRIDE_INHERIT,
+      source: ComboSource.COMBO_SOURCE_DEFAULT,
+    };
+
+    mockCallRPC
+      .mockResolvedValueOnce(
+        Response.encode(
+          Response.create({ listCombos: { combos: [] } }),
+        ).finish(),
+      )
+      .mockResolvedValueOnce(
+        Response.encode(
+          Response.create({
+            getGlobalSettings: {
+              settings: {
+                timeoutMs: 50,
+                slowRelease: false,
+                maxCombo: 16,
+                requirePriorIdleMs: 0,
+              },
+            },
+          }),
+        ).finish(),
+      )
+      .mockResolvedValueOnce(
+        Response.encode(
+          Response.create({ status: { affectedCount: 1, message: "ok" } }),
+        ).finish(),
+      )
+      .mockResolvedValueOnce(
+        Response.encode(
+          Response.create({ listCombos: { combos: [resetCombo] } }),
+        ).finish(),
+      );
+
+    const wrapper = createWrapper({
+      state: {
+        connection: { isConnected: true },
+        customSubsystems: [{ index: 7, identifier: "cormoran__runtime_combo" }],
+      },
+      findSubsystem: (id: string) =>
+        id === "cormoran__runtime_combo"
+          ? { index: 7, identifier: "cormoran__runtime_combo" }
+          : null,
+    });
+
+    const { result } = renderHook(() => useRuntimeCombo(), { wrapper });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    let ok = false;
+    await act(async () => {
+      ok = await result.current.resetCombo(0);
+    });
+
+    expect(ok).toBe(true);
+    expect(result.current.combos).toEqual([resetCombo]);
+    expect(result.current.hasPendingChanges).toBe(true);
+  });
+
+  it("sets the global require-prior-idle duration", async () => {
+    mockCallRPC
+      .mockResolvedValueOnce(
+        Response.encode(
+          Response.create({ listCombos: { combos: [] } }),
+        ).finish(),
+      )
+      .mockResolvedValueOnce(
+        Response.encode(
+          Response.create({
+            getGlobalSettings: {
+              settings: {
+                timeoutMs: 50,
+                slowRelease: false,
+                maxCombo: 16,
+                requirePriorIdleMs: 0,
+              },
+            },
+          }),
+        ).finish(),
+      )
+      .mockResolvedValueOnce(
+        Response.encode(
+          Response.create({ status: { affectedCount: 1, message: "ok" } }),
+        ).finish(),
+      );
+
+    const wrapper = createWrapper({
+      state: {
+        connection: { isConnected: true },
+        customSubsystems: [{ index: 7, identifier: "cormoran__runtime_combo" }],
+      },
+      findSubsystem: (id: string) =>
+        id === "cormoran__runtime_combo"
+          ? { index: 7, identifier: "cormoran__runtime_combo" }
+          : null,
+    });
+
+    const { result } = renderHook(() => useRuntimeCombo(), { wrapper });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    let ok = false;
+    await act(async () => {
+      ok = await result.current.setRequirePriorIdleMs(30);
+    });
+
+    expect(ok).toBe(true);
+    expect(result.current.globalSettings).toEqual({
+      timeoutMs: 50,
+      slowRelease: false,
+      maxCombo: 16,
+      requirePriorIdleMs: 30,
+    });
+    expect(result.current.hasPendingChanges).toBe(true);
   });
 });

--- a/src/hooks/useCustomSettings.ts
+++ b/src/hooks/useCustomSettings.ts
@@ -13,6 +13,10 @@ import {
   type SettingScope,
   type SettingValue,
 } from "../proto/cormoran/zmk/custom_settings/custom_settings";
+import {
+  SINGLE_FRAME_VALUE_MAX,
+  writeValueChunked,
+} from "../lib/customSettingsChunkedValue";
 import { useLanguage } from "./useLanguage";
 
 export const CUSTOM_SETTINGS_IDENTIFIER = "cormoran_custom_settings";
@@ -47,6 +51,12 @@ export interface UseCustomSettingsReturn {
   resetSection: (customSubsystemIndex: number) => Promise<void>;
   discardSetting: (setting: Setting) => Promise<void>;
   resetSetting: (setting: Setting) => Promise<void>;
+  createSetting: (
+    key: string,
+    value: SettingValue,
+    mode: SettingWriteMode,
+  ) => Promise<Response>;
+  deleteSetting: (key: string) => Promise<Response>;
   clearError: () => void;
 }
 
@@ -282,21 +292,48 @@ export function useCustomSettings(): UseCustomSettingsReturn {
         ),
       );
 
+      const settingRef = {
+        customSubsystemIndex: setting.customSubsystemIndex,
+        key: setting.key,
+        source: setting.source,
+        arrayIndex: setting.value?.arrayValue?.index,
+      };
+
+      // A BYTES/STRING scalar value larger than one frame cannot ride the
+      // single-frame SettingValue field, so it is written over the chunked
+      // WriteValueChunk RPC. Arrays and small values keep the plain write
+      // path.
+      const isArray = value.arrayValue !== undefined;
+      const chunkBytes = !isArray
+        ? value.bytesValue !== undefined
+          ? value.bytesValue
+          : value.stringValue !== undefined
+            ? new TextEncoder().encode(value.stringValue)
+            : undefined
+        : undefined;
+
       try {
-        await callCustomRequest(
-          Request.create({
-            writeSetting: {
-              setting: {
-                customSubsystemIndex: setting.customSubsystemIndex,
-                key: setting.key,
-                source: setting.source,
-                arrayIndex: setting.value?.arrayValue?.index,
+        if (
+          chunkBytes !== undefined &&
+          chunkBytes.length > SINGLE_FRAME_VALUE_MAX
+        ) {
+          await writeValueChunked(
+            callCustomRequest,
+            settingRef,
+            chunkBytes,
+            SettingWriteMode.SETTING_WRITE_MODE_MEMORY,
+          );
+        } else {
+          await callCustomRequest(
+            Request.create({
+              writeSetting: {
+                setting: settingRef,
+                value: nextValue,
+                mode: SettingWriteMode.SETTING_WRITE_MODE_MEMORY,
               },
-              value: nextValue,
-              mode: SettingWriteMode.SETTING_WRITE_MODE_MEMORY,
-            },
-          }),
-        );
+            }),
+          );
+        }
         setError(null);
       } catch (err) {
         console.error("Failed to write custom setting:", err);
@@ -309,6 +346,40 @@ export function useCustomSettings(): UseCustomSettingsReturn {
       }
     },
     [callCustomRequest, loadSettings, t],
+  );
+
+  const createSetting = useCallback(
+    async (
+      key: string,
+      value: SettingValue,
+      mode: SettingWriteMode,
+    ): Promise<Response> => {
+      const response = await callCustomRequest(
+        Request.create({
+          createSetting: {
+            setting: { key },
+            value,
+            mode,
+          },
+        }),
+      );
+      return response;
+    },
+    [callCustomRequest],
+  );
+
+  const deleteSetting = useCallback(
+    async (key: string): Promise<Response> => {
+      const response = await callCustomRequest(
+        Request.create({
+          deleteSetting: {
+            setting: { key },
+          },
+        }),
+      );
+      return response;
+    },
+    [callCustomRequest],
   );
 
   const mutateScope = useCallback(
@@ -384,6 +455,8 @@ export function useCustomSettings(): UseCustomSettingsReturn {
       mutateScope(scopeForSetting(setting), "discardSettings"),
     resetSetting: (setting) =>
       mutateScope(scopeForSetting(setting), "resetSettings"),
+    createSetting,
+    deleteSetting,
     clearError: () => setError(null),
   };
 }

--- a/src/hooks/useRuntimeCombo.ts
+++ b/src/hooks/useRuntimeCombo.ts
@@ -13,9 +13,16 @@ import {
   type GlobalSettings,
   type BehaviorBinding,
   type StatusResponse,
+  type SlowReleaseOverride,
 } from "../proto/cormoran/runtime_combo/runtime_combo";
 
-export type { Combo, GlobalSettings, BehaviorBinding, StatusResponse };
+export type {
+  Combo,
+  GlobalSettings,
+  BehaviorBinding,
+  StatusResponse,
+  SlowReleaseOverride,
+};
 
 export const RUNTIME_COMBO_IDENTIFIER = "cormoran__runtime_combo";
 
@@ -30,6 +37,9 @@ export interface ComboInput {
   behavior: BehaviorBinding;
   layerMask: number;
   enabled: boolean;
+  timeoutMs: number;
+  requirePriorIdleMs: number;
+  slowReleaseOverride: SlowReleaseOverride;
 }
 
 export interface UseRuntimeComboReturn {
@@ -49,8 +59,13 @@ export interface UseRuntimeComboReturn {
     persist?: boolean,
   ) => Promise<boolean>;
   deleteCombo: (index: number, persist?: boolean) => Promise<boolean>;
+  resetCombo: (index: number) => Promise<boolean>;
   setTimeoutMs: (timeoutMs: number, persist?: boolean) => Promise<boolean>;
   setSlowRelease: (slowRelease: boolean, persist?: boolean) => Promise<boolean>;
+  setRequirePriorIdleMs: (
+    requirePriorIdleMs: number,
+    persist?: boolean,
+  ) => Promise<boolean>;
   saveChanges: () => Promise<StatusResponse | null>;
   discardChanges: () => Promise<StatusResponse | null>;
   clearError: () => void;
@@ -169,21 +184,9 @@ export function useRuntimeCombo(): UseRuntimeComboReturn {
           return false;
         }
         if (response?.status) {
-          setCombos((prev) => {
-            const existing = prev.find((item) => item.index === combo.index);
-            const nextCombo: Combo = {
-              index: combo.index,
-              name: existing?.name ?? "",
-              keyPositions: [...combo.keyPositions],
-              behavior: { ...combo.behavior },
-              layerMask: combo.layerMask,
-              enabled: combo.enabled,
-            };
-            return [
-              ...prev.filter((item) => item.index !== combo.index),
-              nextCombo,
-            ].sort((a, b) => a.index - b.index);
-          });
+          // The device derives `source` server-side, so refresh from the
+          // device instead of guessing the resulting Combo locally.
+          await loadCombos();
           if (!persist) {
             setHasPendingChanges(true);
           }
@@ -201,7 +204,7 @@ export function useRuntimeCombo(): UseRuntimeComboReturn {
       }
       return false;
     },
-    [callRuntimeComboRPC],
+    [callRuntimeComboRPC, loadCombos],
   );
 
   const setComboName = useCallback(
@@ -280,6 +283,39 @@ export function useRuntimeCombo(): UseRuntimeComboReturn {
     [callRuntimeComboRPC],
   );
 
+  const resetCombo = useCallback(
+    async (index: number): Promise<boolean> => {
+      setIsLoading(true);
+      setError(null);
+      try {
+        const response = await callRuntimeComboRPC(
+          Request.create({ resetCombo: { index } }),
+        );
+        if (response?.error) {
+          return false;
+        }
+        if (response?.status) {
+          // `source` is derived server-side, so refresh from the device
+          // rather than guessing the reset combo's fields locally.
+          await loadCombos();
+          setHasPendingChanges(true);
+          return true;
+        }
+      } catch (err) {
+        console.error("Failed to reset runtime combo:", err);
+        setError(
+          `Failed to reset runtime combo: ${
+            err instanceof Error ? err.message : "Unknown error"
+          }`,
+        );
+      } finally {
+        setIsLoading(false);
+      }
+      return false;
+    },
+    [callRuntimeComboRPC, loadCombos],
+  );
+
   const setTimeoutMs = useCallback(
     async (timeoutMs: number, persist = false): Promise<boolean> => {
       setIsLoading(true);
@@ -295,7 +331,12 @@ export function useRuntimeCombo(): UseRuntimeComboReturn {
           setGlobalSettings((prev) =>
             prev
               ? { ...prev, timeoutMs }
-              : { timeoutMs, slowRelease: false, maxCombo: 0 },
+              : {
+                  timeoutMs,
+                  slowRelease: false,
+                  maxCombo: 0,
+                  requirePriorIdleMs: 0,
+                },
           );
           if (!persist) {
             setHasPendingChanges(true);
@@ -332,7 +373,12 @@ export function useRuntimeCombo(): UseRuntimeComboReturn {
           setGlobalSettings((prev) =>
             prev
               ? { ...prev, slowRelease }
-              : { timeoutMs: 50, slowRelease, maxCombo: 0 },
+              : {
+                  timeoutMs: 50,
+                  slowRelease,
+                  maxCombo: 0,
+                  requirePriorIdleMs: 0,
+                },
           );
           if (!persist) {
             setHasPendingChanges(true);
@@ -343,6 +389,50 @@ export function useRuntimeCombo(): UseRuntimeComboReturn {
         console.error("Failed to set runtime combo slow release:", err);
         setError(
           `Failed to set runtime combo slow release: ${
+            err instanceof Error ? err.message : "Unknown error"
+          }`,
+        );
+      } finally {
+        setIsLoading(false);
+      }
+      return false;
+    },
+    [callRuntimeComboRPC],
+  );
+
+  const setRequirePriorIdleMs = useCallback(
+    async (requirePriorIdleMs: number, persist = false): Promise<boolean> => {
+      setIsLoading(true);
+      setError(null);
+      try {
+        const response = await callRuntimeComboRPC(
+          Request.create({
+            setRequirePriorIdleMs: { requirePriorIdleMs, persist },
+          }),
+        );
+        if (response?.error) {
+          return false;
+        }
+        if (response?.status) {
+          setGlobalSettings((prev) =>
+            prev
+              ? { ...prev, requirePriorIdleMs }
+              : {
+                  timeoutMs: 50,
+                  slowRelease: false,
+                  maxCombo: 0,
+                  requirePriorIdleMs,
+                },
+          );
+          if (!persist) {
+            setHasPendingChanges(true);
+          }
+          return true;
+        }
+      } catch (err) {
+        console.error("Failed to set runtime combo require-prior-idle:", err);
+        setError(
+          `Failed to set runtime combo require-prior-idle: ${
             err instanceof Error ? err.message : "Unknown error"
           }`,
         );
@@ -429,8 +519,10 @@ export function useRuntimeCombo(): UseRuntimeComboReturn {
     setCombo,
     setComboName,
     deleteCombo,
+    resetCombo,
     setTimeoutMs,
     setSlowRelease,
+    setRequirePriorIdleMs,
     saveChanges,
     discardChanges,
     clearError: () => setError(null),

--- a/src/hooks/useRuntimeMacro.ts
+++ b/src/hooks/useRuntimeMacro.ts
@@ -3,16 +3,25 @@ import { useCustomSubsystem } from "@cormoran/zmk-studio-react-hook";
 import {
   Request,
   Response,
+  type MacroDetail,
   type MacroGlobalSettings,
-  type MacroSlot,
   type MacroStep,
   type MacroSummary,
   type StatusResponse,
 } from "../proto/cormoran/runtime_macro/runtime_macro";
+import { SettingWriteMode } from "../proto/cormoran/zmk/custom_settings/custom_settings";
+import { encodeRuntimeMacroSteps } from "../lib/runtimeMacroCodec";
+import { useCustomSettings } from "./useCustomSettings";
 
-export type { MacroGlobalSettings, MacroSlot, MacroStep, MacroSummary };
+export type { MacroDetail, MacroGlobalSettings, MacroStep, MacroSummary };
 
 export const RUNTIME_MACRO_SUBSYSTEM_IDENTIFIER = "cormoran__runtime_macro";
+
+// The custom-settings keyspace prefix for runtime macro entries. Raw
+// create/delete/rename go through the generic custom-settings
+// CreateSetting/DeleteSetting RPC (subsystem "cormoran_custom_settings"),
+// not a runtime-macro-specific request - the firmware routes by key prefix.
+export const MACRO_KEY_PREFIX = "macro/";
 
 const CODEC = {
   encode: (request: Request) => Request.encode(request).finish(),
@@ -30,25 +39,26 @@ export interface UseRuntimeMacroReturn {
   error: string | null;
   clearError: () => void;
   loadMacros: () => Promise<void>;
-  getMacro: (index: number) => Promise<MacroSlot | null>;
-  setMacroName: (
-    index: number,
-    name: string,
-    persist?: boolean,
+  getMacro: (slot: number) => Promise<MacroDetail | null>;
+  createMacro: (name: string) => Promise<boolean>;
+  deleteMacro: (name: string) => Promise<boolean>;
+  renameMacro: (
+    oldName: string,
+    newName: string,
+    steps: MacroStep[],
   ) => Promise<boolean>;
   setMacroStepCount: (
-    index: number,
+    slot: number,
     stepCount: number,
     persist?: boolean,
   ) => Promise<boolean>;
   setMacroStep: (
-    index: number,
+    slot: number,
     stepIndex: number,
     step: MacroStep,
     persist?: boolean,
   ) => Promise<boolean>;
   setTapMs: (tapMs: number, persist?: boolean) => Promise<boolean>;
-  deleteMacro: (index: number, persist?: boolean) => Promise<boolean>;
   saveMacros: () => Promise<boolean>;
   discardMacros: () => Promise<boolean>;
 }
@@ -58,6 +68,7 @@ export function useRuntimeMacro(): UseRuntimeMacroReturn {
     RUNTIME_MACRO_SUBSYSTEM_IDENTIFIER,
     CODEC,
   );
+  const customSettings = useCustomSettings();
   const [macros, setMacros] = useState<MacroSummary[]>([]);
   const [globalSettings, setGlobalSettings] =
     useState<MacroGlobalSettings | null>(null);
@@ -166,12 +177,12 @@ export function useRuntimeMacro(): UseRuntimeMacroReturn {
   }, [callRpc, ready]);
 
   const getMacro = useCallback(
-    async (index: number): Promise<MacroSlot | null> => {
+    async (slot: number): Promise<MacroDetail | null> => {
       setIsLoading(true);
       setError(null);
 
       try {
-        const response = await callRpc(Request.create({ getMacro: { index } }));
+        const response = await callRpc(Request.create({ getMacro: { slot } }));
         return response?.getMacro?.macro ?? null;
       } catch (err) {
         console.error("Failed to get runtime macro:", err);
@@ -188,25 +199,14 @@ export function useRuntimeMacro(): UseRuntimeMacroReturn {
     [callRpc],
   );
 
-  const setMacroName = useCallback(
-    async (index: number, name: string, persist = false): Promise<boolean> => {
-      const status = await runMutation(
-        Request.create({ setMacroName: { index, name, persist } }),
-        persist,
-      );
-      return status !== null;
-    },
-    [runMutation],
-  );
-
   const setMacroStepCount = useCallback(
     async (
-      index: number,
+      slot: number,
       stepCount: number,
       persist = false,
     ): Promise<boolean> => {
       const status = await runMutation(
-        Request.create({ setMacroStepCount: { index, stepCount, persist } }),
+        Request.create({ setMacroStepCount: { slot, stepCount, persist } }),
         persist,
       );
       return status !== null;
@@ -216,14 +216,14 @@ export function useRuntimeMacro(): UseRuntimeMacroReturn {
 
   const setMacroStep = useCallback(
     async (
-      index: number,
+      slot: number,
       stepIndex: number,
       step: MacroStep,
       persist = false,
     ): Promise<boolean> => {
       const status = await runMutation(
         Request.create({
-          setMacroStep: { index, stepIndex, step, persist },
+          setMacroStep: { slot, stepIndex, step, persist },
         }),
         persist,
       );
@@ -241,8 +241,10 @@ export function useRuntimeMacro(): UseRuntimeMacroReturn {
       if (status) {
         setGlobalSettings((prev) => ({
           tapMs,
-          maxMacro: prev?.maxMacro ?? 0,
+          maxEntries: prev?.maxEntries ?? 0,
           keyPressBehaviorId: prev?.keyPressBehaviorId ?? 0,
+          poolBytesTotal: prev?.poolBytesTotal ?? 0,
+          poolBytesUsed: prev?.poolBytesUsed ?? 0,
         }));
       }
       return status !== null;
@@ -250,15 +252,112 @@ export function useRuntimeMacro(): UseRuntimeMacroReturn {
     [runMutation],
   );
 
-  const deleteMacro = useCallback(
-    async (index: number, persist = false): Promise<boolean> => {
-      const status = await runMutation(
-        Request.create({ deleteMacro: { index, persist } }),
-        persist,
-      );
-      return status !== null;
+  // Raw create/delete/rename go through the generic custom-settings
+  // CreateSetting/DeleteSetting RPC (subsystem "cormoran_custom_settings"),
+  // not a runtime-macro-specific request.
+  const createMacro = useCallback(
+    async (name: string): Promise<boolean> => {
+      setIsLoading(true);
+      setError(null);
+      try {
+        const response = await customSettings.createSetting(
+          MACRO_KEY_PREFIX + name,
+          { bytesValue: Uint8Array.from([1]) }, // format version, no steps
+          SettingWriteMode.SETTING_WRITE_MODE_MEMORY,
+        );
+        if (response.error) {
+          setError(response.error.message);
+          return false;
+        }
+        await loadMacros();
+        return true;
+      } catch (err) {
+        console.error("Failed to create runtime macro:", err);
+        setError(
+          `Failed to create runtime macro: ${
+            err instanceof Error ? err.message : "Unknown error"
+          }`,
+        );
+        return false;
+      } finally {
+        setIsLoading(false);
+      }
     },
-    [runMutation],
+    [customSettings, loadMacros],
+  );
+
+  const deleteMacro = useCallback(
+    async (name: string): Promise<boolean> => {
+      setIsLoading(true);
+      setError(null);
+      try {
+        const response = await customSettings.deleteSetting(
+          MACRO_KEY_PREFIX + name,
+        );
+        if (response.error) {
+          setError(response.error.message);
+          return false;
+        }
+        await loadMacros();
+        return true;
+      } catch (err) {
+        console.error("Failed to delete runtime macro:", err);
+        setError(
+          `Failed to delete runtime macro: ${
+            err instanceof Error ? err.message : "Unknown error"
+          }`,
+        );
+        return false;
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    [customSettings, loadMacros],
+  );
+
+  const renameMacro = useCallback(
+    async (
+      oldName: string,
+      newName: string,
+      steps: MacroStep[],
+    ): Promise<boolean> => {
+      setIsLoading(true);
+      setError(null);
+      try {
+        const encoded = encodeRuntimeMacroSteps(steps);
+        // Create the new name first (carrying the current body), then delete
+        // the old one - so a failure never loses data.
+        const createResponse = await customSettings.createSetting(
+          MACRO_KEY_PREFIX + newName,
+          { bytesValue: encoded },
+          SettingWriteMode.SETTING_WRITE_MODE_MEMORY,
+        );
+        if (createResponse.error) {
+          setError(createResponse.error.message);
+          return false;
+        }
+        const deleteResponse = await customSettings.deleteSetting(
+          MACRO_KEY_PREFIX + oldName,
+        );
+        if (deleteResponse.error) {
+          setError(deleteResponse.error.message);
+          return false;
+        }
+        await loadMacros();
+        return true;
+      } catch (err) {
+        console.error("Failed to rename runtime macro:", err);
+        setError(
+          `Failed to rename runtime macro: ${
+            err instanceof Error ? err.message : "Unknown error"
+          }`,
+        );
+        return false;
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    [customSettings, loadMacros],
   );
 
   const saveMacros = useCallback(async (): Promise<boolean> => {
@@ -307,11 +406,12 @@ export function useRuntimeMacro(): UseRuntimeMacroReturn {
     clearError,
     loadMacros,
     getMacro,
-    setMacroName,
+    createMacro,
+    deleteMacro,
+    renameMacro,
     setMacroStepCount,
     setMacroStep,
     setTapMs,
-    deleteMacro,
     saveMacros,
     discardMacros,
   };

--- a/src/i18n/translations.ts
+++ b/src/i18n/translations.ts
@@ -324,7 +324,8 @@ const ja: Record<string, string> = {
   "Runtime macro subsystem not found. Build firmware with":
     "ランタイムマクロサブシステムが見つかりません。ファームウェアに",
   Slots: "スロット",
-  "Macro {{index}}": "マクロ {{index}}",
+  Macros: "マクロ一覧",
+  "Macro {{slot}}": "マクロ {{slot}}",
   "{{encodedSize}}/{{maxMacroBytes}} bytes":
     "{{encodedSize}}/{{maxMacroBytes}} バイト",
   "Global Settings": "グローバル設定",
@@ -341,6 +342,15 @@ const ja: Record<string, string> = {
   String: "文字列",
   "Remove step {{n}}": "ステップ {{n}} を削除",
   "Select a macro slot": "マクロスロットを選択",
+  "Select a macro": "マクロを選択してください",
+  "No macros yet. Create one below.":
+    "マクロがまだありません。下から作成してください。",
+  "No macros yet. Create one to get started.":
+    "マクロがまだありません。作成して始めましょう。",
+  "New macro name": "新しいマクロ名",
+  Create: "作成",
+  "Shared macro pool: {{used}}/{{total}} B":
+    "共有マクロプール: {{used}}/{{total}} B",
 
   "Configure runtime combo slots": "ランタイムコンボスロットを設定",
   "All layers": "すべてのレイヤー",
@@ -386,6 +396,21 @@ const ja: Record<string, string> = {
   "Save Combo": "コンボを保存",
   Slot: "スロット",
   Positions: "位置",
+  Empty: "空",
+  Default: "デフォルト",
+  Overridden: "上書き済み",
+  "Reset to Default": "デフォルトにリセット",
+  "Combo reset to default is pending.":
+    "コンボのデフォルトへのリセットが保留中です。",
+  "Timeout ms (0 = inherit global)":
+    "タイムアウト ms（0 = グローバル設定を継承）",
+  "Require prior idle ms (0 = inherit global)":
+    "事前アイドル時間 ms（0 = グローバル設定を継承）",
+  "Require prior idle ms (0 disables)": "事前アイドル時間 ms（0 で無効化）",
+  "Slow release override": "スローリリースの上書き",
+  "Inherit global": "グローバル設定を継承",
+  On: "オン",
+  Off: "オフ",
 
   "(hidden)": "（非表示）",
   Local: "ローカル",
@@ -764,6 +789,9 @@ const ja: Record<string, string> = {
   "Poor tracking surface.": "トラッキング表面の状態が良くありません。",
   "Surface tracking OK.": "表面トラッキングは正常です。",
   "init error": "初期化エラー",
+
+  "Param 1": "パラメータ1",
+  "Param 2": "パラメータ2",
 
   "Live sensor view": "センサーのライブビュー",
   "Capture Once": "1回キャプチャ",

--- a/src/lib/__tests__/customSettingsChunkedValue.test.ts
+++ b/src/lib/__tests__/customSettingsChunkedValue.test.ts
@@ -1,0 +1,168 @@
+import {
+  CHUNK_DATA_MAX,
+  SINGLE_FRAME_VALUE_MAX,
+  writeValueChunked,
+} from "../customSettingsChunkedValue";
+import {
+  Request,
+  Response,
+  SettingWriteMode,
+} from "../../proto/cormoran/zmk/custom_settings/custom_settings";
+
+describe("customSettingsChunkedValue", () => {
+  describe("constants", () => {
+    it("matches the documented single-frame and chunk limits", () => {
+      expect(SINGLE_FRAME_VALUE_MAX).toBe(64);
+      expect(CHUNK_DATA_MAX).toBe(128);
+    });
+  });
+
+  describe("writeValueChunked", () => {
+    it("sends a single chunk with commit=true for a small value", async () => {
+      const calls: Request[] = [];
+      const callRPC = jest.fn(async (request: Request): Promise<Response> => {
+        calls.push(request);
+        return { status: { affectedCount: 1, message: "ok" } };
+      });
+
+      const bytes = Uint8Array.from([1, 2, 3]);
+      await writeValueChunked(
+        callRPC,
+        { key: "macro/foo" },
+        bytes,
+        SettingWriteMode.SETTING_WRITE_MODE_MEMORY,
+      );
+
+      expect(calls).toHaveLength(1);
+      const chunk = calls[0].writeValueChunk!;
+      expect(chunk.setting).toEqual({ key: "macro/foo" });
+      expect(chunk.totalSize).toBe(3);
+      expect(chunk.offset).toBe(0);
+      expect(chunk.data).toEqual(bytes);
+      expect(chunk.commit).toBe(true);
+      expect(chunk.mode).toBe(SettingWriteMode.SETTING_WRITE_MODE_MEMORY);
+    });
+
+    it("splits a value larger than CHUNK_DATA_MAX into multiple chunks at the right boundaries", async () => {
+      const totalSize = CHUNK_DATA_MAX + 10;
+      const bytes = Uint8Array.from(
+        { length: totalSize },
+        (_, index) => index % 256,
+      );
+      const calls: Request[] = [];
+      const callRPC = jest.fn(async (request: Request): Promise<Response> => {
+        calls.push(request);
+        return { status: { affectedCount: 1, message: "ok" } };
+      });
+
+      await writeValueChunked(
+        callRPC,
+        { key: "macro/bar" },
+        bytes,
+        SettingWriteMode.SETTING_WRITE_MODE_PERSIST,
+      );
+
+      expect(calls).toHaveLength(2);
+
+      const first = calls[0].writeValueChunk!;
+      expect(first.offset).toBe(0);
+      expect(first.data.length).toBe(CHUNK_DATA_MAX);
+      expect(first.data).toEqual(bytes.slice(0, CHUNK_DATA_MAX));
+      expect(first.commit).toBe(false);
+      expect(first.totalSize).toBe(totalSize);
+      expect(first.mode).toBe(SettingWriteMode.SETTING_WRITE_MODE_PERSIST);
+
+      const second = calls[1].writeValueChunk!;
+      expect(second.offset).toBe(CHUNK_DATA_MAX);
+      expect(second.data.length).toBe(10);
+      expect(second.data).toEqual(bytes.slice(CHUNK_DATA_MAX));
+      expect(second.commit).toBe(true);
+    });
+
+    it("chunks a value that is an exact multiple of CHUNK_DATA_MAX", async () => {
+      const totalSize = CHUNK_DATA_MAX * 2;
+      const bytes = Uint8Array.from(
+        { length: totalSize },
+        (_, index) => index % 256,
+      );
+      const calls: Request[] = [];
+      const callRPC = jest.fn(async (request: Request): Promise<Response> => {
+        calls.push(request);
+        return { status: { affectedCount: 1, message: "ok" } };
+      });
+
+      await writeValueChunked(
+        callRPC,
+        { key: "macro/baz" },
+        bytes,
+        SettingWriteMode.SETTING_WRITE_MODE_MEMORY,
+      );
+
+      expect(calls).toHaveLength(2);
+      expect(calls[0].writeValueChunk!.commit).toBe(false);
+      expect(calls[0].writeValueChunk!.data.length).toBe(CHUNK_DATA_MAX);
+      expect(calls[1].writeValueChunk!.commit).toBe(true);
+      expect(calls[1].writeValueChunk!.data.length).toBe(CHUNK_DATA_MAX);
+      expect(calls[1].writeValueChunk!.offset).toBe(CHUNK_DATA_MAX);
+    });
+
+    it("writes a single commit=true chunk for a zero-length value", async () => {
+      const calls: Request[] = [];
+      const callRPC = jest.fn(async (request: Request): Promise<Response> => {
+        calls.push(request);
+        return { status: { affectedCount: 1, message: "ok" } };
+      });
+
+      await writeValueChunked(
+        callRPC,
+        { key: "macro/empty" },
+        new Uint8Array(),
+        SettingWriteMode.SETTING_WRITE_MODE_MEMORY,
+      );
+
+      expect(calls).toHaveLength(1);
+      expect(calls[0].writeValueChunk!.totalSize).toBe(0);
+      expect(calls[0].writeValueChunk!.offset).toBe(0);
+      expect(calls[0].writeValueChunk!.data.length).toBe(0);
+      expect(calls[0].writeValueChunk!.commit).toBe(true);
+    });
+
+    it("propagates an error from the RPC and stops sending further chunks", async () => {
+      const totalSize = CHUNK_DATA_MAX + 5;
+      const bytes = new Uint8Array(totalSize);
+      const callRPC = jest.fn(
+        async (): Promise<Response> => ({
+          error: { message: "device rejected chunk" },
+        }),
+      );
+
+      await expect(
+        writeValueChunked(
+          callRPC,
+          { key: "macro/err" },
+          bytes,
+          SettingWriteMode.SETTING_WRITE_MODE_MEMORY,
+        ),
+      ).rejects.toThrow("device rejected chunk");
+
+      expect(callRPC).toHaveBeenCalledTimes(1);
+    });
+
+    it("falls back to a generic error message when the RPC error has no message", async () => {
+      const callRPC = jest.fn(
+        async (): Promise<Response> => ({
+          error: { message: "" },
+        }),
+      );
+
+      await expect(
+        writeValueChunked(
+          callRPC,
+          { key: "macro/err2" },
+          Uint8Array.from([1]),
+          SettingWriteMode.SETTING_WRITE_MODE_MEMORY,
+        ),
+      ).rejects.toThrow("Write chunk failed");
+    });
+  });
+});

--- a/src/lib/behaviorMetadata.ts
+++ b/src/lib/behaviorMetadata.ts
@@ -72,8 +72,8 @@ export interface FormatContext {
   layers?: (Omit<Layer, "bindings"> & Partial<Pick<Layer, "bindings">>)[];
   /** Keyboard layout for localized keycode display */
   keyboardLayout?: import("./keyboardLayouts").KeyboardLayoutType;
-  /** Runtime macro summaries for resolving macro behavior param1 */
-  runtimeMacros?: Array<{ index: number; name?: string }>;
+  /** Runtime macro summaries for resolving macro behavior param1 (the macro's slot) */
+  runtimeMacros?: Array<{ slot: number; name?: string }>;
 }
 
 /**
@@ -314,15 +314,13 @@ const BEHAVIOR_METADATA_BASE: BehaviorMetadata[] = [
     param1Type: "macro",
     getDisplayText: (binding, context) => {
       const macro = context.runtimeMacros?.find(
-        (item) => item.index === binding.param1,
+        (item) => item.slot === binding.param1,
       );
       return `Macro ${macro?.name || binding.param1}`;
     },
     formatParam: (param1, _param2, paramNumber, context) => {
       if (paramNumber !== 1) return "";
-      const macro = context.runtimeMacros?.find(
-        (item) => item.index === param1,
-      );
+      const macro = context.runtimeMacros?.find((item) => item.slot === param1);
       return macro?.name || param1.toString();
     },
     description: "Execute macro",

--- a/src/lib/customSettingsChunkedValue.ts
+++ b/src/lib/customSettingsChunkedValue.ts
@@ -1,0 +1,63 @@
+// Chunked large-value write helper (mirrors the upstream
+// zmk-feature-custom-settings reference `chunkedValue.ts`).
+//
+// The RX path buffers a whole frame before nanopb decodes it, so a BYTES /
+// STRING value bigger than one frame still has to be written over several
+// WriteValueChunk RPCs. Reading does not need chunking: GetSetting/
+// ListSettings stream a value of any size directly.
+//
+// This helper takes a plain `callRPC(request) => Promise<Response>` so it can
+// be unit tested without a live connection.
+
+import {
+  Request,
+  Response,
+  SettingRef,
+  SettingWriteMode,
+} from "../proto/cormoran/zmk/custom_settings/custom_settings";
+
+// Largest value that still fits a single non-chunked SettingValue frame. A
+// value larger than this is written over the chunked RPC instead (reads of
+// any size go through the plain GetSetting response).
+export const SINGLE_FRAME_VALUE_MAX = 64;
+// Chunk payload size (matches WriteValueChunkRequest.data max_size:128 in the
+// proto options).
+export const CHUNK_DATA_MAX = 128;
+
+export type CallRPC = (request: Request) => Promise<Response>;
+
+// Write a large BYTES/STRING value by splitting it into CHUNK_DATA_MAX frames.
+// The first frame (offset 0) opens the transfer and declares total_size; the
+// final frame sets commit so the device validates and applies the assembled
+// value atomically.
+export async function writeValueChunked(
+  callRPC: CallRPC,
+  setting: SettingRef,
+  bytes: Uint8Array,
+  mode: SettingWriteMode,
+): Promise<void> {
+  const total = bytes.length;
+  let offset = 0;
+
+  do {
+    const end = Math.min(offset + CHUNK_DATA_MAX, total);
+    const data = bytes.slice(offset, end);
+    const commit = end >= total;
+    const resp = await callRPC(
+      Request.create({
+        writeValueChunk: {
+          setting,
+          totalSize: total,
+          offset,
+          data,
+          commit,
+          mode,
+        },
+      }),
+    );
+    if (resp.error) {
+      throw new Error(resp.error.message || "Write chunk failed");
+    }
+    offset = end;
+  } while (offset < total);
+}

--- a/src/lib/transport/__tests__/demo-custom-settings.test.ts
+++ b/src/lib/transport/__tests__/demo-custom-settings.test.ts
@@ -1,0 +1,222 @@
+import {
+  CustomSettingsHandler,
+  MACRO_KEYSPACE_PREFIX,
+} from "../demo-custom-settings";
+import {
+  Request,
+  SettingWriteMode,
+} from "../../../proto/cormoran/zmk/custom_settings/custom_settings";
+
+describe("demo-custom-settings CustomSettingsHandler", () => {
+  it("creates a new entry in the macro/ keyspace", () => {
+    const handler = new CustomSettingsHandler(3);
+    const response = handler.process(
+      Request.create({
+        createSetting: {
+          setting: { key: `${MACRO_KEYSPACE_PREFIX}foo` },
+          value: { bytesValue: Uint8Array.from([1]) },
+          mode: SettingWriteMode.SETTING_WRITE_MODE_MEMORY,
+        },
+      }),
+    );
+
+    expect(response.error).toBeUndefined();
+    expect(response.status?.affectedCount).toBe(1);
+
+    const entries = handler.keyspaceEntries(MACRO_KEYSPACE_PREFIX);
+    expect(entries).toHaveLength(1);
+    expect(entries[0].key).toBe(`${MACRO_KEYSPACE_PREFIX}foo`);
+    expect(entries[0].value.bytesValue).toEqual(Uint8Array.from([1]));
+  });
+
+  it("rejects creating a setting outside a registered keyspace", () => {
+    const handler = new CustomSettingsHandler(3);
+    const response = handler.process(
+      Request.create({
+        createSetting: {
+          setting: { key: "not_a_keyspace/foo" },
+          value: { bytesValue: Uint8Array.from([1]) },
+          mode: SettingWriteMode.SETTING_WRITE_MODE_MEMORY,
+        },
+      }),
+    );
+
+    expect(response.error).toBeDefined();
+  });
+
+  it("rejects creating a duplicate key", () => {
+    const handler = new CustomSettingsHandler(3);
+    const create = () =>
+      handler.process(
+        Request.create({
+          createSetting: {
+            setting: { key: `${MACRO_KEYSPACE_PREFIX}dup` },
+            value: { bytesValue: Uint8Array.from([1]) },
+            mode: SettingWriteMode.SETTING_WRITE_MODE_MEMORY,
+          },
+        }),
+      );
+
+    expect(create().error).toBeUndefined();
+    expect(create().error).toBeDefined();
+  });
+
+  it("deletes a previously created entry", () => {
+    const handler = new CustomSettingsHandler(3);
+    handler.process(
+      Request.create({
+        createSetting: {
+          setting: { key: `${MACRO_KEYSPACE_PREFIX}gone` },
+          value: { bytesValue: Uint8Array.from([1]) },
+          mode: SettingWriteMode.SETTING_WRITE_MODE_MEMORY,
+        },
+      }),
+    );
+
+    const response = handler.process(
+      Request.create({
+        deleteSetting: {
+          setting: { key: `${MACRO_KEYSPACE_PREFIX}gone` },
+        },
+      }),
+    );
+
+    expect(response.error).toBeUndefined();
+    expect(handler.keyspaceEntries(MACRO_KEYSPACE_PREFIX)).toHaveLength(0);
+  });
+
+  it("fails to delete a key with no live entry", () => {
+    const handler = new CustomSettingsHandler(3);
+    const response = handler.process(
+      Request.create({
+        deleteSetting: {
+          setting: { key: `${MACRO_KEYSPACE_PREFIX}missing` },
+        },
+      }),
+    );
+
+    expect(response.error).toBeDefined();
+  });
+
+  it("notifies keyspace change listeners on create/delete", () => {
+    const handler = new CustomSettingsHandler(3);
+    const onChange = jest.fn();
+    handler.onKeyspaceChange(onChange);
+
+    handler.process(
+      Request.create({
+        createSetting: {
+          setting: { key: `${MACRO_KEYSPACE_PREFIX}notify` },
+          value: { bytesValue: Uint8Array.from([1]) },
+          mode: SettingWriteMode.SETTING_WRITE_MODE_MEMORY,
+        },
+      }),
+    );
+    expect(onChange).toHaveBeenCalledTimes(1);
+
+    handler.process(
+      Request.create({
+        deleteSetting: {
+          setting: { key: `${MACRO_KEYSPACE_PREFIX}notify` },
+        },
+      }),
+    );
+    expect(onChange).toHaveBeenCalledTimes(2);
+  });
+
+  it("assembles a value written over multiple WriteValueChunk RPCs", () => {
+    const handler = new CustomSettingsHandler(3);
+    handler.process(
+      Request.create({
+        createSetting: {
+          setting: { key: `${MACRO_KEYSPACE_PREFIX}chunked` },
+          value: { bytesValue: Uint8Array.from([]) },
+          mode: SettingWriteMode.SETTING_WRITE_MODE_MEMORY,
+        },
+      }),
+    );
+
+    const first = Uint8Array.from({ length: 128 }, (_, i) => i % 256);
+    const second = Uint8Array.from([9, 9, 9]);
+    const total = first.length + second.length;
+
+    const chunk1 = handler.process(
+      Request.create({
+        writeValueChunk: {
+          setting: { key: `${MACRO_KEYSPACE_PREFIX}chunked` },
+          totalSize: total,
+          offset: 0,
+          data: first,
+          commit: false,
+          mode: SettingWriteMode.SETTING_WRITE_MODE_MEMORY,
+        },
+      }),
+    );
+    expect(chunk1.error).toBeUndefined();
+
+    const chunk2 = handler.process(
+      Request.create({
+        writeValueChunk: {
+          setting: { key: `${MACRO_KEYSPACE_PREFIX}chunked` },
+          totalSize: total,
+          offset: first.length,
+          data: second,
+          commit: true,
+          mode: SettingWriteMode.SETTING_WRITE_MODE_MEMORY,
+        },
+      }),
+    );
+    expect(chunk2.error).toBeUndefined();
+    expect(chunk2.status?.affectedCount).toBe(1);
+
+    const entries = handler.keyspaceEntries(MACRO_KEYSPACE_PREFIX);
+    expect(entries).toHaveLength(1);
+    expect(entries[0].value.bytesValue).toEqual(
+      Uint8Array.from([...first, ...second]),
+    );
+  });
+
+  it("rejects an out-of-order chunk", () => {
+    const handler = new CustomSettingsHandler(3);
+    handler.process(
+      Request.create({
+        createSetting: {
+          setting: { key: `${MACRO_KEYSPACE_PREFIX}bad` },
+          value: { bytesValue: Uint8Array.from([]) },
+          mode: SettingWriteMode.SETTING_WRITE_MODE_MEMORY,
+        },
+      }),
+    );
+
+    const response = handler.process(
+      Request.create({
+        writeValueChunk: {
+          setting: { key: `${MACRO_KEYSPACE_PREFIX}bad` },
+          totalSize: 10,
+          offset: 5,
+          data: Uint8Array.from([1, 2, 3]),
+          commit: true,
+          mode: SettingWriteMode.SETTING_WRITE_MODE_MEMORY,
+        },
+      }),
+    );
+
+    expect(response.error).toBeDefined();
+  });
+
+  it("lists the built-in mock settings including the behavior-typed value", (done) => {
+    const handler = new CustomSettingsHandler(3);
+    const notifications: Uint8Array[] = [];
+    handler.notify((payload) => notifications.push(payload));
+
+    const response = handler.process(
+      Request.create({ listSettings: { scope: { source: 0xffffffff } } }),
+    );
+    expect(response.status?.affectedCount).toBeGreaterThan(0);
+
+    setTimeout(() => {
+      expect(notifications.length).toBe(response.status?.affectedCount);
+      done();
+    }, 250);
+  });
+});

--- a/src/lib/transport/__tests__/demo-runtime-macro.test.ts
+++ b/src/lib/transport/__tests__/demo-runtime-macro.test.ts
@@ -1,14 +1,24 @@
 import { RuntimeMacroHandler } from "../demo-runtime-macro";
+import {
+  CustomSettingsHandler,
+  MACRO_KEYSPACE_PREFIX,
+} from "../demo-custom-settings";
 import { Request } from "../../../proto/cormoran/runtime_macro/runtime_macro";
+import {
+  Request as CustomSettingsRequest,
+  SettingWriteMode,
+} from "../../../proto/cormoran/zmk/custom_settings/custom_settings";
 
 describe("RuntimeMacroHandler", () => {
+  let customSettings: CustomSettingsHandler;
   let handler: RuntimeMacroHandler;
 
   beforeEach(() => {
-    handler = new RuntimeMacroHandler();
+    customSettings = new CustomSettingsHandler(9);
+    handler = new RuntimeMacroHandler(customSettings);
   });
 
-  it("lists macro slots and global limits", () => {
+  it("lists macros and global limits", () => {
     const response = handler.process(Request.create({ listMacros: {} }));
 
     expect(response.listMacros?.macros.length).toBeGreaterThan(0);
@@ -16,30 +26,33 @@ describe("RuntimeMacroHandler", () => {
     expect(response.listMacros?.maxNameLength).toBe(64);
   });
 
-  it("gets an existing macro slot", () => {
-    const response = handler.process(
-      Request.create({ getMacro: { index: 0 } }),
-    );
+  it("gets an existing macro by slot", () => {
+    const response = handler.process(Request.create({ getMacro: { slot: 0 } }));
 
-    expect(response.getMacro?.macro?.index).toBe(0);
+    expect(response.getMacro?.macro?.slot).toBe(0);
     expect(response.getMacro?.macro?.name).toBe("Hello");
     expect(response.getMacro?.macro?.steps.length).toBeGreaterThan(0);
   });
 
-  it("updates macro name and steps in memory", () => {
-    const nameResponse = handler.process(
-      Request.create({
-        setMacroName: {
-          index: 2,
-          name: "Layer macro",
-          persist: false,
-        },
-      }),
+  it("reports pool usage in global settings", () => {
+    const response = handler.process(
+      Request.create({ getMacroGlobalSettings: {} }),
     );
+
+    expect(response.getMacroGlobalSettings?.settings?.poolBytesTotal).toBe(
+      1024,
+    );
+    expect(
+      response.getMacroGlobalSettings?.settings?.poolBytesUsed,
+    ).toBeGreaterThan(0);
+    expect(response.getMacroGlobalSettings?.settings?.maxEntries).toBe(8);
+  });
+
+  it("updates macro steps in memory", () => {
     const countResponse = handler.process(
       Request.create({
         setMacroStepCount: {
-          index: 2,
+          slot: 0,
           stepCount: 1,
           persist: false,
         },
@@ -48,7 +61,7 @@ describe("RuntimeMacroHandler", () => {
     const stepResponse = handler.process(
       Request.create({
         setMacroStep: {
-          index: 2,
+          slot: 0,
           stepIndex: 0,
           persist: false,
           step: {
@@ -62,24 +75,18 @@ describe("RuntimeMacroHandler", () => {
       }),
     );
     const getResponse = handler.process(
-      Request.create({ getMacro: { index: 2 } }),
+      Request.create({ getMacro: { slot: 0 } }),
     );
 
-    expect(nameResponse.status?.affectedCount).toBe(1);
     expect(countResponse.status?.affectedCount).toBe(1);
     expect(stepResponse.status?.affectedCount).toBe(1);
-    expect(getResponse.getMacro?.macro?.name).toBe("Layer macro");
     expect(getResponse.getMacro?.macro?.steps[0].tap?.param1).toBe(0x29);
   });
 
   it("discards memory-only changes", () => {
     handler.process(
       Request.create({
-        setMacroName: {
-          index: 0,
-          name: "Unsaved",
-          persist: false,
-        },
+        setMacroStepCount: { slot: 0, stepCount: 0, persist: false },
       }),
     );
 
@@ -87,31 +94,68 @@ describe("RuntimeMacroHandler", () => {
       Request.create({ discardMacros: {} }),
     );
     const getResponse = handler.process(
-      Request.create({ getMacro: { index: 0 } }),
+      Request.create({ getMacro: { slot: 0 } }),
     );
 
     expect(discardResponse.status?.affectedCount).toBe(1);
-    expect(getResponse.getMacro?.macro?.name).toBe("Hello");
+    expect(getResponse.getMacro?.macro?.steps.length).toBeGreaterThan(0);
   });
 
   it("persists saved changes", () => {
     handler.process(
       Request.create({
-        setMacroName: {
-          index: 0,
-          name: "Saved",
-          persist: false,
-        },
+        setMacroStepCount: { slot: 0, stepCount: 0, persist: false },
       }),
     );
 
     const saveResponse = handler.process(Request.create({ saveMacros: {} }));
     handler.process(Request.create({ discardMacros: {} }));
     const getResponse = handler.process(
-      Request.create({ getMacro: { index: 0 } }),
+      Request.create({ getMacro: { slot: 0 } }),
     );
 
     expect(saveResponse.status?.affectedCount).toBe(1);
-    expect(getResponse.getMacro?.macro?.name).toBe("Saved");
+    expect(getResponse.getMacro?.macro?.steps.length).toBe(0);
+  });
+
+  it("creates a new macro when the custom-settings keyspace gains a matching entry", () => {
+    const createResponse = customSettings.process(
+      CustomSettingsRequest.create({
+        createSetting: {
+          setting: { key: `${MACRO_KEYSPACE_PREFIX}new-macro` },
+          value: { bytesValue: Uint8Array.from([1]) },
+          mode: SettingWriteMode.SETTING_WRITE_MODE_MEMORY,
+        },
+      }),
+    );
+    expect(createResponse.error).toBeUndefined();
+
+    const listResponse = handler.process(Request.create({ listMacros: {} }));
+    const created = listResponse.listMacros?.macros.find(
+      (macro) => macro.name === "new-macro",
+    );
+    expect(created).toBeDefined();
+    expect(created?.encodedSize).toBe(0);
+  });
+
+  it("removes a macro when its custom-settings keyspace entry is deleted", () => {
+    const before = handler.process(Request.create({ listMacros: {} }));
+    expect(
+      before.listMacros?.macros.some((macro) => macro.name === "Hello"),
+    ).toBe(true);
+
+    const deleteResponse = customSettings.process(
+      CustomSettingsRequest.create({
+        deleteSetting: {
+          setting: { key: `${MACRO_KEYSPACE_PREFIX}Hello` },
+        },
+      }),
+    );
+    expect(deleteResponse.error).toBeUndefined();
+
+    const after = handler.process(Request.create({ listMacros: {} }));
+    expect(
+      after.listMacros?.macros.some((macro) => macro.name === "Hello"),
+    ).toBe(false);
   });
 });

--- a/src/lib/transport/demo-custom-settings.ts
+++ b/src/lib/transport/demo-custom-settings.ts
@@ -3,6 +3,7 @@ import {
   Request,
   Response,
   SettingNotificationKind,
+  SettingWriteMode,
   type Setting,
   type SettingScope,
   type SettingValue,
@@ -11,6 +12,20 @@ import {
 export const CUSTOM_SETTINGS_IDENTIFIER = "cormoran_custom_settings";
 
 const SOURCE_ALL = 0xffffffff;
+
+// A simple RPC-creatable keyspace: any key starting with this prefix can be
+// created/deleted via CreateSetting/DeleteSetting. This backs the demo
+// runtime-macro handler's "macro/<name>" entries (see
+// demo-runtime-macro.ts), mirroring firmware's
+// ZMK_CUSTOM_SETTING_KEYSPACE_DEFINE.
+export const MACRO_KEYSPACE_PREFIX = "macro/";
+
+interface PendingChunkedWrite {
+  totalSize: number;
+  received: number;
+  chunks: Uint8Array[];
+  mode: SettingWriteMode;
+}
 
 function createMockSettings(customSubsystemIndex: number): Setting[] {
   return [
@@ -90,6 +105,19 @@ function createMockSettings(customSubsystemIndex: number): Setting[] {
       },
       value: { bytesValue: Uint8Array.from([0x01, 0x02, 0x0a, 0xff]) },
     },
+    {
+      customSubsystemIndex,
+      key: "tap_behavior_binding",
+      source: 0,
+      hasUnsavedValue: false,
+      meta: {
+        confidentiality: 2,
+        readPermission: 0,
+        writePermission: 0,
+        constraints: [],
+      },
+      value: { behaviorValue: { behaviorId: 10, param1: 0, param2: 0 } },
+    },
   ];
 }
 
@@ -109,6 +137,9 @@ function cloneValue(value: SettingValue | undefined): SettingValue | undefined {
   }
   if (value.stringValue !== undefined) {
     return { stringValue: value.stringValue };
+  }
+  if (value.behaviorValue !== undefined) {
+    return { behaviorValue: { ...value.behaviorValue } };
   }
   if (value.arrayValue !== undefined) {
     return {
@@ -205,15 +236,48 @@ function settingValueForWrite(
 }
 
 export class CustomSettingsHandler {
+  private readonly customSubsystemIndex: number;
   private readonly defaults: Setting[];
   private persistent: Setting[];
   private settings: Setting[];
   private callbacks: ((data: Uint8Array) => void)[] = [];
+  private pendingChunks = new Map<string, PendingChunkedWrite>();
+  private keyspaceChangeCallbacks: (() => void)[] = [];
 
   constructor(customSubsystemIndex: number) {
+    this.customSubsystemIndex = customSubsystemIndex;
     this.defaults = createMockSettings(customSubsystemIndex);
     this.persistent = this.defaults.map(cloneSetting);
     this.settings = this.defaults.map(cloneSetting);
+  }
+
+  // Lets other demo handlers (e.g. demo-runtime-macro.ts) read/react to the
+  // "macro/" keyspace entries this handler owns, so create/delete via
+  // CreateSetting/DeleteSetting is visible to ListMacros without duplicating
+  // storage.
+  onKeyspaceChange(callback: () => void) {
+    this.keyspaceChangeCallbacks.push(callback);
+  }
+
+  keyspaceEntries(prefix: string): { key: string; value: SettingValue }[] {
+    return this.settings
+      .filter((setting) => setting.key.startsWith(prefix) && setting.value)
+      .map((setting) => ({ key: setting.key, value: setting.value! }));
+  }
+
+  // Seeds an initial keyspace entry (e.g. for demo mock data) without going
+  // through the CreateSetting request/notification path.
+  seedKeyspaceEntry(key: string, value: SettingValue) {
+    if (this.settings.some((setting) => setting.key === key)) {
+      return;
+    }
+    this.settings.push({
+      customSubsystemIndex: this.customSubsystemIndex,
+      key,
+      source: 0,
+      hasUnsavedValue: false,
+      value: cloneValue(value) ?? {},
+    });
   }
 
   process(request: Request): Response {
@@ -313,7 +377,122 @@ export class CustomSettingsHandler {
       return { status: { affectedCount: affected, message: "reset" } };
     }
 
+    if (request.createSetting?.setting) {
+      return this.handleCreateSetting(request.createSetting);
+    }
+
+    if (request.deleteSetting?.setting) {
+      return this.handleDeleteSetting(request.deleteSetting);
+    }
+
+    if (request.writeValueChunk?.setting) {
+      return this.handleWriteValueChunk(request.writeValueChunk);
+    }
+
     return { error: { message: "Not implemented" } };
+  }
+
+  private handleCreateSetting(
+    createSetting: NonNullable<Request["createSetting"]>,
+  ): Response {
+    const ref = createSetting.setting!;
+    const key = ref.key ?? "";
+    if (!key.startsWith(MACRO_KEYSPACE_PREFIX)) {
+      return {
+        error: { message: `No keyspace registered for key "${key}"` },
+      };
+    }
+    if (this.settings.some((setting) => setting.key === key)) {
+      return { error: { message: `Key already in use: ${key}` } };
+    }
+
+    const setting: Setting = {
+      customSubsystemIndex: this.customSubsystemIndex,
+      key,
+      source: 0,
+      hasUnsavedValue:
+        createSetting.mode !== SettingWriteMode.SETTING_WRITE_MODE_PERSIST,
+      value: cloneValue(createSetting.value) ?? {},
+    };
+    this.settings.push(setting);
+    if (createSetting.mode === SettingWriteMode.SETTING_WRITE_MODE_PERSIST) {
+      this.persistent.push(cloneSetting(setting));
+    }
+    this.notifySetting(setting);
+    this.notifyKeyspaceChange();
+    return { status: { affectedCount: 1, message: "created" } };
+  }
+
+  private handleDeleteSetting(
+    deleteSetting: NonNullable<Request["deleteSetting"]>,
+  ): Response {
+    const ref = deleteSetting.setting!;
+    const key = ref.key ?? "";
+    const index = this.settings.findIndex((setting) => setting.key === key);
+    if (index < 0) {
+      return { error: { message: `No live entry for key: ${key}` } };
+    }
+    this.settings.splice(index, 1);
+    this.persistent = this.persistent.filter((setting) => setting.key !== key);
+    this.notifyKeyspaceChange();
+    return { status: { affectedCount: 1, message: "deleted" } };
+  }
+
+  private handleWriteValueChunk(
+    writeValueChunk: NonNullable<Request["writeValueChunk"]>,
+  ): Response {
+    const ref = writeValueChunk.setting!;
+    const key = ref.key ?? "";
+    const { totalSize, offset, data, commit, mode } = writeValueChunk;
+
+    if (offset === 0) {
+      this.pendingChunks.set(key, {
+        totalSize,
+        received: 0,
+        chunks: [],
+        mode,
+      });
+    }
+
+    const pending = this.pendingChunks.get(key);
+    if (!pending || offset !== pending.received) {
+      this.pendingChunks.delete(key);
+      return { error: { message: "Chunk out of order" } };
+    }
+
+    pending.chunks.push(data);
+    pending.received += data.length;
+
+    if (!commit) {
+      return { status: { affectedCount: 0, message: "chunk received" } };
+    }
+
+    this.pendingChunks.delete(key);
+    const assembled = new Uint8Array(pending.received);
+    let cursor = 0;
+    for (const chunk of pending.chunks) {
+      assembled.set(chunk, cursor);
+      cursor += chunk.length;
+    }
+
+    const setting = this.settings.find((candidate) => candidate.key === key);
+    if (!setting) {
+      return { error: { message: "Setting not found" } };
+    }
+
+    setting.value = settingValueForWrite(setting, { bytesValue: assembled });
+    setting.hasUnsavedValue =
+      mode !== SettingWriteMode.SETTING_WRITE_MODE_PERSIST;
+    this.notifySetting(
+      setting,
+      SettingNotificationKind.SETTING_NOTIFICATION_KIND_VALUE_UPDATED,
+    );
+    this.notifyKeyspaceChange();
+    return { status: { affectedCount: 1, message: "written" } };
+  }
+
+  private notifyKeyspaceChange() {
+    this.keyspaceChangeCallbacks.forEach((callback) => callback());
   }
 
   notify(callback: (data: Uint8Array) => void) {

--- a/src/lib/transport/demo-runtime-combo.ts
+++ b/src/lib/transport/demo-runtime-combo.ts
@@ -5,6 +5,8 @@
  */
 
 import {
+  ComboSource,
+  SlowReleaseOverride,
   type BehaviorBinding,
   type Combo,
   type GlobalSettings,
@@ -32,6 +34,10 @@ const MOCK_COMBOS: Combo[] = [
     behavior: createBehavior(BEHAVIOR_KEY_PRESS, 0x29),
     layerMask: 0,
     enabled: true,
+    timeoutMs: 0,
+    requirePriorIdleMs: 0,
+    slowReleaseOverride: SlowReleaseOverride.SLOW_RELEASE_OVERRIDE_INHERIT,
+    source: ComboSource.COMBO_SOURCE_DEFAULT,
   },
   {
     index: 1,
@@ -40,6 +46,10 @@ const MOCK_COMBOS: Combo[] = [
     behavior: createBehavior(BEHAVIOR_KEY_PRESS, 0x2b),
     layerMask: 1,
     enabled: true,
+    timeoutMs: 0,
+    requirePriorIdleMs: 0,
+    slowReleaseOverride: SlowReleaseOverride.SLOW_RELEASE_OVERRIDE_INHERIT,
+    source: ComboSource.COMBO_SOURCE_DEFAULT,
   },
 ];
 
@@ -47,7 +57,11 @@ const MOCK_GLOBAL_SETTINGS: GlobalSettings = {
   timeoutMs: 50,
   slowRelease: false,
   maxCombo: 16,
+  requirePriorIdleMs: 0,
 };
+
+/** Slots that exist as compile-time defaults (i.e. seeded in MOCK_COMBOS). */
+const DEFAULT_SLOT_INDICES = new Set(MOCK_COMBOS.map((combo) => combo.index));
 
 function cloneCombo(combo: Combo): Combo {
   return {
@@ -88,8 +102,17 @@ export class RuntimeComboHandler {
     }
 
     if (request.setCombo !== undefined) {
-      const { index, keyPositions, behavior, layerMask, enabled, persist } =
-        request.setCombo;
+      const {
+        index,
+        keyPositions,
+        behavior,
+        layerMask,
+        enabled,
+        persist,
+        timeoutMs,
+        requirePriorIdleMs,
+        slowReleaseOverride,
+      } = request.setCombo;
       if (index >= this.globalSettings.maxCombo) {
         return { error: { message: `Invalid combo slot: ${index}` } };
       }
@@ -98,6 +121,7 @@ export class RuntimeComboHandler {
       }
 
       const current = this.combos.find((item) => item.index === index);
+      const hasCompileTimeDefault = DEFAULT_SLOT_INDICES.has(index);
       const nextCombo: Combo = {
         index,
         name: current?.name ?? "",
@@ -105,6 +129,12 @@ export class RuntimeComboHandler {
         behavior: { ...behavior },
         layerMask,
         enabled,
+        timeoutMs,
+        requirePriorIdleMs,
+        slowReleaseOverride,
+        source: hasCompileTimeDefault
+          ? ComboSource.COMBO_SOURCE_OVERRIDDEN
+          : ComboSource.COMBO_SOURCE_RUNTIME,
       };
       this.combos = [
         ...this.combos.filter((item) => item.index !== index),
@@ -137,6 +167,9 @@ export class RuntimeComboHandler {
     if (request.deleteCombo !== undefined) {
       const { index, persist } = request.deleteCombo;
       const before = this.combos.length;
+      // Deleting removes any stored runtime value for this slot, which is
+      // conceptually source = COMBO_SOURCE_EMPTY; represented here by
+      // filtering the combo out of the in-memory list entirely.
       this.combos = this.combos.filter((item) => item.index !== index);
       if (persist) {
         this.persistentCombos = this.combos.map(cloneCombo);
@@ -148,6 +181,26 @@ export class RuntimeComboHandler {
           affectedCount: before === this.combos.length ? 0 : 1,
           message: "Combo disabled",
         },
+      };
+    }
+
+    if (request.resetCombo !== undefined) {
+      const { index } = request.resetCombo;
+      const defaultCombo = MOCK_COMBOS.find((item) => item.index === index);
+      if (defaultCombo) {
+        this.combos = [
+          ...this.combos.filter((item) => item.index !== index),
+          {
+            ...cloneCombo(defaultCombo),
+            source: ComboSource.COMBO_SOURCE_DEFAULT,
+          },
+        ].sort((a, b) => a.index - b.index);
+      } else {
+        this.combos = this.combos.filter((item) => item.index !== index);
+      }
+      this.pendingChanges = true;
+      return {
+        status: { affectedCount: 1, message: "Combo reset to default" },
       };
     }
 
@@ -186,6 +239,25 @@ export class RuntimeComboHandler {
         status: {
           affectedCount: 1,
           message: "Runtime combo slow release written",
+        },
+      };
+    }
+
+    if (request.setRequirePriorIdleMs !== undefined) {
+      const { requirePriorIdleMs, persist } = request.setRequirePriorIdleMs;
+      if (requirePriorIdleMs < 0 || requirePriorIdleMs > 65535) {
+        return { error: { message: "Invalid require-prior-idle duration" } };
+      }
+      this.globalSettings.requirePriorIdleMs = requirePriorIdleMs;
+      if (persist) {
+        this.persistentGlobalSettings = { ...this.globalSettings };
+      } else {
+        this.pendingChanges = true;
+      }
+      return {
+        status: {
+          affectedCount: 1,
+          message: "Runtime combo require-prior-idle written",
         },
       };
     }

--- a/src/lib/transport/demo-runtime-macro.ts
+++ b/src/lib/transport/demo-runtime-macro.ts
@@ -1,30 +1,43 @@
 /**
  * Demo Runtime Macro Custom Subsystem Handler
  *
- * Provides mock runtime macro slots for demo mode.
+ * Provides mock runtime macros for demo mode. Macros are modeled as a
+ * variable list of named entries (not fixed slots): creation/deletion/rename
+ * of the macro identity is driven by the "macro/" keyspace in
+ * demo-custom-settings.ts (mirroring firmware, where raw create/delete/
+ * rename go through the generic custom-settings CreateSetting/DeleteSetting
+ * RPC). This handler owns the actual step data and global settings, and
+ * assigns/reclaims slots as keyspace entries come and go.
  */
 
 import {
+  type MacroDetail,
   type MacroGlobalSettings,
-  type MacroSlot,
   type MacroStep,
   type MacroSummary,
   type Request,
   type Response,
 } from "../../proto/cormoran/runtime_macro/runtime_macro";
 import { getRuntimeMacroEncodedSize } from "../runtimeMacroCodec";
+import {
+  CustomSettingsHandler,
+  MACRO_KEYSPACE_PREFIX,
+} from "./demo-custom-settings";
 
 export const RUNTIME_MACRO_IDENTIFIER = "cormoran__runtime_macro";
 
 const BEHAVIOR_KEY_PRESS = 10;
-const MAX_MACRO = 8;
+const MAX_ENTRIES = 8;
 const MAX_MACRO_BYTES = 64;
 const MAX_NAME_LENGTH = 64;
+const POOL_BYTES_TOTAL = 1024;
 
 const MOCK_GLOBAL_SETTINGS: MacroGlobalSettings = {
   tapMs: 30,
-  maxMacro: MAX_MACRO,
+  maxEntries: MAX_ENTRIES,
   keyPressBehaviorId: BEHAVIOR_KEY_PRESS,
+  poolBytesTotal: POOL_BYTES_TOTAL,
+  poolBytesUsed: 0,
 };
 
 function createTapStep(param1: number): MacroStep {
@@ -55,53 +68,77 @@ function cloneStep(step: MacroStep): MacroStep {
   return { tap: { ...(step.tap ?? { behaviorId: 0, param1: 0, param2: 0 }) } };
 }
 
-function cloneMacro(macro: MacroSlot): MacroSlot {
+function cloneMacro(macro: MacroDetail): MacroDetail {
   return {
     ...macro,
     steps: macro.steps.map(cloneStep),
   };
 }
 
-function createMacro(index: number, name = "", steps: MacroStep[] = []) {
+function createMacro(
+  slot: number,
+  name = "",
+  steps: MacroStep[] = [],
+): MacroDetail {
   return {
-    index,
+    slot,
     name,
     steps,
     encodedSize: steps.length === 0 ? 0 : getRuntimeMacroEncodedSize(steps),
   };
 }
 
-function macroSummary(macro: MacroSlot): MacroSummary {
+function macroSummary(macro: MacroDetail): MacroSummary {
   return {
-    index: macro.index,
+    slot: macro.slot,
     name: macro.name,
     encodedSize: macro.encodedSize,
   };
 }
 
-const MOCK_MACROS: MacroSlot[] = Array.from({ length: MAX_MACRO }, (_, index) =>
-  createMacro(index),
-);
-MOCK_MACROS[0] = createMacro(0, "Hello", [
-  createTapStep(0x0b),
-  createTapStep(0x08),
-  createTapStep(0x0f),
-  createTapStep(0x0f),
-  createTapStep(0x12),
-]);
-MOCK_MACROS[1] = createMacro(1, "Wait Enter", [
-  createDelayStep(100),
-  createTapStep(0x28),
-]);
+const SEED_MACROS: MacroDetail[] = [
+  createMacro(0, "Hello", [
+    createTapStep(0x0b),
+    createTapStep(0x08),
+    createTapStep(0x0f),
+    createTapStep(0x0f),
+    createTapStep(0x12),
+  ]),
+  createMacro(1, "Wait Enter", [createDelayStep(100), createTapStep(0x28)]),
+];
 
 export class RuntimeMacroHandler {
-  private persistentMacros: MacroSlot[] = MOCK_MACROS.map(cloneMacro);
-  private macros: MacroSlot[] = MOCK_MACROS.map(cloneMacro);
+  private readonly customSettings: CustomSettingsHandler;
+  private persistentMacros: MacroDetail[];
+  private macros: MacroDetail[];
   private persistentGlobalSettings: MacroGlobalSettings = {
     ...MOCK_GLOBAL_SETTINGS,
   };
   private globalSettings: MacroGlobalSettings = { ...MOCK_GLOBAL_SETTINGS };
   private pendingChanges = false;
+  private nextSlot = SEED_MACROS.length;
+
+  constructor(customSettings?: CustomSettingsHandler) {
+    // Fall back to an owned instance so this handler stays constructible on
+    // its own (e.g. in unit tests), while demo.ts wires the app's shared
+    // CustomSettingsHandler through for real coordination.
+    this.customSettings = customSettings ?? new CustomSettingsHandler(0);
+    this.macros = SEED_MACROS.map(cloneMacro);
+    this.persistentMacros = SEED_MACROS.map(cloneMacro);
+    this.refreshPoolUsage();
+
+    // Seed the custom-settings "macro/" keyspace with entries for the mock
+    // macros so create/delete/rename (routed through CreateSetting/
+    // DeleteSetting) can find them by name from the start.
+    for (const macro of this.macros) {
+      this.customSettings.seedKeyspaceEntry(
+        MACRO_KEYSPACE_PREFIX + macro.name,
+        { bytesValue: Uint8Array.from([1]) },
+      );
+    }
+
+    this.customSettings.onKeyspaceChange(() => this.syncFromKeyspace());
+  }
 
   process(request: Request): Response {
     if (request.listMacros !== undefined) {
@@ -115,10 +152,12 @@ export class RuntimeMacroHandler {
     }
 
     if (request.getMacro !== undefined) {
-      const macro = this.macros[request.getMacro.index];
+      const macro = this.macros.find(
+        (candidate) => candidate.slot === request.getMacro?.slot,
+      );
       if (!macro) {
         return {
-          error: { message: `Macro not found: ${request.getMacro.index}` },
+          error: { message: `Macro not found: ${request.getMacro.slot}` },
         };
       }
       return { getMacro: { macro: cloneMacro(macro) } };
@@ -142,23 +181,11 @@ export class RuntimeMacroHandler {
       return { status: { affectedCount: 1, message: "Tap time updated" } };
     }
 
-    if (request.setMacroName !== undefined) {
-      const { index, name, persist } = request.setMacroName;
-      const macro = this.macros[index];
-      if (!macro) {
-        return { error: { message: `Macro not found: ${index}` } };
-      }
-      macro.name = name.slice(0, MAX_NAME_LENGTH);
-      this.refreshEncodedSize(macro);
-      this.markChanged(persist);
-      return { status: { affectedCount: 1, message: "Macro name updated" } };
-    }
-
     if (request.setMacroStepCount !== undefined) {
-      const { index, stepCount, persist } = request.setMacroStepCount;
-      const macro = this.macros[index];
+      const { slot, stepCount, persist } = request.setMacroStepCount;
+      const macro = this.macros.find((candidate) => candidate.slot === slot);
       if (!macro) {
-        return { error: { message: `Macro not found: ${index}` } };
+        return { error: { message: `Macro not found: ${slot}` } };
       }
       if (stepCount > 32) {
         return { error: { message: "Too many macro steps" } };
@@ -174,10 +201,10 @@ export class RuntimeMacroHandler {
     }
 
     if (request.setMacroStep !== undefined) {
-      const { index, stepIndex, step, persist } = request.setMacroStep;
-      const macro = this.macros[index];
+      const { slot, stepIndex, step, persist } = request.setMacroStep;
+      const macro = this.macros.find((candidate) => candidate.slot === slot);
       if (!macro) {
-        return { error: { message: `Macro not found: ${index}` } };
+        return { error: { message: `Macro not found: ${slot}` } };
       }
       if (!step || stepIndex >= macro.steps.length) {
         return { error: { message: "Invalid macro step" } };
@@ -189,17 +216,20 @@ export class RuntimeMacroHandler {
       return { status: { affectedCount: 1, message: "Macro step updated" } };
     }
 
-    if (request.deleteMacro !== undefined) {
-      const { index, persist } = request.deleteMacro;
-      const macro = this.macros[index];
+    if (request.appendMacroStep !== undefined) {
+      const { slot, step, persist } = request.appendMacroStep;
+      const macro = this.macros.find((candidate) => candidate.slot === slot);
       if (!macro) {
-        return { error: { message: `Macro not found: ${index}` } };
+        return { error: { message: `Macro not found: ${slot}` } };
       }
-      macro.name = "";
-      macro.steps = [];
-      macro.encodedSize = 0;
+      if (!step) {
+        return { error: { message: "Invalid macro step" } };
+      }
+      macro.steps.push(cloneStep(step));
+      const error = this.refreshEncodedSize(macro);
+      if (error) return error;
       this.markChanged(persist);
-      return { status: { affectedCount: 1, message: "Macro deleted" } };
+      return { status: { affectedCount: 1, message: "Macro step appended" } };
     }
 
     if (request.saveMacros !== undefined) {
@@ -220,6 +250,7 @@ export class RuntimeMacroHandler {
       this.macros = this.persistentMacros.map(cloneMacro);
       this.globalSettings = { ...this.persistentGlobalSettings };
       this.pendingChanges = false;
+      this.refreshPoolUsage();
       return {
         status: {
           affectedCount,
@@ -231,6 +262,32 @@ export class RuntimeMacroHandler {
     return { error: { message: "Not implemented" } };
   }
 
+  // Reconciles this handler's macro list with the custom-settings "macro/"
+  // keyspace after a CreateSetting/DeleteSetting call: new keys become new
+  // (empty) macro slots, and keys that disappeared remove their macro.
+  private syncFromKeyspace() {
+    const entries = this.customSettings.keyspaceEntries(MACRO_KEYSPACE_PREFIX);
+    const namesInKeyspace = new Set(
+      entries.map((entry) => entry.key.slice(MACRO_KEYSPACE_PREFIX.length)),
+    );
+
+    // Remove macros whose keyspace entry is gone (deleted).
+    this.macros = this.macros.filter((macro) =>
+      namesInKeyspace.has(macro.name),
+    );
+
+    // Add a new (empty) macro for any keyspace entry with no matching macro
+    // yet (created).
+    for (const name of namesInKeyspace) {
+      if (!this.macros.some((macro) => macro.name === name)) {
+        this.macros.push(createMacro(this.nextSlot++, name));
+      }
+    }
+
+    this.pendingChanges = true;
+    this.refreshPoolUsage();
+  }
+
   private markChanged(persist: boolean) {
     if (persist) {
       this.persistentMacros = this.macros.map(cloneMacro);
@@ -239,9 +296,10 @@ export class RuntimeMacroHandler {
     } else {
       this.pendingChanges = true;
     }
+    this.refreshPoolUsage();
   }
 
-  private refreshEncodedSize(macro: MacroSlot): Response | null {
+  private refreshEncodedSize(macro: MacroDetail): Response | null {
     const encodedSize =
       macro.steps.length === 0 ? 0 : getRuntimeMacroEncodedSize(macro.steps);
     if (encodedSize > MAX_MACRO_BYTES) {
@@ -249,5 +307,16 @@ export class RuntimeMacroHandler {
     }
     macro.encodedSize = encodedSize;
     return null;
+  }
+
+  private refreshPoolUsage() {
+    const used = this.macros.reduce(
+      (total, macro) => total + macro.encodedSize + macro.name.length,
+      0,
+    );
+    this.globalSettings.poolBytesUsed = Math.min(
+      used,
+      this.globalSettings.poolBytesTotal,
+    );
   }
 }

--- a/src/lib/transport/demo.ts
+++ b/src/lib/transport/demo.ts
@@ -227,7 +227,7 @@ class Keyboard {
   private runtimeInputProcessorHandler = new RuntimeInputProcessorHandler();
   private runtimeSensorRotateHandler = new RuntimeSensorRotateHandler();
   private runtimeComboHandler = new RuntimeComboHandler();
-  private runtimeMacroHandler = new RuntimeMacroHandler();
+  private runtimeMacroHandler: RuntimeMacroHandler;
   private physicalLayoutsHandler = new PhysicalLayoutsHandler();
   private inputStreamHandler = new InputStreamHandler();
   private customSettingsHandler: CustomSettingsHandler;
@@ -254,6 +254,9 @@ class Keyboard {
   constructor() {
     this.customSettingsHandler = new CustomSettingsHandler(
       this.SETTINGS_SUBSYSTEM_INDEX,
+    );
+    this.runtimeMacroHandler = new RuntimeMacroHandler(
+      this.customSettingsHandler,
     );
     this.defaultLayerHandler = new DefaultLayerHandler(
       this.data.keymap.layers.length,

--- a/src/pages/ComboPage.tsx
+++ b/src/pages/ComboPage.tsx
@@ -24,6 +24,10 @@ import { useRuntimeMacro } from "../hooks/useRuntimeMacro";
 import type { Combo } from "../hooks/useRuntimeCombo";
 import { formatBehaviorBinding } from "../lib/behaviorMetadata";
 import type { KeyboardLayoutType } from "../lib/keyboardLayouts";
+import {
+  ComboSource,
+  SlowReleaseOverride,
+} from "../proto/cormoran/runtime_combo/runtime_combo";
 
 const MAX_POSITIONS_PER_COMBO = 16;
 const MAX_NAME_LENGTH = 64;
@@ -36,11 +40,34 @@ interface ComboDraft {
   behavior: BehaviorBinding;
   layerMask: number;
   enabled: boolean;
+  timeoutMs: number;
+  requirePriorIdleMs: number;
+  slowReleaseOverride: SlowReleaseOverride;
+  source: ComboSource;
 }
 
 interface GlobalSettingsDraft {
   timeoutMs: number | null;
   slowRelease: boolean | null;
+  requirePriorIdleMs: number | null;
+}
+
+function comboSourceLabel(
+  source: ComboSource,
+  t: (key: string) => string,
+): string {
+  switch (source) {
+    case ComboSource.COMBO_SOURCE_EMPTY:
+      return t("Empty");
+    case ComboSource.COMBO_SOURCE_DEFAULT:
+      return t("Default");
+    case ComboSource.COMBO_SOURCE_OVERRIDDEN:
+      return t("Overridden");
+    case ComboSource.COMBO_SOURCE_RUNTIME:
+      return t("Runtime");
+    default:
+      return t("Unknown");
+  }
 }
 
 function defaultBehaviorBinding(
@@ -90,6 +117,10 @@ function comboToDraft(
       : defaultBehaviorBinding(behaviors),
     layerMask: combo.layerMask,
     enabled: combo.enabled,
+    timeoutMs: combo.timeoutMs,
+    requirePriorIdleMs: combo.requirePriorIdleMs,
+    slowReleaseOverride: combo.slowReleaseOverride,
+    source: combo.source,
   };
 }
 
@@ -115,6 +146,10 @@ function createDraft(
     behavior: defaultBehaviorBinding(behaviors),
     layerMask: 0,
     enabled: true,
+    timeoutMs: 0,
+    requirePriorIdleMs: 0,
+    slowReleaseOverride: SlowReleaseOverride.SLOW_RELEASE_OVERRIDE_INHERIT,
+    source: ComboSource.COMBO_SOURCE_EMPTY,
   };
 }
 
@@ -141,7 +176,7 @@ function formatComboBehavior(
   behaviors: Map<number, BehaviorDefinition>,
   layers: Array<{ id: number; name: string }>,
   keyboardLayout: KeyboardLayoutType,
-  runtimeMacros: Array<{ index: number; name?: string }>,
+  runtimeMacros: Array<{ slot: number; name?: string }>,
   t: (key: string, params?: Record<string, number | string>) => string,
 ): string {
   const behavior = behaviors.get(binding.behaviorId);
@@ -171,6 +206,7 @@ export function ComboPage() {
   const [globalDraft, setGlobalDraft] = useState<GlobalSettingsDraft>({
     timeoutMs: null,
     slowRelease: null,
+    requirePriorIdleMs: null,
   });
   const [showBehaviorSelector, setShowBehaviorSelector] = useState(false);
   const [statusMessage, setStatusMessage] = useState<string | null>(null);
@@ -184,6 +220,10 @@ export function ComboPage() {
     globalDraft.slowRelease ??
     runtimeCombo.globalSettings?.slowRelease ??
     false;
+  const displayRequirePriorIdleMs =
+    globalDraft.requirePriorIdleMs ??
+    runtimeCombo.globalSettings?.requirePriorIdleMs ??
+    0;
   const keymapLayers = keymap.keymap?.layers;
   const physicalLayouts = keymap.physicalLayouts?.layouts;
   const activeLayoutIndex = keymap.physicalLayouts?.activeLayoutIndex;
@@ -278,6 +318,9 @@ export function ComboPage() {
       behavior: draft.behavior,
       layerMask: draft.layerMask,
       enabled: draft.enabled,
+      timeoutMs: draft.timeoutMs,
+      requirePriorIdleMs: draft.requirePriorIdleMs,
+      slowReleaseOverride: draft.slowReleaseOverride,
     });
     if (!comboSaved) return;
 
@@ -302,6 +345,23 @@ export function ComboPage() {
     }
   }, [draft.index, keymap.behaviors, maxCombo, runtimeCombo, selectDraft, t]);
 
+  const handleResetCombo = useCallback(async () => {
+    const resetIndex = draft.index;
+    const reset = await runtimeCombo.resetCombo(resetIndex);
+    if (reset) {
+      // resetCombo() already refreshed `combos` from the device, so look up
+      // the (possibly restored, possibly now-empty) slot in the fresh list.
+      const updated = runtimeCombo.combos.find(
+        (combo) => combo.index === resetIndex,
+      );
+      const nextDraft = updated
+        ? comboToDraft(updated, keymap.behaviors)
+        : createDraft(runtimeCombo.combos, maxCombo, keymap.behaviors);
+      selectDraft(nextDraft);
+      setStatusMessage(t("Combo reset to default is pending."));
+    }
+  }, [draft.index, keymap.behaviors, maxCombo, runtimeCombo, selectDraft, t]);
+
   const handleApplyGlobalSettings = useCallback(async () => {
     setStatusMessage(null);
     const current = runtimeCombo.globalSettings;
@@ -312,11 +372,26 @@ export function ComboPage() {
     if (!current || current.slowRelease !== displaySlowRelease) {
       ok = (await runtimeCombo.setSlowRelease(displaySlowRelease)) && ok;
     }
+    if (!current || current.requirePriorIdleMs !== displayRequirePriorIdleMs) {
+      ok =
+        (await runtimeCombo.setRequirePriorIdleMs(displayRequirePriorIdleMs)) &&
+        ok;
+    }
     if (ok) {
-      setGlobalDraft({ timeoutMs: null, slowRelease: null });
+      setGlobalDraft({
+        timeoutMs: null,
+        slowRelease: null,
+        requirePriorIdleMs: null,
+      });
       setStatusMessage(t("Global settings are pending."));
     }
-  }, [displaySlowRelease, displayTimeoutMs, runtimeCombo, t]);
+  }, [
+    displayRequirePriorIdleMs,
+    displaySlowRelease,
+    displayTimeoutMs,
+    runtimeCombo,
+    t,
+  ]);
 
   const handleSavePending = useCallback(async () => {
     const status = await runtimeCombo.saveChanges();
@@ -522,8 +597,13 @@ export function ComboPage() {
                                   index: combo.index,
                                 })}
                             </span>
-                            <span className="text-xs font-mono text-[var(--color-text-muted)]">
-                              #{combo.index}
+                            <span className="flex items-center gap-1.5 shrink-0">
+                              <span className="text-xs font-mono text-[var(--color-text-muted)]">
+                                #{combo.index}
+                              </span>
+                              <span className="text-[10px] px-1.5 py-0.5 rounded-full border border-[var(--color-border)] text-[var(--color-text-muted)]">
+                                {comboSourceLabel(combo.source, t)}
+                              </span>
                             </span>
                           </div>
                           <div className="mt-1 text-xs text-[var(--color-text-muted)] truncate">
@@ -600,13 +680,33 @@ export function ComboPage() {
                         <Switch.Thumb className="block w-4 h-4 rounded-full transition-transform data-[state=checked]:translate-x-5 translate-x-0.5 will-change-transform bg-white border border-[var(--color-border)]" />
                       </Switch.Root>
                     </div>
+                    <label className="block">
+                      <span className="text-xs text-[var(--color-text-muted)]">
+                        {t("Require prior idle ms (0 disables)")}
+                      </span>
+                      <input
+                        type="number"
+                        min={0}
+                        max={65535}
+                        className="mt-1 w-full px-3 py-2 rounded-lg bg-[var(--color-bg)] border border-[var(--color-border)] text-[var(--color-text)]"
+                        value={displayRequirePriorIdleMs}
+                        onChange={(event) =>
+                          setGlobalDraft((prev) => ({
+                            ...prev,
+                            requirePriorIdleMs: Number(event.target.value),
+                          }))
+                        }
+                      />
+                    </label>
                     <button
                       className="btn-electric w-full text-sm"
                       onClick={handleApplyGlobalSettings}
                       disabled={
                         runtimeCombo.isLoading ||
                         displayTimeoutMs < 1 ||
-                        displayTimeoutMs > 65535
+                        displayTimeoutMs > 65535 ||
+                        displayRequirePriorIdleMs < 0 ||
+                        displayRequirePriorIdleMs > 65535
                       }
                     >
                       {t("Apply Global Settings")}
@@ -641,9 +741,14 @@ export function ComboPage() {
                 <section className="glass-card p-4 tablet:p-6">
                   <div className="flex items-center justify-between gap-3 mb-4">
                     <div>
-                      <h2 className="text-sm font-medium text-[var(--color-text)]">
-                        {t("Combo Editor")}
-                      </h2>
+                      <div className="flex items-center gap-2">
+                        <h2 className="text-sm font-medium text-[var(--color-text)]">
+                          {t("Combo Editor")}
+                        </h2>
+                        <span className="text-[10px] px-1.5 py-0.5 rounded-full border border-[var(--color-border)] text-[var(--color-text-muted)]">
+                          {comboSourceLabel(draft.source, t)}
+                        </span>
+                      </div>
                       <p className="text-xs text-[var(--color-text-muted)]">
                         {selectedComboExists
                           ? t("Existing slot")
@@ -651,6 +756,18 @@ export function ComboPage() {
                       </p>
                     </div>
                     <div className="flex items-center gap-2">
+                      {(draft.source === ComboSource.COMBO_SOURCE_DEFAULT ||
+                        draft.source ===
+                          ComboSource.COMBO_SOURCE_OVERRIDDEN) && (
+                        <button
+                          className="btn-ghost text-sm flex items-center gap-1.5"
+                          onClick={handleResetCombo}
+                          disabled={runtimeCombo.isLoading}
+                        >
+                          <IconRestore size={16} />
+                          {t("Reset to Default")}
+                        </button>
+                      )}
                       <button
                         className="btn-ghost text-sm flex items-center gap-1.5"
                         onClick={handleDeleteCombo}
@@ -757,6 +874,80 @@ export function ComboPage() {
                         <Switch.Thumb className="block w-4 h-4 rounded-full transition-transform data-[state=checked]:translate-x-5 translate-x-0.5 will-change-transform bg-white border border-[var(--color-border)]" />
                       </Switch.Root>
                     </div>
+                  </div>
+
+                  <div className="grid grid-cols-1 tablet:grid-cols-3 gap-3 mb-4">
+                    <label>
+                      <span className="text-xs text-[var(--color-text-muted)]">
+                        {t("Timeout ms (0 = inherit global)")}
+                      </span>
+                      <input
+                        type="number"
+                        min={0}
+                        max={65535}
+                        className="mt-1 w-full px-3 py-2 rounded-lg bg-[var(--color-bg)] border border-[var(--color-border)] text-[var(--color-text)]"
+                        value={draft.timeoutMs}
+                        onChange={(event) =>
+                          setDraft((prev) => ({
+                            ...prev,
+                            timeoutMs: Number(event.target.value),
+                          }))
+                        }
+                      />
+                    </label>
+                    <label>
+                      <span className="text-xs text-[var(--color-text-muted)]">
+                        {t("Require prior idle ms (0 = inherit global)")}
+                      </span>
+                      <input
+                        type="number"
+                        min={0}
+                        max={65535}
+                        className="mt-1 w-full px-3 py-2 rounded-lg bg-[var(--color-bg)] border border-[var(--color-border)] text-[var(--color-text)]"
+                        value={draft.requirePriorIdleMs}
+                        onChange={(event) =>
+                          setDraft((prev) => ({
+                            ...prev,
+                            requirePriorIdleMs: Number(event.target.value),
+                          }))
+                        }
+                      />
+                    </label>
+                    <label>
+                      <span className="text-xs text-[var(--color-text-muted)]">
+                        {t("Slow release override")}
+                      </span>
+                      <select
+                        className="select-field mt-1 w-full text-sm"
+                        value={draft.slowReleaseOverride}
+                        onChange={(event) =>
+                          setDraft((prev) => ({
+                            ...prev,
+                            slowReleaseOverride: Number(
+                              event.target.value,
+                            ) as SlowReleaseOverride,
+                          }))
+                        }
+                      >
+                        <option
+                          value={
+                            SlowReleaseOverride.SLOW_RELEASE_OVERRIDE_INHERIT
+                          }
+                        >
+                          {t("Inherit global")}
+                        </option>
+                        <option
+                          value={SlowReleaseOverride.SLOW_RELEASE_OVERRIDE_ON}
+                        >
+                          {t("On")}
+                        </option>
+                        <option
+                          value={SlowReleaseOverride.SLOW_RELEASE_OVERRIDE_OFF}
+                        >
+                          {t("Off")}
+                        </option>
+                      </select>
+                    </label>
                   </div>
 
                   <div className="mb-4">

--- a/src/pages/MacroPage.tsx
+++ b/src/pages/MacroPage.tsx
@@ -16,15 +16,12 @@ import { KeyboardLayoutContext } from "../contexts/KeyboardLayoutContext";
 import { useKeymap } from "../hooks/useKeymap";
 import { useLanguage } from "../hooks/useLanguage";
 import { useRuntimeMacro } from "../hooks/useRuntimeMacro";
-import {
-  getRuntimeMacroEncodedSize,
-  RUNTIME_MACRO_FORMAT_VERSION,
-} from "../lib/runtimeMacroCodec";
+import { getRuntimeMacroEncodedSize } from "../lib/runtimeMacroCodec";
 import { formatBehaviorBinding } from "../lib/behaviorMetadata";
 import { createHidUsage, HID_USAGE_PAGE_KEYBOARD } from "../lib/keycodes";
 import type { BehaviorBinding as KeymapBehaviorBinding } from "../hooks/useKeymap";
 import type {
-  MacroSlot,
+  MacroDetail,
   MacroStep,
 } from "../proto/cormoran/runtime_macro/runtime_macro";
 
@@ -176,9 +173,9 @@ function createStep(
   return { [action]: nextBinding };
 }
 
-function formatMacroName(macro: MacroSlot | null, index: number): string {
+function formatMacroName(macro: MacroDetail | null, slot: number): string {
   if (macro?.name) return macro.name;
-  return `Macro ${index}`;
+  return `Macro ${slot}`;
 }
 
 function clampUInt32(value: number): number {
@@ -356,11 +353,15 @@ export function MacroPage() {
   const runtimeMacro = useRuntimeMacro();
   const keymap = useKeymap();
   const keyboardLayoutContext = useContext(KeyboardLayoutContext);
-  const [selectedIndex, setSelectedIndex] = useState<number | null>(null);
-  const [loadedMacro, setLoadedMacro] = useState<MacroSlot | null>(null);
+  const [selectedName, setSelectedName] = useState<string | null>(null);
+  const [loadedMacro, setLoadedMacro] = useState<MacroDetail | null>(null);
   const [editingStepIndex, setEditingStepIndex] = useState<number | null>(null);
   const [isSaving, setIsSaving] = useState(false);
   const [isDiscarding, setIsDiscarding] = useState(false);
+  const [isCreating, setIsCreating] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
+  const [newMacroName, setNewMacroName] = useState("");
+  const [renameDraft, setRenameDraft] = useState("");
   const [stringConversionError, setStringConversionError] = useState<
     string | null
   >(null);
@@ -413,11 +414,12 @@ export function MacroPage() {
     editingStepIndex !== null ? loadedMacro?.steps[editingStepIndex] : null;
 
   const loadMacro = useCallback(
-    async (index: number) => {
-      const macro = await runtimeMacro.getMacro(index);
+    async (slot: number) => {
+      const macro = await runtimeMacro.getMacro(slot);
       if (macro) {
-        setSelectedIndex(index);
+        setSelectedName(macro.name);
         setLoadedMacro(macro);
+        setRenameDraft(macro.name);
         setStringDraft(null);
         setStringConversionError(null);
       }
@@ -428,17 +430,22 @@ export function MacroPage() {
   useEffect(() => {
     const timer = window.setTimeout(() => {
       if (!runtimeMacro.isAvailable || runtimeMacro.macros.length === 0) {
-        setSelectedIndex(null);
+        setSelectedName(null);
         setLoadedMacro(null);
         return;
       }
 
-      const nextIndex = selectedIndex ?? runtimeMacro.macros[0].index;
-      if (selectedIndex === null) {
-        setSelectedIndex(nextIndex);
+      // Reselect by name (not slot) after a create/delete/rename, since a
+      // macro's slot can change identity across a re-list.
+      const stillSelected = runtimeMacro.macros.find(
+        (macro) => macro.name === selectedName,
+      );
+      const nextMacro = stillSelected ?? runtimeMacro.macros[0];
+      if (selectedName === null) {
+        setSelectedName(nextMacro.name);
       }
-      if (!loadedMacro || loadedMacro.index !== nextIndex) {
-        void loadMacro(nextIndex);
+      if (!loadedMacro || loadedMacro.slot !== nextMacro.slot) {
+        void loadMacro(nextMacro.slot);
       }
     }, 0);
     return () => window.clearTimeout(timer);
@@ -447,19 +454,28 @@ export function MacroPage() {
     loadedMacro,
     runtimeMacro.isAvailable,
     runtimeMacro.macros,
-    selectedIndex,
+    selectedName,
   ]);
 
-  const commitMacroName = useCallback(
-    async (name: string) => {
-      if (!loadedMacro) return;
-      const trimmedName = name.slice(0, runtimeMacro.maxNameLength);
+  const commitRename = useCallback(async () => {
+    if (!loadedMacro) return;
+    const trimmedName = renameDraft.slice(0, runtimeMacro.maxNameLength).trim();
+    if (!trimmedName || trimmedName === loadedMacro.name) {
+      setRenameDraft(loadedMacro.name);
+      return;
+    }
+    const ok = await runtimeMacro.renameMacro(
+      loadedMacro.name,
+      trimmedName,
+      loadedMacro.steps,
+    );
+    if (ok) {
+      setSelectedName(trimmedName);
       setLoadedMacro({ ...loadedMacro, name: trimmedName });
-      await runtimeMacro.setMacroName(loadedMacro.index, trimmedName);
-      await runtimeMacro.loadMacros();
-    },
-    [loadedMacro, runtimeMacro],
-  );
+    } else {
+      setRenameDraft(loadedMacro.name);
+    }
+  }, [loadedMacro, renameDraft, runtimeMacro]);
 
   const commitSteps = useCallback(
     async (steps: MacroStep[]) => {
@@ -478,14 +494,14 @@ export function MacroPage() {
       }
 
       const countUpdated = await runtimeMacro.setMacroStepCount(
-        loadedMacro.index,
+        loadedMacro.slot,
         steps.length,
       );
       if (!countUpdated) return false;
 
       for (const [stepIndex, step] of steps.entries()) {
         const stepUpdated = await runtimeMacro.setMacroStep(
-          loadedMacro.index,
+          loadedMacro.slot,
           stepIndex,
           step,
         );
@@ -643,18 +659,32 @@ export function MacroPage() {
 
   const handleDeleteMacro = useCallback(async () => {
     if (!loadedMacro) return;
-    const ok = await runtimeMacro.deleteMacro(loadedMacro.index);
-    if (ok) {
-      const emptyMacro = {
-        ...loadedMacro,
-        name: "",
-        steps: [],
-        encodedSize: RUNTIME_MACRO_FORMAT_VERSION === 1 ? 1 : 0,
-      };
-      setLoadedMacro(emptyMacro);
-      await runtimeMacro.loadMacros();
+    setIsDeleting(true);
+    try {
+      const ok = await runtimeMacro.deleteMacro(loadedMacro.name);
+      if (ok) {
+        setSelectedName(null);
+        setLoadedMacro(null);
+      }
+    } finally {
+      setIsDeleting(false);
     }
   }, [loadedMacro, runtimeMacro]);
+
+  const handleCreateMacro = useCallback(async () => {
+    const name = newMacroName.trim();
+    if (!name) return;
+    setIsCreating(true);
+    try {
+      const ok = await runtimeMacro.createMacro(name);
+      if (ok) {
+        setNewMacroName("");
+        setSelectedName(name);
+      }
+    } finally {
+      setIsCreating(false);
+    }
+  }, [newMacroName, runtimeMacro]);
 
   const handleSave = useCallback(async () => {
     setIsSaving(true);
@@ -669,13 +699,13 @@ export function MacroPage() {
     setIsDiscarding(true);
     try {
       await runtimeMacro.discardMacros();
-      if (selectedIndex !== null) {
-        await loadMacro(selectedIndex);
+      if (loadedMacro) {
+        await loadMacro(loadedMacro.slot);
       }
     } finally {
       setIsDiscarding(false);
     }
-  }, [loadMacro, runtimeMacro, selectedIndex]);
+  }, [loadMacro, loadedMacro, runtimeMacro]);
 
   const handleTapMsChange = useCallback(
     async (tapMs: number) => {
@@ -813,7 +843,7 @@ export function MacroPage() {
               <div className="glass-card p-3">
                 <div className="flex items-center justify-between mb-3">
                   <h2 className="text-sm font-medium text-[var(--color-text)]">
-                    {t("Slots")}
+                    {t("Macros")}
                   </h2>
                   {runtimeMacro.isLoading && (
                     <IconLoader2
@@ -823,19 +853,24 @@ export function MacroPage() {
                   )}
                 </div>
                 <div className="space-y-1">
+                  {runtimeMacro.macros.length === 0 && (
+                    <p className="text-sm text-[var(--color-text-muted)] py-4 text-center">
+                      {t("No macros yet. Create one below.")}
+                    </p>
+                  )}
                   {runtimeMacro.macros.map((macro) => (
                     <button
-                      key={macro.index}
+                      key={macro.name}
                       className={`w-full px-3 py-2 rounded-lg text-left transition-colors ${
-                        selectedIndex === macro.index
+                        selectedName === macro.name
                           ? "bg-[var(--color-electric)]/20 text-[var(--color-electric)] border border-[var(--color-electric)]/30"
                           : "text-[var(--color-text-secondary)] hover:bg-[var(--color-border)]"
                       }`}
-                      onClick={() => void loadMacro(macro.index)}
+                      onClick={() => void loadMacro(macro.slot)}
                     >
                       <span className="block text-sm font-medium truncate">
                         {macro.name ||
-                          t("Macro {{index}}", { index: macro.index })}
+                          t("Macro {{slot}}", { slot: macro.slot })}
                       </span>
                       <span className="block text-xs text-[var(--color-text-muted)]">
                         {t("{{encodedSize}}/{{maxMacroBytes}} bytes", {
@@ -845,6 +880,27 @@ export function MacroPage() {
                       </span>
                     </button>
                   ))}
+                </div>
+                <div className="mt-3 flex gap-2">
+                  <input
+                    className="flex-1 min-w-0 px-3 py-2 rounded-lg bg-[var(--color-bg)] border border-[var(--color-border)] text-sm text-[var(--color-text)] focus:outline-none focus:border-[var(--color-electric)]/50"
+                    value={newMacroName}
+                    maxLength={runtimeMacro.maxNameLength}
+                    placeholder={t("New macro name")}
+                    onChange={(event) => setNewMacroName(event.target.value)}
+                  />
+                  <button
+                    className="btn-electric text-sm flex items-center gap-1.5 px-3"
+                    onClick={() => void handleCreateMacro()}
+                    disabled={isCreating || !newMacroName.trim()}
+                  >
+                    {isCreating ? (
+                      <IconLoader2 size={16} className="animate-spin" />
+                    ) : (
+                      <IconPlus size={16} />
+                    )}
+                    {t("Create")}
+                  </button>
                 </div>
               </div>
 
@@ -873,6 +929,22 @@ export function MacroPage() {
                     }
                   />
                 </label>
+                {runtimeMacro.globalSettings &&
+                  runtimeMacro.globalSettings.poolBytesTotal > 0 && (
+                    <p
+                      className={`mt-3 text-xs ${
+                        runtimeMacro.globalSettings.poolBytesUsed >=
+                        runtimeMacro.globalSettings.poolBytesTotal
+                          ? "text-amber-400"
+                          : "text-[var(--color-text-muted)]"
+                      }`}
+                    >
+                      {t("Shared macro pool: {{used}}/{{total}} B", {
+                        used: runtimeMacro.globalSettings.poolBytesUsed,
+                        total: runtimeMacro.globalSettings.poolBytesTotal,
+                      })}
+                    </p>
+                  )}
               </div>
             </div>
 
@@ -886,24 +958,14 @@ export function MacroPage() {
                       </label>
                       <input
                         className="w-full px-3 py-2 rounded-lg bg-[var(--color-bg)] border border-[var(--color-border)] text-[var(--color-text)] focus:outline-none focus:border-[var(--color-electric)]/50"
-                        value={loadedMacro.name}
+                        value={renameDraft}
                         maxLength={runtimeMacro.maxNameLength}
                         placeholder={formatMacroName(
                           loadedMacro,
-                          loadedMacro.index,
-                        ).replace(
-                          `Macro ${loadedMacro.index}`,
-                          t("Macro {{index}}", { index: loadedMacro.index }),
+                          loadedMacro.slot,
                         )}
-                        onChange={(event) =>
-                          setLoadedMacro({
-                            ...loadedMacro,
-                            name: event.target.value,
-                          })
-                        }
-                        onBlur={(event) =>
-                          void commitMacroName(event.target.value)
-                        }
+                        onChange={(event) => setRenameDraft(event.target.value)}
+                        onBlur={() => void commitRename()}
                       />
                     </div>
                     <div>
@@ -928,12 +990,16 @@ export function MacroPage() {
                     </h2>
                     <div className="flex items-center gap-2">
                       <button
-                        className="btn-ghost text-sm flex items-center gap-1.5"
-                        onClick={handleDeleteMacro}
-                        disabled={runtimeMacro.isLoading}
+                        className="btn-ghost text-sm flex items-center gap-1.5 text-red-400"
+                        onClick={() => void handleDeleteMacro()}
+                        disabled={isDeleting || runtimeMacro.isLoading}
                       >
-                        <IconTrash size={16} />
-                        {t("Clear")}
+                        {isDeleting ? (
+                          <IconLoader2 size={16} className="animate-spin" />
+                        ) : (
+                          <IconTrash size={16} />
+                        )}
+                        {t("Delete")}
                       </button>
                       <button
                         className="btn-electric text-sm flex items-center gap-1.5"
@@ -1052,7 +1118,9 @@ export function MacroPage() {
               ) : (
                 <div className="p-6 text-center">
                   <p className="text-sm text-[var(--color-text-muted)]">
-                    {t("Select a macro slot")}
+                    {runtimeMacro.macros.length === 0
+                      ? t("No macros yet. Create one to get started.")
+                      : t("Select a macro")}
                   </p>
                 </div>
               )}

--- a/src/proto/cormoran/runtime_combo/runtime_combo.ts
+++ b/src/proto/cormoran/runtime_combo/runtime_combo.ts
@@ -9,6 +9,49 @@ import { BinaryReader, BinaryWriter } from "@bufbuild/protobuf/wire";
 
 export const protobufPackage = "cormoran.runtime_combo";
 
+/** Tri-state override for the global slow-release setting. */
+export const SlowReleaseOverride = {
+  SLOW_RELEASE_OVERRIDE_INHERIT: 0,
+  SLOW_RELEASE_OVERRIDE_ON: 1,
+  SLOW_RELEASE_OVERRIDE_OFF: 2,
+  UNRECOGNIZED: -1,
+} as const;
+
+export type SlowReleaseOverride = typeof SlowReleaseOverride[keyof typeof SlowReleaseOverride];
+
+export namespace SlowReleaseOverride {
+  export type SLOW_RELEASE_OVERRIDE_INHERIT = typeof SlowReleaseOverride.SLOW_RELEASE_OVERRIDE_INHERIT;
+  export type SLOW_RELEASE_OVERRIDE_ON = typeof SlowReleaseOverride.SLOW_RELEASE_OVERRIDE_ON;
+  export type SLOW_RELEASE_OVERRIDE_OFF = typeof SlowReleaseOverride.SLOW_RELEASE_OVERRIDE_OFF;
+  export type UNRECOGNIZED = typeof SlowReleaseOverride.UNRECOGNIZED;
+}
+
+/** Where a combo's currently effective configuration comes from. */
+export const ComboSource = {
+  /** COMBO_SOURCE_EMPTY - No stored value and no compile-time default. */
+  COMBO_SOURCE_EMPTY: 0,
+  /** COMBO_SOURCE_DEFAULT - A compile-time default, not overridden at runtime. */
+  COMBO_SOURCE_DEFAULT: 1,
+  /**
+   * COMBO_SOURCE_OVERRIDDEN - A compile-time default exists, but a stored runtime value takes
+   * precedence (which may itself be a disabled tombstone).
+   */
+  COMBO_SOURCE_OVERRIDDEN: 2,
+  /** COMBO_SOURCE_RUNTIME - A stored runtime value with no compile-time default. */
+  COMBO_SOURCE_RUNTIME: 3,
+  UNRECOGNIZED: -1,
+} as const;
+
+export type ComboSource = typeof ComboSource[keyof typeof ComboSource];
+
+export namespace ComboSource {
+  export type COMBO_SOURCE_EMPTY = typeof ComboSource.COMBO_SOURCE_EMPTY;
+  export type COMBO_SOURCE_DEFAULT = typeof ComboSource.COMBO_SOURCE_DEFAULT;
+  export type COMBO_SOURCE_OVERRIDDEN = typeof ComboSource.COMBO_SOURCE_OVERRIDDEN;
+  export type COMBO_SOURCE_RUNTIME = typeof ComboSource.COMBO_SOURCE_RUNTIME;
+  export type UNRECOGNIZED = typeof ComboSource.UNRECOGNIZED;
+}
+
 export interface BehaviorBinding {
   behaviorId: number;
   param1: number;
@@ -22,12 +65,20 @@ export interface Combo {
   behavior: BehaviorBinding | undefined;
   layerMask: number;
   enabled: boolean;
+  /** 0 means inherit the global timeout. */
+  timeoutMs: number;
+  /** 0 means inherit the global require-prior-idle setting. */
+  requirePriorIdleMs: number;
+  slowReleaseOverride: SlowReleaseOverride;
+  source: ComboSource;
 }
 
 export interface GlobalSettings {
   timeoutMs: number;
   slowRelease: boolean;
   maxCombo: number;
+  /** 0 disables the require-prior-idle guard. */
+  requirePriorIdleMs: number;
 }
 
 export interface ListCombosRequest {
@@ -44,6 +95,11 @@ export interface SetComboRequest {
   layerMask: number;
   enabled: boolean;
   persist: boolean;
+  /** 0 means inherit the global timeout. */
+  timeoutMs: number;
+  /** 0 means inherit the global require-prior-idle setting. */
+  requirePriorIdleMs: number;
+  slowReleaseOverride: SlowReleaseOverride;
 }
 
 export interface SetComboNameRequest {
@@ -57,6 +113,14 @@ export interface DeleteComboRequest {
   persist: boolean;
 }
 
+/**
+ * Erases a stored runtime override, restoring the compile-time default (or an
+ * empty slot, if there is none).
+ */
+export interface ResetComboRequest {
+  index: number;
+}
+
 export interface GetGlobalSettingsRequest {
 }
 
@@ -67,6 +131,11 @@ export interface SetTimeoutMsRequest {
 
 export interface SetSlowReleaseRequest {
   slowRelease: boolean;
+  persist: boolean;
+}
+
+export interface SetRequirePriorIdleMsRequest {
+  requirePriorIdleMs: number;
   persist: boolean;
 }
 
@@ -87,6 +156,8 @@ export interface Request {
   setSlowRelease?: SetSlowReleaseRequest | undefined;
   save?: SaveRequest | undefined;
   discard?: DiscardRequest | undefined;
+  setRequirePriorIdleMs?: SetRequirePriorIdleMsRequest | undefined;
+  resetCombo?: ResetComboRequest | undefined;
 }
 
 export interface ListCombosResponse {
@@ -189,7 +260,18 @@ export const BehaviorBinding: MessageFns<BehaviorBinding> = {
 };
 
 function createBaseCombo(): Combo {
-  return { index: 0, name: "", keyPositions: [], behavior: undefined, layerMask: 0, enabled: false };
+  return {
+    index: 0,
+    name: "",
+    keyPositions: [],
+    behavior: undefined,
+    layerMask: 0,
+    enabled: false,
+    timeoutMs: 0,
+    requirePriorIdleMs: 0,
+    slowReleaseOverride: 0,
+    source: 0,
+  };
 }
 
 export const Combo: MessageFns<Combo> = {
@@ -213,6 +295,18 @@ export const Combo: MessageFns<Combo> = {
     }
     if (message.enabled !== false) {
       writer.uint32(64).bool(message.enabled);
+    }
+    if (message.timeoutMs !== 0) {
+      writer.uint32(72).uint32(message.timeoutMs);
+    }
+    if (message.requirePriorIdleMs !== 0) {
+      writer.uint32(80).uint32(message.requirePriorIdleMs);
+    }
+    if (message.slowReleaseOverride !== 0) {
+      writer.uint32(88).int32(message.slowReleaseOverride);
+    }
+    if (message.source !== 0) {
+      writer.uint32(96).int32(message.source);
     }
     return writer;
   },
@@ -282,6 +376,38 @@ export const Combo: MessageFns<Combo> = {
           message.enabled = reader.bool();
           continue;
         }
+        case 9: {
+          if (tag !== 72) {
+            break;
+          }
+
+          message.timeoutMs = reader.uint32();
+          continue;
+        }
+        case 10: {
+          if (tag !== 80) {
+            break;
+          }
+
+          message.requirePriorIdleMs = reader.uint32();
+          continue;
+        }
+        case 11: {
+          if (tag !== 88) {
+            break;
+          }
+
+          message.slowReleaseOverride = reader.int32() as any;
+          continue;
+        }
+        case 12: {
+          if (tag !== 96) {
+            break;
+          }
+
+          message.source = reader.int32() as any;
+          continue;
+        }
       }
       if ((tag & 7) === 4 || tag === 0) {
         break;
@@ -304,12 +430,16 @@ export const Combo: MessageFns<Combo> = {
       : undefined;
     message.layerMask = object.layerMask ?? 0;
     message.enabled = object.enabled ?? false;
+    message.timeoutMs = object.timeoutMs ?? 0;
+    message.requirePriorIdleMs = object.requirePriorIdleMs ?? 0;
+    message.slowReleaseOverride = object.slowReleaseOverride ?? 0;
+    message.source = object.source ?? 0;
     return message;
   },
 };
 
 function createBaseGlobalSettings(): GlobalSettings {
-  return { timeoutMs: 0, slowRelease: false, maxCombo: 0 };
+  return { timeoutMs: 0, slowRelease: false, maxCombo: 0, requirePriorIdleMs: 0 };
 }
 
 export const GlobalSettings: MessageFns<GlobalSettings> = {
@@ -322,6 +452,9 @@ export const GlobalSettings: MessageFns<GlobalSettings> = {
     }
     if (message.maxCombo !== 0) {
       writer.uint32(24).uint32(message.maxCombo);
+    }
+    if (message.requirePriorIdleMs !== 0) {
+      writer.uint32(32).uint32(message.requirePriorIdleMs);
     }
     return writer;
   },
@@ -357,6 +490,14 @@ export const GlobalSettings: MessageFns<GlobalSettings> = {
           message.maxCombo = reader.uint32();
           continue;
         }
+        case 4: {
+          if (tag !== 32) {
+            break;
+          }
+
+          message.requirePriorIdleMs = reader.uint32();
+          continue;
+        }
       }
       if ((tag & 7) === 4 || tag === 0) {
         break;
@@ -374,6 +515,7 @@ export const GlobalSettings: MessageFns<GlobalSettings> = {
     message.timeoutMs = object.timeoutMs ?? 0;
     message.slowRelease = object.slowRelease ?? false;
     message.maxCombo = object.maxCombo ?? 0;
+    message.requirePriorIdleMs = object.requirePriorIdleMs ?? 0;
     return message;
   },
 };
@@ -459,7 +601,17 @@ export const GetComboRequest: MessageFns<GetComboRequest> = {
 };
 
 function createBaseSetComboRequest(): SetComboRequest {
-  return { index: 0, keyPositions: [], behavior: undefined, layerMask: 0, enabled: false, persist: false };
+  return {
+    index: 0,
+    keyPositions: [],
+    behavior: undefined,
+    layerMask: 0,
+    enabled: false,
+    persist: false,
+    timeoutMs: 0,
+    requirePriorIdleMs: 0,
+    slowReleaseOverride: 0,
+  };
 }
 
 export const SetComboRequest: MessageFns<SetComboRequest> = {
@@ -483,6 +635,15 @@ export const SetComboRequest: MessageFns<SetComboRequest> = {
     }
     if (message.persist !== false) {
       writer.uint32(64).bool(message.persist);
+    }
+    if (message.timeoutMs !== 0) {
+      writer.uint32(72).uint32(message.timeoutMs);
+    }
+    if (message.requirePriorIdleMs !== 0) {
+      writer.uint32(80).uint32(message.requirePriorIdleMs);
+    }
+    if (message.slowReleaseOverride !== 0) {
+      writer.uint32(88).int32(message.slowReleaseOverride);
     }
     return writer;
   },
@@ -552,6 +713,30 @@ export const SetComboRequest: MessageFns<SetComboRequest> = {
           message.persist = reader.bool();
           continue;
         }
+        case 9: {
+          if (tag !== 72) {
+            break;
+          }
+
+          message.timeoutMs = reader.uint32();
+          continue;
+        }
+        case 10: {
+          if (tag !== 80) {
+            break;
+          }
+
+          message.requirePriorIdleMs = reader.uint32();
+          continue;
+        }
+        case 11: {
+          if (tag !== 88) {
+            break;
+          }
+
+          message.slowReleaseOverride = reader.int32() as any;
+          continue;
+        }
       }
       if ((tag & 7) === 4 || tag === 0) {
         break;
@@ -574,6 +759,9 @@ export const SetComboRequest: MessageFns<SetComboRequest> = {
     message.layerMask = object.layerMask ?? 0;
     message.enabled = object.enabled ?? false;
     message.persist = object.persist ?? false;
+    message.timeoutMs = object.timeoutMs ?? 0;
+    message.requirePriorIdleMs = object.requirePriorIdleMs ?? 0;
+    message.slowReleaseOverride = object.slowReleaseOverride ?? 0;
     return message;
   },
 };
@@ -702,6 +890,52 @@ export const DeleteComboRequest: MessageFns<DeleteComboRequest> = {
     const message = createBaseDeleteComboRequest();
     message.index = object.index ?? 0;
     message.persist = object.persist ?? false;
+    return message;
+  },
+};
+
+function createBaseResetComboRequest(): ResetComboRequest {
+  return { index: 0 };
+}
+
+export const ResetComboRequest: MessageFns<ResetComboRequest> = {
+  encode(message: ResetComboRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    if (message.index !== 0) {
+      writer.uint32(8).uint32(message.index);
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): ResetComboRequest {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseResetComboRequest();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 8) {
+            break;
+          }
+
+          message.index = reader.uint32();
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  create(base?: DeepPartial<ResetComboRequest>): ResetComboRequest {
+    return ResetComboRequest.fromPartial(base ?? {});
+  },
+  fromPartial(object: DeepPartial<ResetComboRequest>): ResetComboRequest {
+    const message = createBaseResetComboRequest();
+    message.index = object.index ?? 0;
     return message;
   },
 };
@@ -856,6 +1090,64 @@ export const SetSlowReleaseRequest: MessageFns<SetSlowReleaseRequest> = {
   },
 };
 
+function createBaseSetRequirePriorIdleMsRequest(): SetRequirePriorIdleMsRequest {
+  return { requirePriorIdleMs: 0, persist: false };
+}
+
+export const SetRequirePriorIdleMsRequest: MessageFns<SetRequirePriorIdleMsRequest> = {
+  encode(message: SetRequirePriorIdleMsRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    if (message.requirePriorIdleMs !== 0) {
+      writer.uint32(8).uint32(message.requirePriorIdleMs);
+    }
+    if (message.persist !== false) {
+      writer.uint32(16).bool(message.persist);
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): SetRequirePriorIdleMsRequest {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseSetRequirePriorIdleMsRequest();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 8) {
+            break;
+          }
+
+          message.requirePriorIdleMs = reader.uint32();
+          continue;
+        }
+        case 2: {
+          if (tag !== 16) {
+            break;
+          }
+
+          message.persist = reader.bool();
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  create(base?: DeepPartial<SetRequirePriorIdleMsRequest>): SetRequirePriorIdleMsRequest {
+    return SetRequirePriorIdleMsRequest.fromPartial(base ?? {});
+  },
+  fromPartial(object: DeepPartial<SetRequirePriorIdleMsRequest>): SetRequirePriorIdleMsRequest {
+    const message = createBaseSetRequirePriorIdleMsRequest();
+    message.requirePriorIdleMs = object.requirePriorIdleMs ?? 0;
+    message.persist = object.persist ?? false;
+    return message;
+  },
+};
+
 function createBaseSaveRequest(): SaveRequest {
   return {};
 }
@@ -936,6 +1228,8 @@ function createBaseRequest(): Request {
     setSlowRelease: undefined,
     save: undefined,
     discard: undefined,
+    setRequirePriorIdleMs: undefined,
+    resetCombo: undefined,
   };
 }
 
@@ -970,6 +1264,12 @@ export const Request: MessageFns<Request> = {
     }
     if (message.discard !== undefined) {
       DiscardRequest.encode(message.discard, writer.uint32(82).fork()).join();
+    }
+    if (message.setRequirePriorIdleMs !== undefined) {
+      SetRequirePriorIdleMsRequest.encode(message.setRequirePriorIdleMs, writer.uint32(90).fork()).join();
+    }
+    if (message.resetCombo !== undefined) {
+      ResetComboRequest.encode(message.resetCombo, writer.uint32(98).fork()).join();
     }
     return writer;
   },
@@ -1061,6 +1361,22 @@ export const Request: MessageFns<Request> = {
           message.discard = DiscardRequest.decode(reader, reader.uint32());
           continue;
         }
+        case 11: {
+          if (tag !== 90) {
+            break;
+          }
+
+          message.setRequirePriorIdleMs = SetRequirePriorIdleMsRequest.decode(reader, reader.uint32());
+          continue;
+        }
+        case 12: {
+          if (tag !== 98) {
+            break;
+          }
+
+          message.resetCombo = ResetComboRequest.decode(reader, reader.uint32());
+          continue;
+        }
       }
       if ((tag & 7) === 4 || tag === 0) {
         break;
@@ -1104,6 +1420,13 @@ export const Request: MessageFns<Request> = {
       : undefined;
     message.discard = (object.discard !== undefined && object.discard !== null)
       ? DiscardRequest.fromPartial(object.discard)
+      : undefined;
+    message.setRequirePriorIdleMs =
+      (object.setRequirePriorIdleMs !== undefined && object.setRequirePriorIdleMs !== null)
+        ? SetRequirePriorIdleMsRequest.fromPartial(object.setRequirePriorIdleMs)
+        : undefined;
+    message.resetCombo = (object.resetCombo !== undefined && object.resetCombo !== null)
+      ? ResetComboRequest.fromPartial(object.resetCombo)
       : undefined;
     return message;
   },

--- a/src/proto/cormoran/runtime_macro/runtime_macro.ts
+++ b/src/proto/cormoran/runtime_macro/runtime_macro.ts
@@ -13,14 +13,14 @@ export interface ListMacrosRequest {
 }
 
 export interface GetMacroRequest {
-  index: number;
+  slot: number;
 }
 
 export interface GetMacroGlobalSettingsRequest {
 }
 
 export interface MacroSummary {
-  index: number;
+  slot: number;
   name: string;
   encodedSize: number;
 }
@@ -47,39 +47,34 @@ export interface MacroStep {
   keyTapSequence?: KeyTapSequenceStep | undefined;
 }
 
-export interface MacroSlot {
-  index: number;
+export interface MacroDetail {
+  slot: number;
   name: string;
   steps: MacroStep[];
   encodedSize: number;
 }
 
-export interface SetMacroNameRequest {
-  index: number;
-  name: string;
-  persist: boolean;
-}
-
 export interface SetMacroStepCountRequest {
-  index: number;
+  slot: number;
   stepCount: number;
   persist: boolean;
 }
 
 export interface SetMacroStepRequest {
-  index: number;
+  slot: number;
   stepIndex: number;
+  step: MacroStep | undefined;
+  persist: boolean;
+}
+
+export interface AppendMacroStepRequest {
+  slot: number;
   step: MacroStep | undefined;
   persist: boolean;
 }
 
 export interface SetTapMsRequest {
   tapMs: number;
-  persist: boolean;
-}
-
-export interface DeleteMacroRequest {
-  index: number;
   persist: boolean;
 }
 
@@ -92,14 +87,13 @@ export interface DiscardMacrosRequest {
 export interface Request {
   listMacros?: ListMacrosRequest | undefined;
   getMacro?: GetMacroRequest | undefined;
-  setMacroName?: SetMacroNameRequest | undefined;
   setMacroStepCount?: SetMacroStepCountRequest | undefined;
   getMacroGlobalSettings?: GetMacroGlobalSettingsRequest | undefined;
   setTapMs?: SetTapMsRequest | undefined;
   setMacroStep?: SetMacroStepRequest | undefined;
-  deleteMacro?: DeleteMacroRequest | undefined;
   saveMacros?: SaveMacrosRequest | undefined;
   discardMacros?: DiscardMacrosRequest | undefined;
+  appendMacroStep?: AppendMacroStepRequest | undefined;
 }
 
 export interface ErrorResponse {
@@ -118,13 +112,19 @@ export interface ListMacrosResponse {
 }
 
 export interface GetMacroResponse {
-  macro: MacroSlot | undefined;
+  macro: MacroDetail | undefined;
 }
 
 export interface MacroGlobalSettings {
   tapMs: number;
-  maxMacro: number;
+  maxEntries: number;
   keyPressBehaviorId: number;
+  /**
+   * Shared macro name+body pool budget (CONFIG_ZMK_RUNTIME_MACRO_POOL_BYTES)
+   * and the bytes currently occupied by every macro combined.
+   */
+  poolBytesTotal: number;
+  poolBytesUsed: number;
 }
 
 export interface GetMacroGlobalSettingsResponse {
@@ -174,13 +174,13 @@ export const ListMacrosRequest: MessageFns<ListMacrosRequest> = {
 };
 
 function createBaseGetMacroRequest(): GetMacroRequest {
-  return { index: 0 };
+  return { slot: 0 };
 }
 
 export const GetMacroRequest: MessageFns<GetMacroRequest> = {
   encode(message: GetMacroRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.index !== 0) {
-      writer.uint32(8).uint32(message.index);
+    if (message.slot !== 0) {
+      writer.uint32(8).uint32(message.slot);
     }
     return writer;
   },
@@ -197,7 +197,7 @@ export const GetMacroRequest: MessageFns<GetMacroRequest> = {
             break;
           }
 
-          message.index = reader.uint32();
+          message.slot = reader.uint32();
           continue;
         }
       }
@@ -214,7 +214,7 @@ export const GetMacroRequest: MessageFns<GetMacroRequest> = {
   },
   fromPartial(object: DeepPartial<GetMacroRequest>): GetMacroRequest {
     const message = createBaseGetMacroRequest();
-    message.index = object.index ?? 0;
+    message.slot = object.slot ?? 0;
     return message;
   },
 };
@@ -254,13 +254,13 @@ export const GetMacroGlobalSettingsRequest: MessageFns<GetMacroGlobalSettingsReq
 };
 
 function createBaseMacroSummary(): MacroSummary {
-  return { index: 0, name: "", encodedSize: 0 };
+  return { slot: 0, name: "", encodedSize: 0 };
 }
 
 export const MacroSummary: MessageFns<MacroSummary> = {
   encode(message: MacroSummary, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.index !== 0) {
-      writer.uint32(8).uint32(message.index);
+    if (message.slot !== 0) {
+      writer.uint32(8).uint32(message.slot);
     }
     if (message.name !== "") {
       writer.uint32(18).string(message.name);
@@ -283,7 +283,7 @@ export const MacroSummary: MessageFns<MacroSummary> = {
             break;
           }
 
-          message.index = reader.uint32();
+          message.slot = reader.uint32();
           continue;
         }
         case 2: {
@@ -316,7 +316,7 @@ export const MacroSummary: MessageFns<MacroSummary> = {
   },
   fromPartial(object: DeepPartial<MacroSummary>): MacroSummary {
     const message = createBaseMacroSummary();
-    message.index = object.index ?? 0;
+    message.slot = object.slot ?? 0;
     message.name = object.name ?? "";
     message.encodedSize = object.encodedSize ?? 0;
     return message;
@@ -587,14 +587,14 @@ export const MacroStep: MessageFns<MacroStep> = {
   },
 };
 
-function createBaseMacroSlot(): MacroSlot {
-  return { index: 0, name: "", steps: [], encodedSize: 0 };
+function createBaseMacroDetail(): MacroDetail {
+  return { slot: 0, name: "", steps: [], encodedSize: 0 };
 }
 
-export const MacroSlot: MessageFns<MacroSlot> = {
-  encode(message: MacroSlot, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.index !== 0) {
-      writer.uint32(8).uint32(message.index);
+export const MacroDetail: MessageFns<MacroDetail> = {
+  encode(message: MacroDetail, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    if (message.slot !== 0) {
+      writer.uint32(8).uint32(message.slot);
     }
     if (message.name !== "") {
       writer.uint32(18).string(message.name);
@@ -608,10 +608,10 @@ export const MacroSlot: MessageFns<MacroSlot> = {
     return writer;
   },
 
-  decode(input: BinaryReader | Uint8Array, length?: number): MacroSlot {
+  decode(input: BinaryReader | Uint8Array, length?: number): MacroDetail {
     const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
     const end = length === undefined ? reader.len : reader.pos + length;
-    const message = createBaseMacroSlot();
+    const message = createBaseMacroDetail();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -620,7 +620,7 @@ export const MacroSlot: MessageFns<MacroSlot> = {
             break;
           }
 
-          message.index = reader.uint32();
+          message.slot = reader.uint32();
           continue;
         }
         case 2: {
@@ -656,12 +656,12 @@ export const MacroSlot: MessageFns<MacroSlot> = {
     return message;
   },
 
-  create(base?: DeepPartial<MacroSlot>): MacroSlot {
-    return MacroSlot.fromPartial(base ?? {});
+  create(base?: DeepPartial<MacroDetail>): MacroDetail {
+    return MacroDetail.fromPartial(base ?? {});
   },
-  fromPartial(object: DeepPartial<MacroSlot>): MacroSlot {
-    const message = createBaseMacroSlot();
-    message.index = object.index ?? 0;
+  fromPartial(object: DeepPartial<MacroDetail>): MacroDetail {
+    const message = createBaseMacroDetail();
+    message.slot = object.slot ?? 0;
     message.name = object.name ?? "";
     message.steps = object.steps?.map((e) => MacroStep.fromPartial(e)) || [];
     message.encodedSize = object.encodedSize ?? 0;
@@ -669,84 +669,14 @@ export const MacroSlot: MessageFns<MacroSlot> = {
   },
 };
 
-function createBaseSetMacroNameRequest(): SetMacroNameRequest {
-  return { index: 0, name: "", persist: false };
-}
-
-export const SetMacroNameRequest: MessageFns<SetMacroNameRequest> = {
-  encode(message: SetMacroNameRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.index !== 0) {
-      writer.uint32(8).uint32(message.index);
-    }
-    if (message.name !== "") {
-      writer.uint32(18).string(message.name);
-    }
-    if (message.persist !== false) {
-      writer.uint32(24).bool(message.persist);
-    }
-    return writer;
-  },
-
-  decode(input: BinaryReader | Uint8Array, length?: number): SetMacroNameRequest {
-    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
-    const end = length === undefined ? reader.len : reader.pos + length;
-    const message = createBaseSetMacroNameRequest();
-    while (reader.pos < end) {
-      const tag = reader.uint32();
-      switch (tag >>> 3) {
-        case 1: {
-          if (tag !== 8) {
-            break;
-          }
-
-          message.index = reader.uint32();
-          continue;
-        }
-        case 2: {
-          if (tag !== 18) {
-            break;
-          }
-
-          message.name = reader.string();
-          continue;
-        }
-        case 3: {
-          if (tag !== 24) {
-            break;
-          }
-
-          message.persist = reader.bool();
-          continue;
-        }
-      }
-      if ((tag & 7) === 4 || tag === 0) {
-        break;
-      }
-      reader.skip(tag & 7);
-    }
-    return message;
-  },
-
-  create(base?: DeepPartial<SetMacroNameRequest>): SetMacroNameRequest {
-    return SetMacroNameRequest.fromPartial(base ?? {});
-  },
-  fromPartial(object: DeepPartial<SetMacroNameRequest>): SetMacroNameRequest {
-    const message = createBaseSetMacroNameRequest();
-    message.index = object.index ?? 0;
-    message.name = object.name ?? "";
-    message.persist = object.persist ?? false;
-    return message;
-  },
-};
-
 function createBaseSetMacroStepCountRequest(): SetMacroStepCountRequest {
-  return { index: 0, stepCount: 0, persist: false };
+  return { slot: 0, stepCount: 0, persist: false };
 }
 
 export const SetMacroStepCountRequest: MessageFns<SetMacroStepCountRequest> = {
   encode(message: SetMacroStepCountRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.index !== 0) {
-      writer.uint32(8).uint32(message.index);
+    if (message.slot !== 0) {
+      writer.uint32(8).uint32(message.slot);
     }
     if (message.stepCount !== 0) {
       writer.uint32(16).uint32(message.stepCount);
@@ -769,7 +699,7 @@ export const SetMacroStepCountRequest: MessageFns<SetMacroStepCountRequest> = {
             break;
           }
 
-          message.index = reader.uint32();
+          message.slot = reader.uint32();
           continue;
         }
         case 2: {
@@ -802,7 +732,7 @@ export const SetMacroStepCountRequest: MessageFns<SetMacroStepCountRequest> = {
   },
   fromPartial(object: DeepPartial<SetMacroStepCountRequest>): SetMacroStepCountRequest {
     const message = createBaseSetMacroStepCountRequest();
-    message.index = object.index ?? 0;
+    message.slot = object.slot ?? 0;
     message.stepCount = object.stepCount ?? 0;
     message.persist = object.persist ?? false;
     return message;
@@ -810,13 +740,13 @@ export const SetMacroStepCountRequest: MessageFns<SetMacroStepCountRequest> = {
 };
 
 function createBaseSetMacroStepRequest(): SetMacroStepRequest {
-  return { index: 0, stepIndex: 0, step: undefined, persist: false };
+  return { slot: 0, stepIndex: 0, step: undefined, persist: false };
 }
 
 export const SetMacroStepRequest: MessageFns<SetMacroStepRequest> = {
   encode(message: SetMacroStepRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.index !== 0) {
-      writer.uint32(8).uint32(message.index);
+    if (message.slot !== 0) {
+      writer.uint32(8).uint32(message.slot);
     }
     if (message.stepIndex !== 0) {
       writer.uint32(16).uint32(message.stepIndex);
@@ -842,7 +772,7 @@ export const SetMacroStepRequest: MessageFns<SetMacroStepRequest> = {
             break;
           }
 
-          message.index = reader.uint32();
+          message.slot = reader.uint32();
           continue;
         }
         case 2: {
@@ -883,8 +813,78 @@ export const SetMacroStepRequest: MessageFns<SetMacroStepRequest> = {
   },
   fromPartial(object: DeepPartial<SetMacroStepRequest>): SetMacroStepRequest {
     const message = createBaseSetMacroStepRequest();
-    message.index = object.index ?? 0;
+    message.slot = object.slot ?? 0;
     message.stepIndex = object.stepIndex ?? 0;
+    message.step = (object.step !== undefined && object.step !== null) ? MacroStep.fromPartial(object.step) : undefined;
+    message.persist = object.persist ?? false;
+    return message;
+  },
+};
+
+function createBaseAppendMacroStepRequest(): AppendMacroStepRequest {
+  return { slot: 0, step: undefined, persist: false };
+}
+
+export const AppendMacroStepRequest: MessageFns<AppendMacroStepRequest> = {
+  encode(message: AppendMacroStepRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    if (message.slot !== 0) {
+      writer.uint32(8).uint32(message.slot);
+    }
+    if (message.step !== undefined) {
+      MacroStep.encode(message.step, writer.uint32(18).fork()).join();
+    }
+    if (message.persist !== false) {
+      writer.uint32(24).bool(message.persist);
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): AppendMacroStepRequest {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseAppendMacroStepRequest();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 8) {
+            break;
+          }
+
+          message.slot = reader.uint32();
+          continue;
+        }
+        case 2: {
+          if (tag !== 18) {
+            break;
+          }
+
+          message.step = MacroStep.decode(reader, reader.uint32());
+          continue;
+        }
+        case 3: {
+          if (tag !== 24) {
+            break;
+          }
+
+          message.persist = reader.bool();
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  create(base?: DeepPartial<AppendMacroStepRequest>): AppendMacroStepRequest {
+    return AppendMacroStepRequest.fromPartial(base ?? {});
+  },
+  fromPartial(object: DeepPartial<AppendMacroStepRequest>): AppendMacroStepRequest {
+    const message = createBaseAppendMacroStepRequest();
+    message.slot = object.slot ?? 0;
     message.step = (object.step !== undefined && object.step !== null) ? MacroStep.fromPartial(object.step) : undefined;
     message.persist = object.persist ?? false;
     return message;
@@ -944,64 +944,6 @@ export const SetTapMsRequest: MessageFns<SetTapMsRequest> = {
   fromPartial(object: DeepPartial<SetTapMsRequest>): SetTapMsRequest {
     const message = createBaseSetTapMsRequest();
     message.tapMs = object.tapMs ?? 0;
-    message.persist = object.persist ?? false;
-    return message;
-  },
-};
-
-function createBaseDeleteMacroRequest(): DeleteMacroRequest {
-  return { index: 0, persist: false };
-}
-
-export const DeleteMacroRequest: MessageFns<DeleteMacroRequest> = {
-  encode(message: DeleteMacroRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.index !== 0) {
-      writer.uint32(8).uint32(message.index);
-    }
-    if (message.persist !== false) {
-      writer.uint32(16).bool(message.persist);
-    }
-    return writer;
-  },
-
-  decode(input: BinaryReader | Uint8Array, length?: number): DeleteMacroRequest {
-    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
-    const end = length === undefined ? reader.len : reader.pos + length;
-    const message = createBaseDeleteMacroRequest();
-    while (reader.pos < end) {
-      const tag = reader.uint32();
-      switch (tag >>> 3) {
-        case 1: {
-          if (tag !== 8) {
-            break;
-          }
-
-          message.index = reader.uint32();
-          continue;
-        }
-        case 2: {
-          if (tag !== 16) {
-            break;
-          }
-
-          message.persist = reader.bool();
-          continue;
-        }
-      }
-      if ((tag & 7) === 4 || tag === 0) {
-        break;
-      }
-      reader.skip(tag & 7);
-    }
-    return message;
-  },
-
-  create(base?: DeepPartial<DeleteMacroRequest>): DeleteMacroRequest {
-    return DeleteMacroRequest.fromPartial(base ?? {});
-  },
-  fromPartial(object: DeepPartial<DeleteMacroRequest>): DeleteMacroRequest {
-    const message = createBaseDeleteMacroRequest();
-    message.index = object.index ?? 0;
     message.persist = object.persist ?? false;
     return message;
   },
@@ -1079,14 +1021,13 @@ function createBaseRequest(): Request {
   return {
     listMacros: undefined,
     getMacro: undefined,
-    setMacroName: undefined,
     setMacroStepCount: undefined,
     getMacroGlobalSettings: undefined,
     setTapMs: undefined,
     setMacroStep: undefined,
-    deleteMacro: undefined,
     saveMacros: undefined,
     discardMacros: undefined,
+    appendMacroStep: undefined,
   };
 }
 
@@ -1097,9 +1038,6 @@ export const Request: MessageFns<Request> = {
     }
     if (message.getMacro !== undefined) {
       GetMacroRequest.encode(message.getMacro, writer.uint32(18).fork()).join();
-    }
-    if (message.setMacroName !== undefined) {
-      SetMacroNameRequest.encode(message.setMacroName, writer.uint32(26).fork()).join();
     }
     if (message.setMacroStepCount !== undefined) {
       SetMacroStepCountRequest.encode(message.setMacroStepCount, writer.uint32(34).fork()).join();
@@ -1113,14 +1051,14 @@ export const Request: MessageFns<Request> = {
     if (message.setMacroStep !== undefined) {
       SetMacroStepRequest.encode(message.setMacroStep, writer.uint32(58).fork()).join();
     }
-    if (message.deleteMacro !== undefined) {
-      DeleteMacroRequest.encode(message.deleteMacro, writer.uint32(66).fork()).join();
-    }
     if (message.saveMacros !== undefined) {
       SaveMacrosRequest.encode(message.saveMacros, writer.uint32(74).fork()).join();
     }
     if (message.discardMacros !== undefined) {
       DiscardMacrosRequest.encode(message.discardMacros, writer.uint32(82).fork()).join();
+    }
+    if (message.appendMacroStep !== undefined) {
+      AppendMacroStepRequest.encode(message.appendMacroStep, writer.uint32(90).fork()).join();
     }
     return writer;
   },
@@ -1146,14 +1084,6 @@ export const Request: MessageFns<Request> = {
           }
 
           message.getMacro = GetMacroRequest.decode(reader, reader.uint32());
-          continue;
-        }
-        case 3: {
-          if (tag !== 26) {
-            break;
-          }
-
-          message.setMacroName = SetMacroNameRequest.decode(reader, reader.uint32());
           continue;
         }
         case 4: {
@@ -1188,14 +1118,6 @@ export const Request: MessageFns<Request> = {
           message.setMacroStep = SetMacroStepRequest.decode(reader, reader.uint32());
           continue;
         }
-        case 8: {
-          if (tag !== 66) {
-            break;
-          }
-
-          message.deleteMacro = DeleteMacroRequest.decode(reader, reader.uint32());
-          continue;
-        }
         case 9: {
           if (tag !== 74) {
             break;
@@ -1210,6 +1132,14 @@ export const Request: MessageFns<Request> = {
           }
 
           message.discardMacros = DiscardMacrosRequest.decode(reader, reader.uint32());
+          continue;
+        }
+        case 11: {
+          if (tag !== 90) {
+            break;
+          }
+
+          message.appendMacroStep = AppendMacroStepRequest.decode(reader, reader.uint32());
           continue;
         }
       }
@@ -1232,9 +1162,6 @@ export const Request: MessageFns<Request> = {
     message.getMacro = (object.getMacro !== undefined && object.getMacro !== null)
       ? GetMacroRequest.fromPartial(object.getMacro)
       : undefined;
-    message.setMacroName = (object.setMacroName !== undefined && object.setMacroName !== null)
-      ? SetMacroNameRequest.fromPartial(object.setMacroName)
-      : undefined;
     message.setMacroStepCount = (object.setMacroStepCount !== undefined && object.setMacroStepCount !== null)
       ? SetMacroStepCountRequest.fromPartial(object.setMacroStepCount)
       : undefined;
@@ -1248,14 +1175,14 @@ export const Request: MessageFns<Request> = {
     message.setMacroStep = (object.setMacroStep !== undefined && object.setMacroStep !== null)
       ? SetMacroStepRequest.fromPartial(object.setMacroStep)
       : undefined;
-    message.deleteMacro = (object.deleteMacro !== undefined && object.deleteMacro !== null)
-      ? DeleteMacroRequest.fromPartial(object.deleteMacro)
-      : undefined;
     message.saveMacros = (object.saveMacros !== undefined && object.saveMacros !== null)
       ? SaveMacrosRequest.fromPartial(object.saveMacros)
       : undefined;
     message.discardMacros = (object.discardMacros !== undefined && object.discardMacros !== null)
       ? DiscardMacrosRequest.fromPartial(object.discardMacros)
+      : undefined;
+    message.appendMacroStep = (object.appendMacroStep !== undefined && object.appendMacroStep !== null)
+      ? AppendMacroStepRequest.fromPartial(object.appendMacroStep)
       : undefined;
     return message;
   },
@@ -1442,7 +1369,7 @@ function createBaseGetMacroResponse(): GetMacroResponse {
 export const GetMacroResponse: MessageFns<GetMacroResponse> = {
   encode(message: GetMacroResponse, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.macro !== undefined) {
-      MacroSlot.encode(message.macro, writer.uint32(10).fork()).join();
+      MacroDetail.encode(message.macro, writer.uint32(10).fork()).join();
     }
     return writer;
   },
@@ -1459,7 +1386,7 @@ export const GetMacroResponse: MessageFns<GetMacroResponse> = {
             break;
           }
 
-          message.macro = MacroSlot.decode(reader, reader.uint32());
+          message.macro = MacroDetail.decode(reader, reader.uint32());
           continue;
         }
       }
@@ -1477,14 +1404,14 @@ export const GetMacroResponse: MessageFns<GetMacroResponse> = {
   fromPartial(object: DeepPartial<GetMacroResponse>): GetMacroResponse {
     const message = createBaseGetMacroResponse();
     message.macro = (object.macro !== undefined && object.macro !== null)
-      ? MacroSlot.fromPartial(object.macro)
+      ? MacroDetail.fromPartial(object.macro)
       : undefined;
     return message;
   },
 };
 
 function createBaseMacroGlobalSettings(): MacroGlobalSettings {
-  return { tapMs: 0, maxMacro: 0, keyPressBehaviorId: 0 };
+  return { tapMs: 0, maxEntries: 0, keyPressBehaviorId: 0, poolBytesTotal: 0, poolBytesUsed: 0 };
 }
 
 export const MacroGlobalSettings: MessageFns<MacroGlobalSettings> = {
@@ -1492,11 +1419,17 @@ export const MacroGlobalSettings: MessageFns<MacroGlobalSettings> = {
     if (message.tapMs !== 0) {
       writer.uint32(8).uint32(message.tapMs);
     }
-    if (message.maxMacro !== 0) {
-      writer.uint32(16).uint32(message.maxMacro);
+    if (message.maxEntries !== 0) {
+      writer.uint32(16).uint32(message.maxEntries);
     }
     if (message.keyPressBehaviorId !== 0) {
       writer.uint32(24).uint32(message.keyPressBehaviorId);
+    }
+    if (message.poolBytesTotal !== 0) {
+      writer.uint32(32).uint32(message.poolBytesTotal);
+    }
+    if (message.poolBytesUsed !== 0) {
+      writer.uint32(40).uint32(message.poolBytesUsed);
     }
     return writer;
   },
@@ -1521,7 +1454,7 @@ export const MacroGlobalSettings: MessageFns<MacroGlobalSettings> = {
             break;
           }
 
-          message.maxMacro = reader.uint32();
+          message.maxEntries = reader.uint32();
           continue;
         }
         case 3: {
@@ -1530,6 +1463,22 @@ export const MacroGlobalSettings: MessageFns<MacroGlobalSettings> = {
           }
 
           message.keyPressBehaviorId = reader.uint32();
+          continue;
+        }
+        case 4: {
+          if (tag !== 32) {
+            break;
+          }
+
+          message.poolBytesTotal = reader.uint32();
+          continue;
+        }
+        case 5: {
+          if (tag !== 40) {
+            break;
+          }
+
+          message.poolBytesUsed = reader.uint32();
           continue;
         }
       }
@@ -1547,8 +1496,10 @@ export const MacroGlobalSettings: MessageFns<MacroGlobalSettings> = {
   fromPartial(object: DeepPartial<MacroGlobalSettings>): MacroGlobalSettings {
     const message = createBaseMacroGlobalSettings();
     message.tapMs = object.tapMs ?? 0;
-    message.maxMacro = object.maxMacro ?? 0;
+    message.maxEntries = object.maxEntries ?? 0;
     message.keyPressBehaviorId = object.keyPressBehaviorId ?? 0;
+    message.poolBytesTotal = object.poolBytesTotal ?? 0;
+    message.poolBytesUsed = object.poolBytesUsed ?? 0;
     return message;
   },
 };

--- a/src/proto/cormoran/zmk/custom_settings/custom_settings.ts
+++ b/src/proto/cormoran/zmk/custom_settings/custom_settings.ts
@@ -80,11 +80,22 @@ export namespace SettingNotificationKind {
   export type UNRECOGNIZED = typeof SettingNotificationKind.UNRECOGNIZED;
 }
 
+/**
+ * A ZMK behavior binding: the behavior's local ID (see
+ * CONFIG_ZMK_BEHAVIOR_LOCAL_IDS) plus its two binding parameters.
+ */
+export interface SettingBehaviorValue {
+  behaviorId: number;
+  param1: number;
+  param2: number;
+}
+
 export interface SettingScalarValue {
   bytesValue?: Uint8Array | undefined;
   int32Value?: number | undefined;
   boolValue?: boolean | undefined;
   stringValue?: string | undefined;
+  behaviorValue?: SettingBehaviorValue | undefined;
 }
 
 /** Array values encode one active element plus the active array length. */
@@ -101,6 +112,7 @@ export interface SettingValue {
   boolValue?: boolean | undefined;
   stringValue?: string | undefined;
   arrayValue?: SettingArrayValue | undefined;
+  behaviorValue?: SettingBehaviorValue | undefined;
 }
 
 export interface SettingConstraintRange {
@@ -212,6 +224,28 @@ export interface PopBackArrayRequest {
   mode: SettingWriteMode;
 }
 
+/**
+ * Create one entry in an RPC-creatable keyspace (see
+ * ZMK_CUSTOM_SETTING_KEYSPACE_DEFINE). setting.key must start with the
+ * target keyspace's key_prefix and fit its max_key_len; setting.array_index
+ * is unused. Fails with an ErrorResponse if the keyspace is full, the key is
+ * already in use, or the key does not match any registered keyspace prefix.
+ */
+export interface CreateSettingRequest {
+  setting: SettingRef | undefined;
+  value: SettingValue | undefined;
+  mode: SettingWriteMode;
+}
+
+/**
+ * Delete one entry previously created by CreateSettingRequest (or persisted
+ * by one in an earlier session). Fails with an ErrorResponse if setting.key
+ * has no live entry.
+ */
+export interface DeleteSettingRequest {
+  setting: SettingRef | undefined;
+}
+
 export interface SaveSettingsRequest {
   scope: SettingScope | undefined;
 }
@@ -224,6 +258,23 @@ export interface ResetSettingsRequest {
   scope: SettingScope | undefined;
 }
 
+/**
+ * Write one chunk of a bytes/string setting value. The first chunk (offset =
+ * 0) opens a transfer session and declares total_size; subsequent chunks for
+ * the same setting must arrive in order (offset must equal the number of
+ * bytes received so far). Set commit = true on the final chunk to validate
+ * and apply the assembled value; the write only takes effect on commit, so a
+ * half-transferred value is never observable.
+ */
+export interface WriteValueChunkRequest {
+  setting: SettingRef | undefined;
+  totalSize: number;
+  offset: number;
+  data: Uint8Array;
+  commit: boolean;
+  mode: SettingWriteMode;
+}
+
 export interface Request {
   listSettings?: ListSettingsRequest | undefined;
   getSetting?: GetSettingRequest | undefined;
@@ -233,6 +284,9 @@ export interface Request {
   resetSettings?: ResetSettingsRequest | undefined;
   pushBackArray?: PushBackArrayRequest | undefined;
   popBackArray?: PopBackArrayRequest | undefined;
+  writeValueChunk?: WriteValueChunkRequest | undefined;
+  createSetting?: CreateSettingRequest | undefined;
+  deleteSetting?: DeleteSettingRequest | undefined;
 }
 
 export interface ErrorResponse {
@@ -263,8 +317,84 @@ export interface Notification {
   setting?: SettingNotification | undefined;
 }
 
+function createBaseSettingBehaviorValue(): SettingBehaviorValue {
+  return { behaviorId: 0, param1: 0, param2: 0 };
+}
+
+export const SettingBehaviorValue: MessageFns<SettingBehaviorValue> = {
+  encode(message: SettingBehaviorValue, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    if (message.behaviorId !== 0) {
+      writer.uint32(8).uint32(message.behaviorId);
+    }
+    if (message.param1 !== 0) {
+      writer.uint32(16).uint32(message.param1);
+    }
+    if (message.param2 !== 0) {
+      writer.uint32(24).uint32(message.param2);
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): SettingBehaviorValue {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseSettingBehaviorValue();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 8) {
+            break;
+          }
+
+          message.behaviorId = reader.uint32();
+          continue;
+        }
+        case 2: {
+          if (tag !== 16) {
+            break;
+          }
+
+          message.param1 = reader.uint32();
+          continue;
+        }
+        case 3: {
+          if (tag !== 24) {
+            break;
+          }
+
+          message.param2 = reader.uint32();
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  create(base?: DeepPartial<SettingBehaviorValue>): SettingBehaviorValue {
+    return SettingBehaviorValue.fromPartial(base ?? {});
+  },
+  fromPartial(object: DeepPartial<SettingBehaviorValue>): SettingBehaviorValue {
+    const message = createBaseSettingBehaviorValue();
+    message.behaviorId = object.behaviorId ?? 0;
+    message.param1 = object.param1 ?? 0;
+    message.param2 = object.param2 ?? 0;
+    return message;
+  },
+};
+
 function createBaseSettingScalarValue(): SettingScalarValue {
-  return { bytesValue: undefined, int32Value: undefined, boolValue: undefined, stringValue: undefined };
+  return {
+    bytesValue: undefined,
+    int32Value: undefined,
+    boolValue: undefined,
+    stringValue: undefined,
+    behaviorValue: undefined,
+  };
 }
 
 export const SettingScalarValue: MessageFns<SettingScalarValue> = {
@@ -280,6 +410,9 @@ export const SettingScalarValue: MessageFns<SettingScalarValue> = {
     }
     if (message.stringValue !== undefined) {
       writer.uint32(34).string(message.stringValue);
+    }
+    if (message.behaviorValue !== undefined) {
+      SettingBehaviorValue.encode(message.behaviorValue, writer.uint32(42).fork()).join();
     }
     return writer;
   },
@@ -323,6 +456,14 @@ export const SettingScalarValue: MessageFns<SettingScalarValue> = {
           message.stringValue = reader.string();
           continue;
         }
+        case 5: {
+          if (tag !== 42) {
+            break;
+          }
+
+          message.behaviorValue = SettingBehaviorValue.decode(reader, reader.uint32());
+          continue;
+        }
       }
       if ((tag & 7) === 4 || tag === 0) {
         break;
@@ -341,6 +482,9 @@ export const SettingScalarValue: MessageFns<SettingScalarValue> = {
     message.int32Value = object.int32Value ?? undefined;
     message.boolValue = object.boolValue ?? undefined;
     message.stringValue = object.stringValue ?? undefined;
+    message.behaviorValue = (object.behaviorValue !== undefined && object.behaviorValue !== null)
+      ? SettingBehaviorValue.fromPartial(object.behaviorValue)
+      : undefined;
     return message;
   },
 };
@@ -424,6 +568,7 @@ function createBaseSettingValue(): SettingValue {
     boolValue: undefined,
     stringValue: undefined,
     arrayValue: undefined,
+    behaviorValue: undefined,
   };
 }
 
@@ -443,6 +588,9 @@ export const SettingValue: MessageFns<SettingValue> = {
     }
     if (message.arrayValue !== undefined) {
       SettingArrayValue.encode(message.arrayValue, writer.uint32(42).fork()).join();
+    }
+    if (message.behaviorValue !== undefined) {
+      SettingBehaviorValue.encode(message.behaviorValue, writer.uint32(50).fork()).join();
     }
     return writer;
   },
@@ -494,6 +642,14 @@ export const SettingValue: MessageFns<SettingValue> = {
           message.arrayValue = SettingArrayValue.decode(reader, reader.uint32());
           continue;
         }
+        case 6: {
+          if (tag !== 50) {
+            break;
+          }
+
+          message.behaviorValue = SettingBehaviorValue.decode(reader, reader.uint32());
+          continue;
+        }
       }
       if ((tag & 7) === 4 || tag === 0) {
         break;
@@ -514,6 +670,9 @@ export const SettingValue: MessageFns<SettingValue> = {
     message.stringValue = object.stringValue ?? undefined;
     message.arrayValue = (object.arrayValue !== undefined && object.arrayValue !== null)
       ? SettingArrayValue.fromPartial(object.arrayValue)
+      : undefined;
+    message.behaviorValue = (object.behaviorValue !== undefined && object.behaviorValue !== null)
+      ? SettingBehaviorValue.fromPartial(object.behaviorValue)
       : undefined;
     return message;
   },
@@ -1565,6 +1724,128 @@ export const PopBackArrayRequest: MessageFns<PopBackArrayRequest> = {
   },
 };
 
+function createBaseCreateSettingRequest(): CreateSettingRequest {
+  return { setting: undefined, value: undefined, mode: 0 };
+}
+
+export const CreateSettingRequest: MessageFns<CreateSettingRequest> = {
+  encode(message: CreateSettingRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    if (message.setting !== undefined) {
+      SettingRef.encode(message.setting, writer.uint32(10).fork()).join();
+    }
+    if (message.value !== undefined) {
+      SettingValue.encode(message.value, writer.uint32(18).fork()).join();
+    }
+    if (message.mode !== 0) {
+      writer.uint32(24).int32(message.mode);
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): CreateSettingRequest {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseCreateSettingRequest();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          message.setting = SettingRef.decode(reader, reader.uint32());
+          continue;
+        }
+        case 2: {
+          if (tag !== 18) {
+            break;
+          }
+
+          message.value = SettingValue.decode(reader, reader.uint32());
+          continue;
+        }
+        case 3: {
+          if (tag !== 24) {
+            break;
+          }
+
+          message.mode = reader.int32() as any;
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  create(base?: DeepPartial<CreateSettingRequest>): CreateSettingRequest {
+    return CreateSettingRequest.fromPartial(base ?? {});
+  },
+  fromPartial(object: DeepPartial<CreateSettingRequest>): CreateSettingRequest {
+    const message = createBaseCreateSettingRequest();
+    message.setting = (object.setting !== undefined && object.setting !== null)
+      ? SettingRef.fromPartial(object.setting)
+      : undefined;
+    message.value = (object.value !== undefined && object.value !== null)
+      ? SettingValue.fromPartial(object.value)
+      : undefined;
+    message.mode = object.mode ?? 0;
+    return message;
+  },
+};
+
+function createBaseDeleteSettingRequest(): DeleteSettingRequest {
+  return { setting: undefined };
+}
+
+export const DeleteSettingRequest: MessageFns<DeleteSettingRequest> = {
+  encode(message: DeleteSettingRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    if (message.setting !== undefined) {
+      SettingRef.encode(message.setting, writer.uint32(10).fork()).join();
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): DeleteSettingRequest {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseDeleteSettingRequest();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          message.setting = SettingRef.decode(reader, reader.uint32());
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  create(base?: DeepPartial<DeleteSettingRequest>): DeleteSettingRequest {
+    return DeleteSettingRequest.fromPartial(base ?? {});
+  },
+  fromPartial(object: DeepPartial<DeleteSettingRequest>): DeleteSettingRequest {
+    const message = createBaseDeleteSettingRequest();
+    message.setting = (object.setting !== undefined && object.setting !== null)
+      ? SettingRef.fromPartial(object.setting)
+      : undefined;
+    return message;
+  },
+};
+
 function createBaseSaveSettingsRequest(): SaveSettingsRequest {
   return { scope: undefined };
 }
@@ -1709,6 +1990,114 @@ export const ResetSettingsRequest: MessageFns<ResetSettingsRequest> = {
   },
 };
 
+function createBaseWriteValueChunkRequest(): WriteValueChunkRequest {
+  return { setting: undefined, totalSize: 0, offset: 0, data: new Uint8Array(0), commit: false, mode: 0 };
+}
+
+export const WriteValueChunkRequest: MessageFns<WriteValueChunkRequest> = {
+  encode(message: WriteValueChunkRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    if (message.setting !== undefined) {
+      SettingRef.encode(message.setting, writer.uint32(10).fork()).join();
+    }
+    if (message.totalSize !== 0) {
+      writer.uint32(16).uint32(message.totalSize);
+    }
+    if (message.offset !== 0) {
+      writer.uint32(24).uint32(message.offset);
+    }
+    if (message.data.length !== 0) {
+      writer.uint32(34).bytes(message.data);
+    }
+    if (message.commit !== false) {
+      writer.uint32(40).bool(message.commit);
+    }
+    if (message.mode !== 0) {
+      writer.uint32(48).int32(message.mode);
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): WriteValueChunkRequest {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseWriteValueChunkRequest();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          message.setting = SettingRef.decode(reader, reader.uint32());
+          continue;
+        }
+        case 2: {
+          if (tag !== 16) {
+            break;
+          }
+
+          message.totalSize = reader.uint32();
+          continue;
+        }
+        case 3: {
+          if (tag !== 24) {
+            break;
+          }
+
+          message.offset = reader.uint32();
+          continue;
+        }
+        case 4: {
+          if (tag !== 34) {
+            break;
+          }
+
+          message.data = reader.bytes();
+          continue;
+        }
+        case 5: {
+          if (tag !== 40) {
+            break;
+          }
+
+          message.commit = reader.bool();
+          continue;
+        }
+        case 6: {
+          if (tag !== 48) {
+            break;
+          }
+
+          message.mode = reader.int32() as any;
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  create(base?: DeepPartial<WriteValueChunkRequest>): WriteValueChunkRequest {
+    return WriteValueChunkRequest.fromPartial(base ?? {});
+  },
+  fromPartial(object: DeepPartial<WriteValueChunkRequest>): WriteValueChunkRequest {
+    const message = createBaseWriteValueChunkRequest();
+    message.setting = (object.setting !== undefined && object.setting !== null)
+      ? SettingRef.fromPartial(object.setting)
+      : undefined;
+    message.totalSize = object.totalSize ?? 0;
+    message.offset = object.offset ?? 0;
+    message.data = object.data ?? new Uint8Array(0);
+    message.commit = object.commit ?? false;
+    message.mode = object.mode ?? 0;
+    return message;
+  },
+};
+
 function createBaseRequest(): Request {
   return {
     listSettings: undefined,
@@ -1719,6 +2108,9 @@ function createBaseRequest(): Request {
     resetSettings: undefined,
     pushBackArray: undefined,
     popBackArray: undefined,
+    writeValueChunk: undefined,
+    createSetting: undefined,
+    deleteSetting: undefined,
   };
 }
 
@@ -1747,6 +2139,15 @@ export const Request: MessageFns<Request> = {
     }
     if (message.popBackArray !== undefined) {
       PopBackArrayRequest.encode(message.popBackArray, writer.uint32(66).fork()).join();
+    }
+    if (message.writeValueChunk !== undefined) {
+      WriteValueChunkRequest.encode(message.writeValueChunk, writer.uint32(82).fork()).join();
+    }
+    if (message.createSetting !== undefined) {
+      CreateSettingRequest.encode(message.createSetting, writer.uint32(90).fork()).join();
+    }
+    if (message.deleteSetting !== undefined) {
+      DeleteSettingRequest.encode(message.deleteSetting, writer.uint32(98).fork()).join();
     }
     return writer;
   },
@@ -1822,6 +2223,30 @@ export const Request: MessageFns<Request> = {
           message.popBackArray = PopBackArrayRequest.decode(reader, reader.uint32());
           continue;
         }
+        case 10: {
+          if (tag !== 82) {
+            break;
+          }
+
+          message.writeValueChunk = WriteValueChunkRequest.decode(reader, reader.uint32());
+          continue;
+        }
+        case 11: {
+          if (tag !== 90) {
+            break;
+          }
+
+          message.createSetting = CreateSettingRequest.decode(reader, reader.uint32());
+          continue;
+        }
+        case 12: {
+          if (tag !== 98) {
+            break;
+          }
+
+          message.deleteSetting = DeleteSettingRequest.decode(reader, reader.uint32());
+          continue;
+        }
       }
       if ((tag & 7) === 4 || tag === 0) {
         break;
@@ -1859,6 +2284,15 @@ export const Request: MessageFns<Request> = {
       : undefined;
     message.popBackArray = (object.popBackArray !== undefined && object.popBackArray !== null)
       ? PopBackArrayRequest.fromPartial(object.popBackArray)
+      : undefined;
+    message.writeValueChunk = (object.writeValueChunk !== undefined && object.writeValueChunk !== null)
+      ? WriteValueChunkRequest.fromPartial(object.writeValueChunk)
+      : undefined;
+    message.createSetting = (object.createSetting !== undefined && object.createSetting !== null)
+      ? CreateSettingRequest.fromPartial(object.createSetting)
+      : undefined;
+    message.deleteSetting = (object.deleteSetting !== undefined && object.deleteSetting !== null)
+      ? DeleteSettingRequest.fromPartial(object.deleteSetting)
       : undefined;
     return message;
   },


### PR DESCRIPTION
## Description

The `zmk-feature-custom-settings` module had a major protocol update, which cascaded into `runtime-macro` and `runtime-combo`. This syncs the vendored `.proto` files to upstream, regenerates the TypeScript, and updates the frontend to match. The other referenced modules (`os-detection`, `default-layer`, `pmw3610`) were already identical to upstream, so no changes were needed there.

### custom-settings
- Regenerated proto: new `SettingBehaviorValue` value type, `CreateSetting`/`DeleteSetting` (RPC-creatable keyspaces), `WriteValueChunk` (chunked large writes); the old `ReadValueChunk` path is gone.
- Added `createSetting`/`deleteSetting` to `useCustomSettings` (key-based routing — no `customSubsystemIndex`, firmware routes by key prefix).
- Scalar bytes/string writes larger than one frame (>64 B) now go over the chunked `WriteValueChunk` RPC via the new `customSettingsChunkedValue.ts`. **This also fixes a latent bug**: the byte editor could already produce >64 B writes that silently failed.
- Added a behavior-value editor to `AdvancedSettingsSection`, kept distinct from the existing behavior-id INT32-*constraint* path.

### runtime-macro
- Regenerated proto: `index`→`slot`, `MacroSlot`→`MacroDetail`, `max_macro`→`max_entries` + `pool_bytes_total/used`; `SetMacroName`/`DeleteMacro` removed; `AppendMacroStep` added.
- Create/rename/delete now go through the generic custom-settings `CreateSetting`/`DeleteSetting` RPC on key `macro/<name>`. Rename creates the new name carrying the current body, then deletes the old one, so a partial failure never loses content.
- `MacroPage` moves from 8 fixed slots to a **variable named-macro list** (name + Create input; Delete removes the macro) and displays shared-pool usage.
- The macro slot rename is propagated into the KeymapPage/ComboPage macro picker (the `&rmacro <slot>` binding parameter is the slot).

### runtime-combo
- Regenerated proto: per-combo `timeout_ms`/`require_prior_idle_ms`/`slow_release_override`/`source`; `ResetCombo` + global `SetRequirePriorIdleMs`.
- `ComboPage` gains per-combo timeout/idle inputs (0 = inherit global), a slow-release tri-state select, source badges, a Reset-to-Default button, and a global require-prior-idle input (0 = disable guard).

### Testing
Demo transports and unit tests were updated for all three subsystems, and new i18n strings were added for `en` and `ja`. `tsc`, lint, `jest` (379 passed / 1 pre-existing skip), and the production build all pass. Wire-level interop with real firmware (chunked writes, key-prefix routing, reset/idle semantics) was validated against the demo transport only and would need a physical device to confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## CLA (Contributor License Agreement)

By submitting this pull request, I agree that my contributions
are licensed under the project's current license.

I also grant the maintainer(s) of this project the right to relicense
my contributions under any license, for use in future versions of the project.
This does not affect the license of any previously released versions.