### PR TITLE
feat: expose appendMacroStep and use it when adding macro steps

### DIFF
--- a/src/hooks/useRuntimeMacro.ts
+++ b/src/hooks/useRuntimeMacro.ts
@@ -58,6 +58,11 @@ export interface UseRuntimeMacroReturn {
     step: MacroStep,
     persist?: boolean,
   ) => Promise<boolean>;
+  appendMacroStep: (
+    slot: number,
+    step: MacroStep,
+    persist?: boolean,
+  ) => Promise<boolean>;
   setTapMs: (tapMs: number, persist?: boolean) => Promise<boolean>;
   saveMacros: () => Promise<boolean>;
   discardMacros: () => Promise<boolean>;
@@ -225,6 +230,17 @@ export function useRuntimeMacro(): UseRuntimeMacroReturn {
         Request.create({
           setMacroStep: { slot, stepIndex, step, persist },
         }),
+        persist,
+      );
+      return status !== null;
+    },
+    [runMutation],
+  );
+
+  const appendMacroStep = useCallback(
+    async (slot: number, step: MacroStep, persist = false): Promise<boolean> => {
+      const status = await runMutation(
+        Request.create({ appendMacroStep: { slot, step, persist } }),
         persist,
       );
       return status !== null;
@@ -411,6 +427,7 @@ export function useRuntimeMacro(): UseRuntimeMacroReturn {
     renameMacro,
     setMacroStepCount,
     setMacroStep,
+    appendMacroStep,
     setTapMs,
     saveMacros,
     discardMacros,

--- a/src/lib/transport/__tests__/demo-runtime-macro.test.ts
+++ b/src/lib/transport/__tests__/demo-runtime-macro.test.ts
@@ -118,6 +118,26 @@ describe("RuntimeMacroHandler", () => {
     expect(getResponse.getMacro?.macro?.steps.length).toBe(0);
   });
 
+  it("appends a step without rewriting existing steps", () => {
+    const before = handler.process(Request.create({ getMacro: { slot: 0 } }));
+    const initialCount = before.getMacro?.macro?.steps.length ?? 0;
+
+    const appendResponse = handler.process(
+      Request.create({
+        appendMacroStep: {
+          slot: 0,
+          step: { delay: { delayMs: 50 } },
+          persist: false,
+        },
+      }),
+    );
+    expect(appendResponse.status?.affectedCount).toBe(1);
+
+    const after = handler.process(Request.create({ getMacro: { slot: 0 } }));
+    expect(after.getMacro?.macro?.steps.length).toBe(initialCount + 1);
+    expect(after.getMacro?.macro?.steps[initialCount].delay?.delayMs).toBe(50);
+  });
+
   it("creates a new macro when the custom-settings keyspace gains a matching entry", () => {
     const createResponse = customSettings.process(
       CustomSettingsRequest.create({

--- a/src/pages/MacroPage.tsx
+++ b/src/pages/MacroPage.tsx
@@ -648,14 +648,23 @@ export function MacroPage() {
   const handleAddStep = useCallback(async () => {
     if (!loadedMacro) return;
     const steps = [...loadedMacro.steps, DEFAULT_STEP];
+    try {
+      const size = getRuntimeMacroEncodedSize(steps);
+      if (size > runtimeMacro.maxMacroBytes) return;
+    } catch {
+      return;
+    }
     setStringDraft(null);
-    setLoadedMacro({
-      ...loadedMacro,
-      steps,
-      encodedSize: getRuntimeMacroEncodedSize(steps),
-    });
-    await commitSteps(steps);
-  }, [commitSteps, loadedMacro]);
+    const ok = await runtimeMacro.appendMacroStep(loadedMacro.slot, DEFAULT_STEP);
+    if (ok) {
+      setLoadedMacro({
+        ...loadedMacro,
+        steps,
+        encodedSize: getRuntimeMacroEncodedSize(steps),
+      });
+      await runtimeMacro.loadMacros();
+    }
+  }, [loadedMacro, runtimeMacro]);
 
   const handleDeleteMacro = useCallback(async () => {
     if (!loadedMacro) return;


### PR DESCRIPTION
## Summary

- Exposes `appendMacroStep` in `UseRuntimeMacroReturn` / `useRuntimeMacro` hook, wrapping the `AppendMacroStepRequest` that was recently added to `zmk-feature-runtime-macro`
- Updates `MacroPage.handleAddStep` to call `appendMacroStep` (1 RPC) instead of `commitSteps` (setMacroStepCount + N × setMacroStep) when adding a step to the end — includes a pre-flight byte-size guard
- Adds a unit test for `appendMacroStep` in `demo-runtime-macro.test.ts`

## Test plan

- [ ] `npm test` passes (all existing + new `appendMacroStep` test)
- [ ] `npx tsc --noEmit` clean
- [ ] In the Macro tab on a connected device, clicking **+ Step** adds a delay step without rewriting existing steps; save/discard/pool-usage still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)