### PR TITLE
feat: use native CreateMacro/DeleteMacro/RenameMacro RPCs

### DIFF
--- a/proto/cormoran/runtime_macro/runtime_macro.proto
+++ b/proto/cormoran/runtime_macro/runtime_macro.proto
@@ -2,20 +2,17 @@ syntax = "proto3";
 
 package cormoran.runtime_macro;
 
-// Raw create/delete/rename of a macro entry is intentionally NOT duplicated
-// here: it is already covered by the generic zmk-feature-custom-settings
-// Studio RPC (CreateSetting/DeleteSetting, subsystem "cormoran__runtime_macro",
-// key "macro/<name>"). This subsystem only carries macro-domain operations
-// that the generic RPC cannot express: structured step-level editing, slot
-// resolution, and playback-adjacent global settings.
+// Runtime macro Studio RPC subsystem ("cormoran__runtime_macro").
+//
+// Lifecycle operations (create/delete/rename) are native to this subsystem
+// since zmk-feature-runtime-macro#13 - the earlier approach of routing them
+// through the generic cormoran_custom_settings RPC had a keyspace-lookup bug.
 //
 // Every operational RPC below (get/set-step-count/set-step/append-step)
 // addresses a macro by its `slot` number, not its name - the same numeric
 // index the keymap behavior binding uses to play it. A macro's slot is only
 // known for certain by reading its `slot` field from ListMacrosResponse or
-// MacroDetail (e.g. right after creating it via the generic CreateSetting
-// RPC). Renaming/creating/deleting a macro still goes through the
-// name-keyed generic CreateSetting/DeleteSetting RPC, unaffected by this.
+// MacroDetail (e.g. right after creating it via CreateMacroRequest).
 
 message ListMacrosRequest {}
 
@@ -84,9 +81,22 @@ message SaveMacrosRequest {}
 
 message DiscardMacrosRequest {}
 
+message CreateMacroRequest {
+    string name = 1;
+    bool persist = 2;
+}
+
+message DeleteMacroRequest { string name = 1; }
+
+message RenameMacroRequest {
+    string old_name = 1;
+    string new_name = 2;
+    bool persist = 3;
+}
+
 message Request {
     reserved 3,
-        8; // formerly set_macro_name, delete_macro - see generic CreateSetting/DeleteSetting
+        8; // formerly set_macro_name, delete_macro
     oneof request_type {
         ListMacrosRequest list_macros = 1;
         GetMacroRequest get_macro = 2;
@@ -97,6 +107,9 @@ message Request {
         SaveMacrosRequest save_macros = 9;
         DiscardMacrosRequest discard_macros = 10;
         AppendMacroStepRequest append_macro_step = 11;
+        CreateMacroRequest create_macro = 12;
+        DeleteMacroRequest delete_macro = 13;
+        RenameMacroRequest rename_macro = 14;
     }
 }
 

--- a/src/hooks/useRuntimeMacro.ts
+++ b/src/hooks/useRuntimeMacro.ts
@@ -9,19 +9,10 @@ import {
   type MacroSummary,
   type StatusResponse,
 } from "../proto/cormoran/runtime_macro/runtime_macro";
-import { SettingWriteMode } from "../proto/cormoran/zmk/custom_settings/custom_settings";
-import { encodeRuntimeMacroSteps } from "../lib/runtimeMacroCodec";
-import { useCustomSettings } from "./useCustomSettings";
 
 export type { MacroDetail, MacroGlobalSettings, MacroStep, MacroSummary };
 
 export const RUNTIME_MACRO_SUBSYSTEM_IDENTIFIER = "cormoran__runtime_macro";
-
-// The custom-settings keyspace prefix for runtime macro entries. Raw
-// create/delete/rename go through the generic custom-settings
-// CreateSetting/DeleteSetting RPC (subsystem "cormoran_custom_settings"),
-// not a runtime-macro-specific request - the firmware routes by key prefix.
-export const MACRO_KEY_PREFIX = "macro/";
 
 const CODEC = {
   encode: (request: Request) => Request.encode(request).finish(),
@@ -42,11 +33,7 @@ export interface UseRuntimeMacroReturn {
   getMacro: (slot: number) => Promise<MacroDetail | null>;
   createMacro: (name: string) => Promise<boolean>;
   deleteMacro: (name: string) => Promise<boolean>;
-  renameMacro: (
-    oldName: string,
-    newName: string,
-    steps: MacroStep[],
-  ) => Promise<boolean>;
+  renameMacro: (oldName: string, newName: string) => Promise<boolean>;
   setMacroStepCount: (
     slot: number,
     stepCount: number,
@@ -73,7 +60,6 @@ export function useRuntimeMacro(): UseRuntimeMacroReturn {
     RUNTIME_MACRO_SUBSYSTEM_IDENTIFIER,
     CODEC,
   );
-  const customSettings = useCustomSettings();
   const [macros, setMacros] = useState<MacroSummary[]>([]);
   const [globalSettings, setGlobalSettings] =
     useState<MacroGlobalSettings | null>(null);
@@ -268,112 +254,49 @@ export function useRuntimeMacro(): UseRuntimeMacroReturn {
     [runMutation],
   );
 
-  // Raw create/delete/rename go through the generic custom-settings
-  // CreateSetting/DeleteSetting RPC (subsystem "cormoran_custom_settings"),
-  // not a runtime-macro-specific request.
   const createMacro = useCallback(
     async (name: string): Promise<boolean> => {
-      setIsLoading(true);
-      setError(null);
-      try {
-        const response = await customSettings.createSetting(
-          MACRO_KEY_PREFIX + name,
-          { bytesValue: Uint8Array.from([1]) }, // format version, no steps
-          SettingWriteMode.SETTING_WRITE_MODE_MEMORY,
-        );
-        if (response.error) {
-          setError(response.error.message);
-          return false;
-        }
+      const status = await runMutation(
+        Request.create({ createMacro: { name, persist: false } }),
+        false,
+      );
+      if (status !== null) {
         await loadMacros();
         return true;
-      } catch (err) {
-        console.error("Failed to create runtime macro:", err);
-        setError(
-          `Failed to create runtime macro: ${
-            err instanceof Error ? err.message : "Unknown error"
-          }`,
-        );
-        return false;
-      } finally {
-        setIsLoading(false);
       }
+      return false;
     },
-    [customSettings, loadMacros],
+    [runMutation, loadMacros],
   );
 
   const deleteMacro = useCallback(
     async (name: string): Promise<boolean> => {
-      setIsLoading(true);
-      setError(null);
-      try {
-        const response = await customSettings.deleteSetting(
-          MACRO_KEY_PREFIX + name,
-        );
-        if (response.error) {
-          setError(response.error.message);
-          return false;
-        }
+      const status = await runMutation(
+        Request.create({ deleteMacro: { name } }),
+        false,
+      );
+      if (status !== null) {
         await loadMacros();
         return true;
-      } catch (err) {
-        console.error("Failed to delete runtime macro:", err);
-        setError(
-          `Failed to delete runtime macro: ${
-            err instanceof Error ? err.message : "Unknown error"
-          }`,
-        );
-        return false;
-      } finally {
-        setIsLoading(false);
       }
+      return false;
     },
-    [customSettings, loadMacros],
+    [runMutation, loadMacros],
   );
 
   const renameMacro = useCallback(
-    async (
-      oldName: string,
-      newName: string,
-      steps: MacroStep[],
-    ): Promise<boolean> => {
-      setIsLoading(true);
-      setError(null);
-      try {
-        const encoded = encodeRuntimeMacroSteps(steps);
-        // Create the new name first (carrying the current body), then delete
-        // the old one - so a failure never loses data.
-        const createResponse = await customSettings.createSetting(
-          MACRO_KEY_PREFIX + newName,
-          { bytesValue: encoded },
-          SettingWriteMode.SETTING_WRITE_MODE_MEMORY,
-        );
-        if (createResponse.error) {
-          setError(createResponse.error.message);
-          return false;
-        }
-        const deleteResponse = await customSettings.deleteSetting(
-          MACRO_KEY_PREFIX + oldName,
-        );
-        if (deleteResponse.error) {
-          setError(deleteResponse.error.message);
-          return false;
-        }
+    async (oldName: string, newName: string): Promise<boolean> => {
+      const status = await runMutation(
+        Request.create({ renameMacro: { oldName, newName, persist: false } }),
+        false,
+      );
+      if (status !== null) {
         await loadMacros();
         return true;
-      } catch (err) {
-        console.error("Failed to rename runtime macro:", err);
-        setError(
-          `Failed to rename runtime macro: ${
-            err instanceof Error ? err.message : "Unknown error"
-          }`,
-        );
-        return false;
-      } finally {
-        setIsLoading(false);
       }
+      return false;
     },
-    [customSettings, loadMacros],
+    [runMutation, loadMacros],
   );
 
   const saveMacros = useCallback(async (): Promise<boolean> => {

--- a/src/lib/transport/__tests__/demo-runtime-macro.test.ts
+++ b/src/lib/transport/__tests__/demo-runtime-macro.test.ts
@@ -9,6 +9,10 @@ import {
   SettingWriteMode,
 } from "../../../proto/cormoran/zmk/custom_settings/custom_settings";
 
+// Keep legacy custom-settings helpers for the backwards-compat test that
+// verifies the keyspace-change path still works when the old firmware path
+// is used.
+
 describe("RuntimeMacroHandler", () => {
   let customSettings: CustomSettingsHandler;
   let handler: RuntimeMacroHandler;
@@ -138,7 +142,65 @@ describe("RuntimeMacroHandler", () => {
     expect(after.getMacro?.macro?.steps[initialCount].delay?.delayMs).toBe(50);
   });
 
-  it("creates a new macro when the custom-settings keyspace gains a matching entry", () => {
+  it("creates a new macro via native createMacro RPC", () => {
+    const createResponse = handler.process(
+      Request.create({ createMacro: { name: "new-macro", persist: false } }),
+    );
+    expect(createResponse.error).toBeUndefined();
+    expect(createResponse.status?.affectedCount).toBe(1);
+
+    const listResponse = handler.process(Request.create({ listMacros: {} }));
+    const created = listResponse.listMacros?.macros.find(
+      (macro) => macro.name === "new-macro",
+    );
+    expect(created).toBeDefined();
+    expect(created?.encodedSize).toBe(0);
+  });
+
+  it("removes a macro via native deleteMacro RPC", () => {
+    const before = handler.process(Request.create({ listMacros: {} }));
+    expect(
+      before.listMacros?.macros.some((macro) => macro.name === "Hello"),
+    ).toBe(true);
+
+    const deleteResponse = handler.process(
+      Request.create({ deleteMacro: { name: "Hello" } }),
+    );
+    expect(deleteResponse.error).toBeUndefined();
+    expect(deleteResponse.status?.affectedCount).toBe(1);
+
+    const after = handler.process(Request.create({ listMacros: {} }));
+    expect(
+      after.listMacros?.macros.some((macro) => macro.name === "Hello"),
+    ).toBe(false);
+  });
+
+  it("renames a macro via native renameMacro RPC preserving steps", () => {
+    const before = handler.process(Request.create({ getMacro: { slot: 0 } }));
+    const stepsBefore = before.getMacro?.macro?.steps.length ?? 0;
+    expect(stepsBefore).toBeGreaterThan(0);
+
+    const renameResponse = handler.process(
+      Request.create({
+        renameMacro: { oldName: "Hello", newName: "Hi", persist: false },
+      }),
+    );
+    expect(renameResponse.error).toBeUndefined();
+    expect(renameResponse.status?.affectedCount).toBe(1);
+
+    const listResponse = handler.process(Request.create({ listMacros: {} }));
+    expect(
+      listResponse.listMacros?.macros.some((m) => m.name === "Hi"),
+    ).toBe(true);
+    expect(
+      listResponse.listMacros?.macros.some((m) => m.name === "Hello"),
+    ).toBe(false);
+
+    const after = handler.process(Request.create({ getMacro: { slot: 0 } }));
+    expect(after.getMacro?.macro?.steps.length).toBe(stepsBefore);
+  });
+
+  it("creates a new macro when the custom-settings keyspace gains a matching entry (legacy path)", () => {
     const createResponse = customSettings.process(
       CustomSettingsRequest.create({
         createSetting: {
@@ -158,7 +220,7 @@ describe("RuntimeMacroHandler", () => {
     expect(created?.encodedSize).toBe(0);
   });
 
-  it("removes a macro when its custom-settings keyspace entry is deleted", () => {
+  it("removes a macro when its custom-settings keyspace entry is deleted (legacy path)", () => {
     const before = handler.process(Request.create({ listMacros: {} }));
     expect(
       before.listMacros?.macros.some((macro) => macro.name === "Hello"),

--- a/src/lib/transport/demo-runtime-macro.ts
+++ b/src/lib/transport/demo-runtime-macro.ts
@@ -232,6 +232,45 @@ export class RuntimeMacroHandler {
       return { status: { affectedCount: 1, message: "Macro step appended" } };
     }
 
+    if (request.createMacro !== undefined) {
+      const { name, persist } = request.createMacro;
+      if (this.macros.some((m) => m.name === name)) {
+        return { error: { message: `Macro already exists: ${name}` } };
+      }
+      this.macros.push(createMacro(this.nextSlot++, name));
+      this.refreshPoolUsage();
+      this.markChanged(persist);
+      return { status: { affectedCount: 1, message: "Macro created" } };
+    }
+
+    if (request.deleteMacro !== undefined) {
+      const { name } = request.deleteMacro;
+      const index = this.macros.findIndex((m) => m.name === name);
+      if (index === -1) {
+        return { error: { message: `Macro not found: ${name}` } };
+      }
+      this.macros.splice(index, 1);
+      this.refreshPoolUsage();
+      this.markChanged(false);
+      return { status: { affectedCount: 1, message: "Macro deleted" } };
+    }
+
+    if (request.renameMacro !== undefined) {
+      const { oldName, newName, persist } = request.renameMacro;
+      const macro = this.macros.find((m) => m.name === oldName);
+      if (!macro) {
+        return { error: { message: `Macro not found: ${oldName}` } };
+      }
+      if (this.macros.some((m) => m.name === newName)) {
+        return {
+          error: { message: `Macro already exists: ${newName}` },
+        };
+      }
+      macro.name = newName;
+      this.markChanged(persist);
+      return { status: { affectedCount: 1, message: "Macro renamed" } };
+    }
+
     if (request.saveMacros !== undefined) {
       const affectedCount = this.pendingChanges ? 1 : 0;
       this.persistentMacros = this.macros.map(cloneMacro);

--- a/src/pages/MacroPage.tsx
+++ b/src/pages/MacroPage.tsx
@@ -464,11 +464,7 @@ export function MacroPage() {
       setRenameDraft(loadedMacro.name);
       return;
     }
-    const ok = await runtimeMacro.renameMacro(
-      loadedMacro.name,
-      trimmedName,
-      loadedMacro.steps,
-    );
+    const ok = await runtimeMacro.renameMacro(loadedMacro.name, trimmedName);
     if (ok) {
       setSelectedName(trimmedName);
       setLoadedMacro({ ...loadedMacro, name: trimmedName });

--- a/src/proto/cormoran/runtime_macro/runtime_macro.ts
+++ b/src/proto/cormoran/runtime_macro/runtime_macro.ts
@@ -9,15 +9,13 @@ import { BinaryReader, BinaryWriter } from "@bufbuild/protobuf/wire";
 
 export const protobufPackage = "cormoran.runtime_macro";
 
-export interface ListMacrosRequest {
-}
+export interface ListMacrosRequest {}
 
 export interface GetMacroRequest {
   slot: number;
 }
 
-export interface GetMacroGlobalSettingsRequest {
-}
+export interface GetMacroGlobalSettingsRequest {}
 
 export interface MacroSummary {
   slot: number;
@@ -78,10 +76,23 @@ export interface SetTapMsRequest {
   persist: boolean;
 }
 
-export interface SaveMacrosRequest {
+export interface SaveMacrosRequest {}
+
+export interface DiscardMacrosRequest {}
+
+export interface CreateMacroRequest {
+  name: string;
+  persist: boolean;
 }
 
-export interface DiscardMacrosRequest {
+export interface DeleteMacroRequest {
+  name: string;
+}
+
+export interface RenameMacroRequest {
+  oldName: string;
+  newName: string;
+  persist: boolean;
 }
 
 export interface Request {
@@ -94,6 +105,9 @@ export interface Request {
   saveMacros?: SaveMacrosRequest | undefined;
   discardMacros?: DiscardMacrosRequest | undefined;
   appendMacroStep?: AppendMacroStepRequest | undefined;
+  createMacro?: CreateMacroRequest | undefined;
+  deleteMacro?: DeleteMacroRequest | undefined;
+  renameMacro?: RenameMacroRequest | undefined;
 }
 
 export interface ErrorResponse {
@@ -144,12 +158,16 @@ function createBaseListMacrosRequest(): ListMacrosRequest {
 }
 
 export const ListMacrosRequest: MessageFns<ListMacrosRequest> = {
-  encode(_: ListMacrosRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+  encode(
+    _: ListMacrosRequest,
+    writer: BinaryWriter = new BinaryWriter(),
+  ): BinaryWriter {
     return writer;
   },
 
   decode(input: BinaryReader | Uint8Array, length?: number): ListMacrosRequest {
-    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const reader =
+      input instanceof BinaryReader ? input : new BinaryReader(input);
     const end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseListMacrosRequest();
     while (reader.pos < end) {
@@ -178,7 +196,10 @@ function createBaseGetMacroRequest(): GetMacroRequest {
 }
 
 export const GetMacroRequest: MessageFns<GetMacroRequest> = {
-  encode(message: GetMacroRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+  encode(
+    message: GetMacroRequest,
+    writer: BinaryWriter = new BinaryWriter(),
+  ): BinaryWriter {
     if (message.slot !== 0) {
       writer.uint32(8).uint32(message.slot);
     }
@@ -186,7 +207,8 @@ export const GetMacroRequest: MessageFns<GetMacroRequest> = {
   },
 
   decode(input: BinaryReader | Uint8Array, length?: number): GetMacroRequest {
-    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const reader =
+      input instanceof BinaryReader ? input : new BinaryReader(input);
     const end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseGetMacroRequest();
     while (reader.pos < end) {
@@ -223,42 +245,57 @@ function createBaseGetMacroGlobalSettingsRequest(): GetMacroGlobalSettingsReques
   return {};
 }
 
-export const GetMacroGlobalSettingsRequest: MessageFns<GetMacroGlobalSettingsRequest> = {
-  encode(_: GetMacroGlobalSettingsRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    return writer;
-  },
+export const GetMacroGlobalSettingsRequest: MessageFns<GetMacroGlobalSettingsRequest> =
+  {
+    encode(
+      _: GetMacroGlobalSettingsRequest,
+      writer: BinaryWriter = new BinaryWriter(),
+    ): BinaryWriter {
+      return writer;
+    },
 
-  decode(input: BinaryReader | Uint8Array, length?: number): GetMacroGlobalSettingsRequest {
-    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
-    const end = length === undefined ? reader.len : reader.pos + length;
-    const message = createBaseGetMacroGlobalSettingsRequest();
-    while (reader.pos < end) {
-      const tag = reader.uint32();
-      switch (tag >>> 3) {
+    decode(
+      input: BinaryReader | Uint8Array,
+      length?: number,
+    ): GetMacroGlobalSettingsRequest {
+      const reader =
+        input instanceof BinaryReader ? input : new BinaryReader(input);
+      const end = length === undefined ? reader.len : reader.pos + length;
+      const message = createBaseGetMacroGlobalSettingsRequest();
+      while (reader.pos < end) {
+        const tag = reader.uint32();
+        switch (tag >>> 3) {
+        }
+        if ((tag & 7) === 4 || tag === 0) {
+          break;
+        }
+        reader.skip(tag & 7);
       }
-      if ((tag & 7) === 4 || tag === 0) {
-        break;
-      }
-      reader.skip(tag & 7);
-    }
-    return message;
-  },
+      return message;
+    },
 
-  create(base?: DeepPartial<GetMacroGlobalSettingsRequest>): GetMacroGlobalSettingsRequest {
-    return GetMacroGlobalSettingsRequest.fromPartial(base ?? {});
-  },
-  fromPartial(_: DeepPartial<GetMacroGlobalSettingsRequest>): GetMacroGlobalSettingsRequest {
-    const message = createBaseGetMacroGlobalSettingsRequest();
-    return message;
-  },
-};
+    create(
+      base?: DeepPartial<GetMacroGlobalSettingsRequest>,
+    ): GetMacroGlobalSettingsRequest {
+      return GetMacroGlobalSettingsRequest.fromPartial(base ?? {});
+    },
+    fromPartial(
+      _: DeepPartial<GetMacroGlobalSettingsRequest>,
+    ): GetMacroGlobalSettingsRequest {
+      const message = createBaseGetMacroGlobalSettingsRequest();
+      return message;
+    },
+  };
 
 function createBaseMacroSummary(): MacroSummary {
   return { slot: 0, name: "", encodedSize: 0 };
 }
 
 export const MacroSummary: MessageFns<MacroSummary> = {
-  encode(message: MacroSummary, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+  encode(
+    message: MacroSummary,
+    writer: BinaryWriter = new BinaryWriter(),
+  ): BinaryWriter {
     if (message.slot !== 0) {
       writer.uint32(8).uint32(message.slot);
     }
@@ -272,7 +309,8 @@ export const MacroSummary: MessageFns<MacroSummary> = {
   },
 
   decode(input: BinaryReader | Uint8Array, length?: number): MacroSummary {
-    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const reader =
+      input instanceof BinaryReader ? input : new BinaryReader(input);
     const end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseMacroSummary();
     while (reader.pos < end) {
@@ -328,7 +366,10 @@ function createBaseBehaviorBinding(): BehaviorBinding {
 }
 
 export const BehaviorBinding: MessageFns<BehaviorBinding> = {
-  encode(message: BehaviorBinding, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+  encode(
+    message: BehaviorBinding,
+    writer: BinaryWriter = new BinaryWriter(),
+  ): BinaryWriter {
     if (message.behaviorId !== 0) {
       writer.uint32(8).uint32(message.behaviorId);
     }
@@ -342,7 +383,8 @@ export const BehaviorBinding: MessageFns<BehaviorBinding> = {
   },
 
   decode(input: BinaryReader | Uint8Array, length?: number): BehaviorBinding {
-    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const reader =
+      input instanceof BinaryReader ? input : new BinaryReader(input);
     const end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseBehaviorBinding();
     while (reader.pos < end) {
@@ -398,7 +440,10 @@ function createBaseDelayStep(): DelayStep {
 }
 
 export const DelayStep: MessageFns<DelayStep> = {
-  encode(message: DelayStep, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+  encode(
+    message: DelayStep,
+    writer: BinaryWriter = new BinaryWriter(),
+  ): BinaryWriter {
     if (message.delayMs !== 0) {
       writer.uint32(8).uint32(message.delayMs);
     }
@@ -406,7 +451,8 @@ export const DelayStep: MessageFns<DelayStep> = {
   },
 
   decode(input: BinaryReader | Uint8Array, length?: number): DelayStep {
-    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const reader =
+      input instanceof BinaryReader ? input : new BinaryReader(input);
     const end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseDelayStep();
     while (reader.pos < end) {
@@ -444,15 +490,22 @@ function createBaseKeyTapSequenceStep(): KeyTapSequenceStep {
 }
 
 export const KeyTapSequenceStep: MessageFns<KeyTapSequenceStep> = {
-  encode(message: KeyTapSequenceStep, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+  encode(
+    message: KeyTapSequenceStep,
+    writer: BinaryWriter = new BinaryWriter(),
+  ): BinaryWriter {
     if (message.packedKeys.length !== 0) {
       writer.uint32(10).bytes(message.packedKeys);
     }
     return writer;
   },
 
-  decode(input: BinaryReader | Uint8Array, length?: number): KeyTapSequenceStep {
-    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+  decode(
+    input: BinaryReader | Uint8Array,
+    length?: number,
+  ): KeyTapSequenceStep {
+    const reader =
+      input instanceof BinaryReader ? input : new BinaryReader(input);
     const end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseKeyTapSequenceStep();
     while (reader.pos < end) {
@@ -486,11 +539,20 @@ export const KeyTapSequenceStep: MessageFns<KeyTapSequenceStep> = {
 };
 
 function createBaseMacroStep(): MacroStep {
-  return { down: undefined, up: undefined, tap: undefined, delay: undefined, keyTapSequence: undefined };
+  return {
+    down: undefined,
+    up: undefined,
+    tap: undefined,
+    delay: undefined,
+    keyTapSequence: undefined,
+  };
 }
 
 export const MacroStep: MessageFns<MacroStep> = {
-  encode(message: MacroStep, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+  encode(
+    message: MacroStep,
+    writer: BinaryWriter = new BinaryWriter(),
+  ): BinaryWriter {
     if (message.down !== undefined) {
       BehaviorBinding.encode(message.down, writer.uint32(10).fork()).join();
     }
@@ -504,13 +566,17 @@ export const MacroStep: MessageFns<MacroStep> = {
       DelayStep.encode(message.delay, writer.uint32(34).fork()).join();
     }
     if (message.keyTapSequence !== undefined) {
-      KeyTapSequenceStep.encode(message.keyTapSequence, writer.uint32(42).fork()).join();
+      KeyTapSequenceStep.encode(
+        message.keyTapSequence,
+        writer.uint32(42).fork(),
+      ).join();
     }
     return writer;
   },
 
   decode(input: BinaryReader | Uint8Array, length?: number): MacroStep {
-    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const reader =
+      input instanceof BinaryReader ? input : new BinaryReader(input);
     const end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseMacroStep();
     while (reader.pos < end) {
@@ -553,7 +619,10 @@ export const MacroStep: MessageFns<MacroStep> = {
             break;
           }
 
-          message.keyTapSequence = KeyTapSequenceStep.decode(reader, reader.uint32());
+          message.keyTapSequence = KeyTapSequenceStep.decode(
+            reader,
+            reader.uint32(),
+          );
           continue;
         }
       }
@@ -570,19 +639,26 @@ export const MacroStep: MessageFns<MacroStep> = {
   },
   fromPartial(object: DeepPartial<MacroStep>): MacroStep {
     const message = createBaseMacroStep();
-    message.down = (object.down !== undefined && object.down !== null)
-      ? BehaviorBinding.fromPartial(object.down)
-      : undefined;
-    message.up = (object.up !== undefined && object.up !== null) ? BehaviorBinding.fromPartial(object.up) : undefined;
-    message.tap = (object.tap !== undefined && object.tap !== null)
-      ? BehaviorBinding.fromPartial(object.tap)
-      : undefined;
-    message.delay = (object.delay !== undefined && object.delay !== null)
-      ? DelayStep.fromPartial(object.delay)
-      : undefined;
-    message.keyTapSequence = (object.keyTapSequence !== undefined && object.keyTapSequence !== null)
-      ? KeyTapSequenceStep.fromPartial(object.keyTapSequence)
-      : undefined;
+    message.down =
+      object.down !== undefined && object.down !== null
+        ? BehaviorBinding.fromPartial(object.down)
+        : undefined;
+    message.up =
+      object.up !== undefined && object.up !== null
+        ? BehaviorBinding.fromPartial(object.up)
+        : undefined;
+    message.tap =
+      object.tap !== undefined && object.tap !== null
+        ? BehaviorBinding.fromPartial(object.tap)
+        : undefined;
+    message.delay =
+      object.delay !== undefined && object.delay !== null
+        ? DelayStep.fromPartial(object.delay)
+        : undefined;
+    message.keyTapSequence =
+      object.keyTapSequence !== undefined && object.keyTapSequence !== null
+        ? KeyTapSequenceStep.fromPartial(object.keyTapSequence)
+        : undefined;
     return message;
   },
 };
@@ -592,7 +668,10 @@ function createBaseMacroDetail(): MacroDetail {
 }
 
 export const MacroDetail: MessageFns<MacroDetail> = {
-  encode(message: MacroDetail, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+  encode(
+    message: MacroDetail,
+    writer: BinaryWriter = new BinaryWriter(),
+  ): BinaryWriter {
     if (message.slot !== 0) {
       writer.uint32(8).uint32(message.slot);
     }
@@ -609,7 +688,8 @@ export const MacroDetail: MessageFns<MacroDetail> = {
   },
 
   decode(input: BinaryReader | Uint8Array, length?: number): MacroDetail {
-    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const reader =
+      input instanceof BinaryReader ? input : new BinaryReader(input);
     const end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseMacroDetail();
     while (reader.pos < end) {
@@ -674,7 +754,10 @@ function createBaseSetMacroStepCountRequest(): SetMacroStepCountRequest {
 }
 
 export const SetMacroStepCountRequest: MessageFns<SetMacroStepCountRequest> = {
-  encode(message: SetMacroStepCountRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+  encode(
+    message: SetMacroStepCountRequest,
+    writer: BinaryWriter = new BinaryWriter(),
+  ): BinaryWriter {
     if (message.slot !== 0) {
       writer.uint32(8).uint32(message.slot);
     }
@@ -687,8 +770,12 @@ export const SetMacroStepCountRequest: MessageFns<SetMacroStepCountRequest> = {
     return writer;
   },
 
-  decode(input: BinaryReader | Uint8Array, length?: number): SetMacroStepCountRequest {
-    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+  decode(
+    input: BinaryReader | Uint8Array,
+    length?: number,
+  ): SetMacroStepCountRequest {
+    const reader =
+      input instanceof BinaryReader ? input : new BinaryReader(input);
     const end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseSetMacroStepCountRequest();
     while (reader.pos < end) {
@@ -727,10 +814,14 @@ export const SetMacroStepCountRequest: MessageFns<SetMacroStepCountRequest> = {
     return message;
   },
 
-  create(base?: DeepPartial<SetMacroStepCountRequest>): SetMacroStepCountRequest {
+  create(
+    base?: DeepPartial<SetMacroStepCountRequest>,
+  ): SetMacroStepCountRequest {
     return SetMacroStepCountRequest.fromPartial(base ?? {});
   },
-  fromPartial(object: DeepPartial<SetMacroStepCountRequest>): SetMacroStepCountRequest {
+  fromPartial(
+    object: DeepPartial<SetMacroStepCountRequest>,
+  ): SetMacroStepCountRequest {
     const message = createBaseSetMacroStepCountRequest();
     message.slot = object.slot ?? 0;
     message.stepCount = object.stepCount ?? 0;
@@ -744,7 +835,10 @@ function createBaseSetMacroStepRequest(): SetMacroStepRequest {
 }
 
 export const SetMacroStepRequest: MessageFns<SetMacroStepRequest> = {
-  encode(message: SetMacroStepRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+  encode(
+    message: SetMacroStepRequest,
+    writer: BinaryWriter = new BinaryWriter(),
+  ): BinaryWriter {
     if (message.slot !== 0) {
       writer.uint32(8).uint32(message.slot);
     }
@@ -760,8 +854,12 @@ export const SetMacroStepRequest: MessageFns<SetMacroStepRequest> = {
     return writer;
   },
 
-  decode(input: BinaryReader | Uint8Array, length?: number): SetMacroStepRequest {
-    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+  decode(
+    input: BinaryReader | Uint8Array,
+    length?: number,
+  ): SetMacroStepRequest {
+    const reader =
+      input instanceof BinaryReader ? input : new BinaryReader(input);
     const end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseSetMacroStepRequest();
     while (reader.pos < end) {
@@ -815,7 +913,10 @@ export const SetMacroStepRequest: MessageFns<SetMacroStepRequest> = {
     const message = createBaseSetMacroStepRequest();
     message.slot = object.slot ?? 0;
     message.stepIndex = object.stepIndex ?? 0;
-    message.step = (object.step !== undefined && object.step !== null) ? MacroStep.fromPartial(object.step) : undefined;
+    message.step =
+      object.step !== undefined && object.step !== null
+        ? MacroStep.fromPartial(object.step)
+        : undefined;
     message.persist = object.persist ?? false;
     return message;
   },
@@ -826,7 +927,10 @@ function createBaseAppendMacroStepRequest(): AppendMacroStepRequest {
 }
 
 export const AppendMacroStepRequest: MessageFns<AppendMacroStepRequest> = {
-  encode(message: AppendMacroStepRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+  encode(
+    message: AppendMacroStepRequest,
+    writer: BinaryWriter = new BinaryWriter(),
+  ): BinaryWriter {
     if (message.slot !== 0) {
       writer.uint32(8).uint32(message.slot);
     }
@@ -839,8 +943,12 @@ export const AppendMacroStepRequest: MessageFns<AppendMacroStepRequest> = {
     return writer;
   },
 
-  decode(input: BinaryReader | Uint8Array, length?: number): AppendMacroStepRequest {
-    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+  decode(
+    input: BinaryReader | Uint8Array,
+    length?: number,
+  ): AppendMacroStepRequest {
+    const reader =
+      input instanceof BinaryReader ? input : new BinaryReader(input);
     const end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseAppendMacroStepRequest();
     while (reader.pos < end) {
@@ -882,10 +990,15 @@ export const AppendMacroStepRequest: MessageFns<AppendMacroStepRequest> = {
   create(base?: DeepPartial<AppendMacroStepRequest>): AppendMacroStepRequest {
     return AppendMacroStepRequest.fromPartial(base ?? {});
   },
-  fromPartial(object: DeepPartial<AppendMacroStepRequest>): AppendMacroStepRequest {
+  fromPartial(
+    object: DeepPartial<AppendMacroStepRequest>,
+  ): AppendMacroStepRequest {
     const message = createBaseAppendMacroStepRequest();
     message.slot = object.slot ?? 0;
-    message.step = (object.step !== undefined && object.step !== null) ? MacroStep.fromPartial(object.step) : undefined;
+    message.step =
+      object.step !== undefined && object.step !== null
+        ? MacroStep.fromPartial(object.step)
+        : undefined;
     message.persist = object.persist ?? false;
     return message;
   },
@@ -896,7 +1009,10 @@ function createBaseSetTapMsRequest(): SetTapMsRequest {
 }
 
 export const SetTapMsRequest: MessageFns<SetTapMsRequest> = {
-  encode(message: SetTapMsRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+  encode(
+    message: SetTapMsRequest,
+    writer: BinaryWriter = new BinaryWriter(),
+  ): BinaryWriter {
     if (message.tapMs !== 0) {
       writer.uint32(8).uint32(message.tapMs);
     }
@@ -907,7 +1023,8 @@ export const SetTapMsRequest: MessageFns<SetTapMsRequest> = {
   },
 
   decode(input: BinaryReader | Uint8Array, length?: number): SetTapMsRequest {
-    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const reader =
+      input instanceof BinaryReader ? input : new BinaryReader(input);
     const end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseSetTapMsRequest();
     while (reader.pos < end) {
@@ -954,12 +1071,16 @@ function createBaseSaveMacrosRequest(): SaveMacrosRequest {
 }
 
 export const SaveMacrosRequest: MessageFns<SaveMacrosRequest> = {
-  encode(_: SaveMacrosRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+  encode(
+    _: SaveMacrosRequest,
+    writer: BinaryWriter = new BinaryWriter(),
+  ): BinaryWriter {
     return writer;
   },
 
   decode(input: BinaryReader | Uint8Array, length?: number): SaveMacrosRequest {
-    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const reader =
+      input instanceof BinaryReader ? input : new BinaryReader(input);
     const end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseSaveMacrosRequest();
     while (reader.pos < end) {
@@ -988,12 +1109,19 @@ function createBaseDiscardMacrosRequest(): DiscardMacrosRequest {
 }
 
 export const DiscardMacrosRequest: MessageFns<DiscardMacrosRequest> = {
-  encode(_: DiscardMacrosRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+  encode(
+    _: DiscardMacrosRequest,
+    writer: BinaryWriter = new BinaryWriter(),
+  ): BinaryWriter {
     return writer;
   },
 
-  decode(input: BinaryReader | Uint8Array, length?: number): DiscardMacrosRequest {
-    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+  decode(
+    input: BinaryReader | Uint8Array,
+    length?: number,
+  ): DiscardMacrosRequest {
+    const reader =
+      input instanceof BinaryReader ? input : new BinaryReader(input);
     const end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseDiscardMacrosRequest();
     while (reader.pos < end) {
@@ -1017,6 +1145,195 @@ export const DiscardMacrosRequest: MessageFns<DiscardMacrosRequest> = {
   },
 };
 
+function createBaseCreateMacroRequest(): CreateMacroRequest {
+  return { name: "", persist: false };
+}
+
+export const CreateMacroRequest: MessageFns<CreateMacroRequest> = {
+  encode(
+    message: CreateMacroRequest,
+    writer: BinaryWriter = new BinaryWriter(),
+  ): BinaryWriter {
+    if (message.name !== "") {
+      writer.uint32(10).string(message.name);
+    }
+    if (message.persist !== false) {
+      writer.uint32(16).bool(message.persist);
+    }
+    return writer;
+  },
+
+  decode(
+    input: BinaryReader | Uint8Array,
+    length?: number,
+  ): CreateMacroRequest {
+    const reader =
+      input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseCreateMacroRequest();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+          message.name = reader.string();
+          continue;
+        }
+        case 2: {
+          if (tag !== 16) {
+            break;
+          }
+          message.persist = reader.bool();
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  create(base?: DeepPartial<CreateMacroRequest>): CreateMacroRequest {
+    return CreateMacroRequest.fromPartial(base ?? {});
+  },
+  fromPartial(object: DeepPartial<CreateMacroRequest>): CreateMacroRequest {
+    const message = createBaseCreateMacroRequest();
+    message.name = object.name ?? "";
+    message.persist = object.persist ?? false;
+    return message;
+  },
+};
+
+function createBaseDeleteMacroRequest(): DeleteMacroRequest {
+  return { name: "" };
+}
+
+export const DeleteMacroRequest: MessageFns<DeleteMacroRequest> = {
+  encode(
+    message: DeleteMacroRequest,
+    writer: BinaryWriter = new BinaryWriter(),
+  ): BinaryWriter {
+    if (message.name !== "") {
+      writer.uint32(10).string(message.name);
+    }
+    return writer;
+  },
+
+  decode(
+    input: BinaryReader | Uint8Array,
+    length?: number,
+  ): DeleteMacroRequest {
+    const reader =
+      input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseDeleteMacroRequest();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+          message.name = reader.string();
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  create(base?: DeepPartial<DeleteMacroRequest>): DeleteMacroRequest {
+    return DeleteMacroRequest.fromPartial(base ?? {});
+  },
+  fromPartial(object: DeepPartial<DeleteMacroRequest>): DeleteMacroRequest {
+    const message = createBaseDeleteMacroRequest();
+    message.name = object.name ?? "";
+    return message;
+  },
+};
+
+function createBaseRenameMacroRequest(): RenameMacroRequest {
+  return { oldName: "", newName: "", persist: false };
+}
+
+export const RenameMacroRequest: MessageFns<RenameMacroRequest> = {
+  encode(
+    message: RenameMacroRequest,
+    writer: BinaryWriter = new BinaryWriter(),
+  ): BinaryWriter {
+    if (message.oldName !== "") {
+      writer.uint32(10).string(message.oldName);
+    }
+    if (message.newName !== "") {
+      writer.uint32(18).string(message.newName);
+    }
+    if (message.persist !== false) {
+      writer.uint32(24).bool(message.persist);
+    }
+    return writer;
+  },
+
+  decode(
+    input: BinaryReader | Uint8Array,
+    length?: number,
+  ): RenameMacroRequest {
+    const reader =
+      input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseRenameMacroRequest();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+          message.oldName = reader.string();
+          continue;
+        }
+        case 2: {
+          if (tag !== 18) {
+            break;
+          }
+          message.newName = reader.string();
+          continue;
+        }
+        case 3: {
+          if (tag !== 24) {
+            break;
+          }
+          message.persist = reader.bool();
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  create(base?: DeepPartial<RenameMacroRequest>): RenameMacroRequest {
+    return RenameMacroRequest.fromPartial(base ?? {});
+  },
+  fromPartial(object: DeepPartial<RenameMacroRequest>): RenameMacroRequest {
+    const message = createBaseRenameMacroRequest();
+    message.oldName = object.oldName ?? "";
+    message.newName = object.newName ?? "";
+    message.persist = object.persist ?? false;
+    return message;
+  },
+};
+
 function createBaseRequest(): Request {
   return {
     listMacros: undefined,
@@ -1028,43 +1345,89 @@ function createBaseRequest(): Request {
     saveMacros: undefined,
     discardMacros: undefined,
     appendMacroStep: undefined,
+    createMacro: undefined,
+    deleteMacro: undefined,
+    renameMacro: undefined,
   };
 }
 
 export const Request: MessageFns<Request> = {
-  encode(message: Request, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+  encode(
+    message: Request,
+    writer: BinaryWriter = new BinaryWriter(),
+  ): BinaryWriter {
     if (message.listMacros !== undefined) {
-      ListMacrosRequest.encode(message.listMacros, writer.uint32(10).fork()).join();
+      ListMacrosRequest.encode(
+        message.listMacros,
+        writer.uint32(10).fork(),
+      ).join();
     }
     if (message.getMacro !== undefined) {
       GetMacroRequest.encode(message.getMacro, writer.uint32(18).fork()).join();
     }
     if (message.setMacroStepCount !== undefined) {
-      SetMacroStepCountRequest.encode(message.setMacroStepCount, writer.uint32(34).fork()).join();
+      SetMacroStepCountRequest.encode(
+        message.setMacroStepCount,
+        writer.uint32(34).fork(),
+      ).join();
     }
     if (message.getMacroGlobalSettings !== undefined) {
-      GetMacroGlobalSettingsRequest.encode(message.getMacroGlobalSettings, writer.uint32(42).fork()).join();
+      GetMacroGlobalSettingsRequest.encode(
+        message.getMacroGlobalSettings,
+        writer.uint32(42).fork(),
+      ).join();
     }
     if (message.setTapMs !== undefined) {
       SetTapMsRequest.encode(message.setTapMs, writer.uint32(50).fork()).join();
     }
     if (message.setMacroStep !== undefined) {
-      SetMacroStepRequest.encode(message.setMacroStep, writer.uint32(58).fork()).join();
+      SetMacroStepRequest.encode(
+        message.setMacroStep,
+        writer.uint32(58).fork(),
+      ).join();
     }
     if (message.saveMacros !== undefined) {
-      SaveMacrosRequest.encode(message.saveMacros, writer.uint32(74).fork()).join();
+      SaveMacrosRequest.encode(
+        message.saveMacros,
+        writer.uint32(74).fork(),
+      ).join();
     }
     if (message.discardMacros !== undefined) {
-      DiscardMacrosRequest.encode(message.discardMacros, writer.uint32(82).fork()).join();
+      DiscardMacrosRequest.encode(
+        message.discardMacros,
+        writer.uint32(82).fork(),
+      ).join();
     }
     if (message.appendMacroStep !== undefined) {
-      AppendMacroStepRequest.encode(message.appendMacroStep, writer.uint32(90).fork()).join();
+      AppendMacroStepRequest.encode(
+        message.appendMacroStep,
+        writer.uint32(90).fork(),
+      ).join();
+    }
+    if (message.createMacro !== undefined) {
+      CreateMacroRequest.encode(
+        message.createMacro,
+        writer.uint32(98).fork(),
+      ).join();
+    }
+    if (message.deleteMacro !== undefined) {
+      DeleteMacroRequest.encode(
+        message.deleteMacro,
+        writer.uint32(106).fork(),
+      ).join();
+    }
+    if (message.renameMacro !== undefined) {
+      RenameMacroRequest.encode(
+        message.renameMacro,
+        writer.uint32(114).fork(),
+      ).join();
     }
     return writer;
   },
 
   decode(input: BinaryReader | Uint8Array, length?: number): Request {
-    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const reader =
+      input instanceof BinaryReader ? input : new BinaryReader(input);
     const end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseRequest();
     while (reader.pos < end) {
@@ -1075,7 +1438,10 @@ export const Request: MessageFns<Request> = {
             break;
           }
 
-          message.listMacros = ListMacrosRequest.decode(reader, reader.uint32());
+          message.listMacros = ListMacrosRequest.decode(
+            reader,
+            reader.uint32(),
+          );
           continue;
         }
         case 2: {
@@ -1091,7 +1457,10 @@ export const Request: MessageFns<Request> = {
             break;
           }
 
-          message.setMacroStepCount = SetMacroStepCountRequest.decode(reader, reader.uint32());
+          message.setMacroStepCount = SetMacroStepCountRequest.decode(
+            reader,
+            reader.uint32(),
+          );
           continue;
         }
         case 5: {
@@ -1099,7 +1468,10 @@ export const Request: MessageFns<Request> = {
             break;
           }
 
-          message.getMacroGlobalSettings = GetMacroGlobalSettingsRequest.decode(reader, reader.uint32());
+          message.getMacroGlobalSettings = GetMacroGlobalSettingsRequest.decode(
+            reader,
+            reader.uint32(),
+          );
           continue;
         }
         case 6: {
@@ -1115,7 +1487,10 @@ export const Request: MessageFns<Request> = {
             break;
           }
 
-          message.setMacroStep = SetMacroStepRequest.decode(reader, reader.uint32());
+          message.setMacroStep = SetMacroStepRequest.decode(
+            reader,
+            reader.uint32(),
+          );
           continue;
         }
         case 9: {
@@ -1123,7 +1498,10 @@ export const Request: MessageFns<Request> = {
             break;
           }
 
-          message.saveMacros = SaveMacrosRequest.decode(reader, reader.uint32());
+          message.saveMacros = SaveMacrosRequest.decode(
+            reader,
+            reader.uint32(),
+          );
           continue;
         }
         case 10: {
@@ -1131,7 +1509,10 @@ export const Request: MessageFns<Request> = {
             break;
           }
 
-          message.discardMacros = DiscardMacrosRequest.decode(reader, reader.uint32());
+          message.discardMacros = DiscardMacrosRequest.decode(
+            reader,
+            reader.uint32(),
+          );
           continue;
         }
         case 11: {
@@ -1139,7 +1520,43 @@ export const Request: MessageFns<Request> = {
             break;
           }
 
-          message.appendMacroStep = AppendMacroStepRequest.decode(reader, reader.uint32());
+          message.appendMacroStep = AppendMacroStepRequest.decode(
+            reader,
+            reader.uint32(),
+          );
+          continue;
+        }
+        case 12: {
+          if (tag !== 98) {
+            break;
+          }
+
+          message.createMacro = CreateMacroRequest.decode(
+            reader,
+            reader.uint32(),
+          );
+          continue;
+        }
+        case 13: {
+          if (tag !== 106) {
+            break;
+          }
+
+          message.deleteMacro = DeleteMacroRequest.decode(
+            reader,
+            reader.uint32(),
+          );
+          continue;
+        }
+        case 14: {
+          if (tag !== 114) {
+            break;
+          }
+
+          message.renameMacro = RenameMacroRequest.decode(
+            reader,
+            reader.uint32(),
+          );
           continue;
         }
       }
@@ -1156,34 +1573,58 @@ export const Request: MessageFns<Request> = {
   },
   fromPartial(object: DeepPartial<Request>): Request {
     const message = createBaseRequest();
-    message.listMacros = (object.listMacros !== undefined && object.listMacros !== null)
-      ? ListMacrosRequest.fromPartial(object.listMacros)
-      : undefined;
-    message.getMacro = (object.getMacro !== undefined && object.getMacro !== null)
-      ? GetMacroRequest.fromPartial(object.getMacro)
-      : undefined;
-    message.setMacroStepCount = (object.setMacroStepCount !== undefined && object.setMacroStepCount !== null)
-      ? SetMacroStepCountRequest.fromPartial(object.setMacroStepCount)
-      : undefined;
-    message.getMacroGlobalSettings =
-      (object.getMacroGlobalSettings !== undefined && object.getMacroGlobalSettings !== null)
-        ? GetMacroGlobalSettingsRequest.fromPartial(object.getMacroGlobalSettings)
+    message.listMacros =
+      object.listMacros !== undefined && object.listMacros !== null
+        ? ListMacrosRequest.fromPartial(object.listMacros)
         : undefined;
-    message.setTapMs = (object.setTapMs !== undefined && object.setTapMs !== null)
-      ? SetTapMsRequest.fromPartial(object.setTapMs)
-      : undefined;
-    message.setMacroStep = (object.setMacroStep !== undefined && object.setMacroStep !== null)
-      ? SetMacroStepRequest.fromPartial(object.setMacroStep)
-      : undefined;
-    message.saveMacros = (object.saveMacros !== undefined && object.saveMacros !== null)
-      ? SaveMacrosRequest.fromPartial(object.saveMacros)
-      : undefined;
-    message.discardMacros = (object.discardMacros !== undefined && object.discardMacros !== null)
-      ? DiscardMacrosRequest.fromPartial(object.discardMacros)
-      : undefined;
-    message.appendMacroStep = (object.appendMacroStep !== undefined && object.appendMacroStep !== null)
-      ? AppendMacroStepRequest.fromPartial(object.appendMacroStep)
-      : undefined;
+    message.getMacro =
+      object.getMacro !== undefined && object.getMacro !== null
+        ? GetMacroRequest.fromPartial(object.getMacro)
+        : undefined;
+    message.setMacroStepCount =
+      object.setMacroStepCount !== undefined &&
+      object.setMacroStepCount !== null
+        ? SetMacroStepCountRequest.fromPartial(object.setMacroStepCount)
+        : undefined;
+    message.getMacroGlobalSettings =
+      object.getMacroGlobalSettings !== undefined &&
+      object.getMacroGlobalSettings !== null
+        ? GetMacroGlobalSettingsRequest.fromPartial(
+            object.getMacroGlobalSettings,
+          )
+        : undefined;
+    message.setTapMs =
+      object.setTapMs !== undefined && object.setTapMs !== null
+        ? SetTapMsRequest.fromPartial(object.setTapMs)
+        : undefined;
+    message.setMacroStep =
+      object.setMacroStep !== undefined && object.setMacroStep !== null
+        ? SetMacroStepRequest.fromPartial(object.setMacroStep)
+        : undefined;
+    message.saveMacros =
+      object.saveMacros !== undefined && object.saveMacros !== null
+        ? SaveMacrosRequest.fromPartial(object.saveMacros)
+        : undefined;
+    message.discardMacros =
+      object.discardMacros !== undefined && object.discardMacros !== null
+        ? DiscardMacrosRequest.fromPartial(object.discardMacros)
+        : undefined;
+    message.appendMacroStep =
+      object.appendMacroStep !== undefined && object.appendMacroStep !== null
+        ? AppendMacroStepRequest.fromPartial(object.appendMacroStep)
+        : undefined;
+    message.createMacro =
+      object.createMacro !== undefined && object.createMacro !== null
+        ? CreateMacroRequest.fromPartial(object.createMacro)
+        : undefined;
+    message.deleteMacro =
+      object.deleteMacro !== undefined && object.deleteMacro !== null
+        ? DeleteMacroRequest.fromPartial(object.deleteMacro)
+        : undefined;
+    message.renameMacro =
+      object.renameMacro !== undefined && object.renameMacro !== null
+        ? RenameMacroRequest.fromPartial(object.renameMacro)
+        : undefined;
     return message;
   },
 };
@@ -1193,7 +1634,10 @@ function createBaseErrorResponse(): ErrorResponse {
 }
 
 export const ErrorResponse: MessageFns<ErrorResponse> = {
-  encode(message: ErrorResponse, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+  encode(
+    message: ErrorResponse,
+    writer: BinaryWriter = new BinaryWriter(),
+  ): BinaryWriter {
     if (message.message !== "") {
       writer.uint32(10).string(message.message);
     }
@@ -1201,7 +1645,8 @@ export const ErrorResponse: MessageFns<ErrorResponse> = {
   },
 
   decode(input: BinaryReader | Uint8Array, length?: number): ErrorResponse {
-    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const reader =
+      input instanceof BinaryReader ? input : new BinaryReader(input);
     const end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseErrorResponse();
     while (reader.pos < end) {
@@ -1239,7 +1684,10 @@ function createBaseStatusResponse(): StatusResponse {
 }
 
 export const StatusResponse: MessageFns<StatusResponse> = {
-  encode(message: StatusResponse, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+  encode(
+    message: StatusResponse,
+    writer: BinaryWriter = new BinaryWriter(),
+  ): BinaryWriter {
     if (message.affectedCount !== 0) {
       writer.uint32(8).uint32(message.affectedCount);
     }
@@ -1250,7 +1698,8 @@ export const StatusResponse: MessageFns<StatusResponse> = {
   },
 
   decode(input: BinaryReader | Uint8Array, length?: number): StatusResponse {
-    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const reader =
+      input instanceof BinaryReader ? input : new BinaryReader(input);
     const end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseStatusResponse();
     while (reader.pos < end) {
@@ -1297,7 +1746,10 @@ function createBaseListMacrosResponse(): ListMacrosResponse {
 }
 
 export const ListMacrosResponse: MessageFns<ListMacrosResponse> = {
-  encode(message: ListMacrosResponse, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+  encode(
+    message: ListMacrosResponse,
+    writer: BinaryWriter = new BinaryWriter(),
+  ): BinaryWriter {
     for (const v of message.macros) {
       MacroSummary.encode(v!, writer.uint32(10).fork()).join();
     }
@@ -1310,8 +1762,12 @@ export const ListMacrosResponse: MessageFns<ListMacrosResponse> = {
     return writer;
   },
 
-  decode(input: BinaryReader | Uint8Array, length?: number): ListMacrosResponse {
-    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+  decode(
+    input: BinaryReader | Uint8Array,
+    length?: number,
+  ): ListMacrosResponse {
+    const reader =
+      input instanceof BinaryReader ? input : new BinaryReader(input);
     const end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseListMacrosResponse();
     while (reader.pos < end) {
@@ -1355,7 +1811,8 @@ export const ListMacrosResponse: MessageFns<ListMacrosResponse> = {
   },
   fromPartial(object: DeepPartial<ListMacrosResponse>): ListMacrosResponse {
     const message = createBaseListMacrosResponse();
-    message.macros = object.macros?.map((e) => MacroSummary.fromPartial(e)) || [];
+    message.macros =
+      object.macros?.map((e) => MacroSummary.fromPartial(e)) || [];
     message.maxMacroBytes = object.maxMacroBytes ?? 0;
     message.maxNameLength = object.maxNameLength ?? 0;
     return message;
@@ -1367,7 +1824,10 @@ function createBaseGetMacroResponse(): GetMacroResponse {
 }
 
 export const GetMacroResponse: MessageFns<GetMacroResponse> = {
-  encode(message: GetMacroResponse, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+  encode(
+    message: GetMacroResponse,
+    writer: BinaryWriter = new BinaryWriter(),
+  ): BinaryWriter {
     if (message.macro !== undefined) {
       MacroDetail.encode(message.macro, writer.uint32(10).fork()).join();
     }
@@ -1375,7 +1835,8 @@ export const GetMacroResponse: MessageFns<GetMacroResponse> = {
   },
 
   decode(input: BinaryReader | Uint8Array, length?: number): GetMacroResponse {
-    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const reader =
+      input instanceof BinaryReader ? input : new BinaryReader(input);
     const end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseGetMacroResponse();
     while (reader.pos < end) {
@@ -1403,19 +1864,29 @@ export const GetMacroResponse: MessageFns<GetMacroResponse> = {
   },
   fromPartial(object: DeepPartial<GetMacroResponse>): GetMacroResponse {
     const message = createBaseGetMacroResponse();
-    message.macro = (object.macro !== undefined && object.macro !== null)
-      ? MacroDetail.fromPartial(object.macro)
-      : undefined;
+    message.macro =
+      object.macro !== undefined && object.macro !== null
+        ? MacroDetail.fromPartial(object.macro)
+        : undefined;
     return message;
   },
 };
 
 function createBaseMacroGlobalSettings(): MacroGlobalSettings {
-  return { tapMs: 0, maxEntries: 0, keyPressBehaviorId: 0, poolBytesTotal: 0, poolBytesUsed: 0 };
+  return {
+    tapMs: 0,
+    maxEntries: 0,
+    keyPressBehaviorId: 0,
+    poolBytesTotal: 0,
+    poolBytesUsed: 0,
+  };
 }
 
 export const MacroGlobalSettings: MessageFns<MacroGlobalSettings> = {
-  encode(message: MacroGlobalSettings, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+  encode(
+    message: MacroGlobalSettings,
+    writer: BinaryWriter = new BinaryWriter(),
+  ): BinaryWriter {
     if (message.tapMs !== 0) {
       writer.uint32(8).uint32(message.tapMs);
     }
@@ -1434,8 +1905,12 @@ export const MacroGlobalSettings: MessageFns<MacroGlobalSettings> = {
     return writer;
   },
 
-  decode(input: BinaryReader | Uint8Array, length?: number): MacroGlobalSettings {
-    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+  decode(
+    input: BinaryReader | Uint8Array,
+    length?: number,
+  ): MacroGlobalSettings {
+    const reader =
+      input instanceof BinaryReader ? input : new BinaryReader(input);
     const end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseMacroGlobalSettings();
     while (reader.pos < end) {
@@ -1508,49 +1983,68 @@ function createBaseGetMacroGlobalSettingsResponse(): GetMacroGlobalSettingsRespo
   return { settings: undefined };
 }
 
-export const GetMacroGlobalSettingsResponse: MessageFns<GetMacroGlobalSettingsResponse> = {
-  encode(message: GetMacroGlobalSettingsResponse, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.settings !== undefined) {
-      MacroGlobalSettings.encode(message.settings, writer.uint32(10).fork()).join();
-    }
-    return writer;
-  },
+export const GetMacroGlobalSettingsResponse: MessageFns<GetMacroGlobalSettingsResponse> =
+  {
+    encode(
+      message: GetMacroGlobalSettingsResponse,
+      writer: BinaryWriter = new BinaryWriter(),
+    ): BinaryWriter {
+      if (message.settings !== undefined) {
+        MacroGlobalSettings.encode(
+          message.settings,
+          writer.uint32(10).fork(),
+        ).join();
+      }
+      return writer;
+    },
 
-  decode(input: BinaryReader | Uint8Array, length?: number): GetMacroGlobalSettingsResponse {
-    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
-    const end = length === undefined ? reader.len : reader.pos + length;
-    const message = createBaseGetMacroGlobalSettingsResponse();
-    while (reader.pos < end) {
-      const tag = reader.uint32();
-      switch (tag >>> 3) {
-        case 1: {
-          if (tag !== 10) {
-            break;
+    decode(
+      input: BinaryReader | Uint8Array,
+      length?: number,
+    ): GetMacroGlobalSettingsResponse {
+      const reader =
+        input instanceof BinaryReader ? input : new BinaryReader(input);
+      const end = length === undefined ? reader.len : reader.pos + length;
+      const message = createBaseGetMacroGlobalSettingsResponse();
+      while (reader.pos < end) {
+        const tag = reader.uint32();
+        switch (tag >>> 3) {
+          case 1: {
+            if (tag !== 10) {
+              break;
+            }
+
+            message.settings = MacroGlobalSettings.decode(
+              reader,
+              reader.uint32(),
+            );
+            continue;
           }
-
-          message.settings = MacroGlobalSettings.decode(reader, reader.uint32());
-          continue;
         }
+        if ((tag & 7) === 4 || tag === 0) {
+          break;
+        }
+        reader.skip(tag & 7);
       }
-      if ((tag & 7) === 4 || tag === 0) {
-        break;
-      }
-      reader.skip(tag & 7);
-    }
-    return message;
-  },
+      return message;
+    },
 
-  create(base?: DeepPartial<GetMacroGlobalSettingsResponse>): GetMacroGlobalSettingsResponse {
-    return GetMacroGlobalSettingsResponse.fromPartial(base ?? {});
-  },
-  fromPartial(object: DeepPartial<GetMacroGlobalSettingsResponse>): GetMacroGlobalSettingsResponse {
-    const message = createBaseGetMacroGlobalSettingsResponse();
-    message.settings = (object.settings !== undefined && object.settings !== null)
-      ? MacroGlobalSettings.fromPartial(object.settings)
-      : undefined;
-    return message;
-  },
-};
+    create(
+      base?: DeepPartial<GetMacroGlobalSettingsResponse>,
+    ): GetMacroGlobalSettingsResponse {
+      return GetMacroGlobalSettingsResponse.fromPartial(base ?? {});
+    },
+    fromPartial(
+      object: DeepPartial<GetMacroGlobalSettingsResponse>,
+    ): GetMacroGlobalSettingsResponse {
+      const message = createBaseGetMacroGlobalSettingsResponse();
+      message.settings =
+        object.settings !== undefined && object.settings !== null
+          ? MacroGlobalSettings.fromPartial(object.settings)
+          : undefined;
+      return message;
+    },
+  };
 
 function createBaseResponse(): Response {
   return {
@@ -1563,7 +2057,10 @@ function createBaseResponse(): Response {
 }
 
 export const Response: MessageFns<Response> = {
-  encode(message: Response, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+  encode(
+    message: Response,
+    writer: BinaryWriter = new BinaryWriter(),
+  ): BinaryWriter {
     if (message.error !== undefined) {
       ErrorResponse.encode(message.error, writer.uint32(10).fork()).join();
     }
@@ -1571,19 +2068,29 @@ export const Response: MessageFns<Response> = {
       StatusResponse.encode(message.status, writer.uint32(18).fork()).join();
     }
     if (message.listMacros !== undefined) {
-      ListMacrosResponse.encode(message.listMacros, writer.uint32(26).fork()).join();
+      ListMacrosResponse.encode(
+        message.listMacros,
+        writer.uint32(26).fork(),
+      ).join();
     }
     if (message.getMacro !== undefined) {
-      GetMacroResponse.encode(message.getMacro, writer.uint32(34).fork()).join();
+      GetMacroResponse.encode(
+        message.getMacro,
+        writer.uint32(34).fork(),
+      ).join();
     }
     if (message.getMacroGlobalSettings !== undefined) {
-      GetMacroGlobalSettingsResponse.encode(message.getMacroGlobalSettings, writer.uint32(42).fork()).join();
+      GetMacroGlobalSettingsResponse.encode(
+        message.getMacroGlobalSettings,
+        writer.uint32(42).fork(),
+      ).join();
     }
     return writer;
   },
 
   decode(input: BinaryReader | Uint8Array, length?: number): Response {
-    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const reader =
+      input instanceof BinaryReader ? input : new BinaryReader(input);
     const end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseResponse();
     while (reader.pos < end) {
@@ -1610,7 +2117,10 @@ export const Response: MessageFns<Response> = {
             break;
           }
 
-          message.listMacros = ListMacrosResponse.decode(reader, reader.uint32());
+          message.listMacros = ListMacrosResponse.decode(
+            reader,
+            reader.uint32(),
+          );
           continue;
         }
         case 4: {
@@ -1626,7 +2136,8 @@ export const Response: MessageFns<Response> = {
             break;
           }
 
-          message.getMacroGlobalSettings = GetMacroGlobalSettingsResponse.decode(reader, reader.uint32());
+          message.getMacroGlobalSettings =
+            GetMacroGlobalSettingsResponse.decode(reader, reader.uint32());
           continue;
         }
       }
@@ -1643,33 +2154,51 @@ export const Response: MessageFns<Response> = {
   },
   fromPartial(object: DeepPartial<Response>): Response {
     const message = createBaseResponse();
-    message.error = (object.error !== undefined && object.error !== null)
-      ? ErrorResponse.fromPartial(object.error)
-      : undefined;
-    message.status = (object.status !== undefined && object.status !== null)
-      ? StatusResponse.fromPartial(object.status)
-      : undefined;
-    message.listMacros = (object.listMacros !== undefined && object.listMacros !== null)
-      ? ListMacrosResponse.fromPartial(object.listMacros)
-      : undefined;
-    message.getMacro = (object.getMacro !== undefined && object.getMacro !== null)
-      ? GetMacroResponse.fromPartial(object.getMacro)
-      : undefined;
+    message.error =
+      object.error !== undefined && object.error !== null
+        ? ErrorResponse.fromPartial(object.error)
+        : undefined;
+    message.status =
+      object.status !== undefined && object.status !== null
+        ? StatusResponse.fromPartial(object.status)
+        : undefined;
+    message.listMacros =
+      object.listMacros !== undefined && object.listMacros !== null
+        ? ListMacrosResponse.fromPartial(object.listMacros)
+        : undefined;
+    message.getMacro =
+      object.getMacro !== undefined && object.getMacro !== null
+        ? GetMacroResponse.fromPartial(object.getMacro)
+        : undefined;
     message.getMacroGlobalSettings =
-      (object.getMacroGlobalSettings !== undefined && object.getMacroGlobalSettings !== null)
-        ? GetMacroGlobalSettingsResponse.fromPartial(object.getMacroGlobalSettings)
+      object.getMacroGlobalSettings !== undefined &&
+      object.getMacroGlobalSettings !== null
+        ? GetMacroGlobalSettingsResponse.fromPartial(
+            object.getMacroGlobalSettings,
+          )
         : undefined;
     return message;
   },
 };
 
-type Builtin = Date | Function | Uint8Array | string | number | boolean | undefined;
+type Builtin =
+  | Date
+  | Function
+  | Uint8Array
+  | string
+  | number
+  | boolean
+  | undefined;
 
-export type DeepPartial<T> = T extends Builtin ? T
-  : T extends globalThis.Array<infer U> ? globalThis.Array<DeepPartial<U>>
-  : T extends ReadonlyArray<infer U> ? ReadonlyArray<DeepPartial<U>>
-  : T extends {} ? { [K in keyof T]?: DeepPartial<T[K]> }
-  : Partial<T>;
+export type DeepPartial<T> = T extends Builtin
+  ? T
+  : T extends globalThis.Array<infer U>
+    ? globalThis.Array<DeepPartial<U>>
+    : T extends ReadonlyArray<infer U>
+      ? ReadonlyArray<DeepPartial<U>>
+      : T extends {}
+        ? { [K in keyof T]?: DeepPartial<T[K]> }
+        : Partial<T>;
 
 export interface MessageFns<T> {
   encode(message: T, writer?: BinaryWriter): BinaryWriter;

--- a/src/proto/cormoran/runtime_macro/runtime_macro.ts
+++ b/src/proto/cormoran/runtime_macro/runtime_macro.ts
@@ -9,13 +9,15 @@ import { BinaryReader, BinaryWriter } from "@bufbuild/protobuf/wire";
 
 export const protobufPackage = "cormoran.runtime_macro";
 
-export interface ListMacrosRequest {}
+export interface ListMacrosRequest {
+}
 
 export interface GetMacroRequest {
   slot: number;
 }
 
-export interface GetMacroGlobalSettingsRequest {}
+export interface GetMacroGlobalSettingsRequest {
+}
 
 export interface MacroSummary {
   slot: number;
@@ -76,9 +78,11 @@ export interface SetTapMsRequest {
   persist: boolean;
 }
 
-export interface SaveMacrosRequest {}
+export interface SaveMacrosRequest {
+}
 
-export interface DiscardMacrosRequest {}
+export interface DiscardMacrosRequest {
+}
 
 export interface CreateMacroRequest {
   name: string;
@@ -158,16 +162,12 @@ function createBaseListMacrosRequest(): ListMacrosRequest {
 }
 
 export const ListMacrosRequest: MessageFns<ListMacrosRequest> = {
-  encode(
-    _: ListMacrosRequest,
-    writer: BinaryWriter = new BinaryWriter(),
-  ): BinaryWriter {
+  encode(_: ListMacrosRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     return writer;
   },
 
   decode(input: BinaryReader | Uint8Array, length?: number): ListMacrosRequest {
-    const reader =
-      input instanceof BinaryReader ? input : new BinaryReader(input);
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
     const end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseListMacrosRequest();
     while (reader.pos < end) {
@@ -196,10 +196,7 @@ function createBaseGetMacroRequest(): GetMacroRequest {
 }
 
 export const GetMacroRequest: MessageFns<GetMacroRequest> = {
-  encode(
-    message: GetMacroRequest,
-    writer: BinaryWriter = new BinaryWriter(),
-  ): BinaryWriter {
+  encode(message: GetMacroRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.slot !== 0) {
       writer.uint32(8).uint32(message.slot);
     }
@@ -207,8 +204,7 @@ export const GetMacroRequest: MessageFns<GetMacroRequest> = {
   },
 
   decode(input: BinaryReader | Uint8Array, length?: number): GetMacroRequest {
-    const reader =
-      input instanceof BinaryReader ? input : new BinaryReader(input);
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
     const end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseGetMacroRequest();
     while (reader.pos < end) {
@@ -245,57 +241,42 @@ function createBaseGetMacroGlobalSettingsRequest(): GetMacroGlobalSettingsReques
   return {};
 }
 
-export const GetMacroGlobalSettingsRequest: MessageFns<GetMacroGlobalSettingsRequest> =
-  {
-    encode(
-      _: GetMacroGlobalSettingsRequest,
-      writer: BinaryWriter = new BinaryWriter(),
-    ): BinaryWriter {
-      return writer;
-    },
+export const GetMacroGlobalSettingsRequest: MessageFns<GetMacroGlobalSettingsRequest> = {
+  encode(_: GetMacroGlobalSettingsRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    return writer;
+  },
 
-    decode(
-      input: BinaryReader | Uint8Array,
-      length?: number,
-    ): GetMacroGlobalSettingsRequest {
-      const reader =
-        input instanceof BinaryReader ? input : new BinaryReader(input);
-      const end = length === undefined ? reader.len : reader.pos + length;
-      const message = createBaseGetMacroGlobalSettingsRequest();
-      while (reader.pos < end) {
-        const tag = reader.uint32();
-        switch (tag >>> 3) {
-        }
-        if ((tag & 7) === 4 || tag === 0) {
-          break;
-        }
-        reader.skip(tag & 7);
+  decode(input: BinaryReader | Uint8Array, length?: number): GetMacroGlobalSettingsRequest {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseGetMacroGlobalSettingsRequest();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
       }
-      return message;
-    },
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
 
-    create(
-      base?: DeepPartial<GetMacroGlobalSettingsRequest>,
-    ): GetMacroGlobalSettingsRequest {
-      return GetMacroGlobalSettingsRequest.fromPartial(base ?? {});
-    },
-    fromPartial(
-      _: DeepPartial<GetMacroGlobalSettingsRequest>,
-    ): GetMacroGlobalSettingsRequest {
-      const message = createBaseGetMacroGlobalSettingsRequest();
-      return message;
-    },
-  };
+  create(base?: DeepPartial<GetMacroGlobalSettingsRequest>): GetMacroGlobalSettingsRequest {
+    return GetMacroGlobalSettingsRequest.fromPartial(base ?? {});
+  },
+  fromPartial(_: DeepPartial<GetMacroGlobalSettingsRequest>): GetMacroGlobalSettingsRequest {
+    const message = createBaseGetMacroGlobalSettingsRequest();
+    return message;
+  },
+};
 
 function createBaseMacroSummary(): MacroSummary {
   return { slot: 0, name: "", encodedSize: 0 };
 }
 
 export const MacroSummary: MessageFns<MacroSummary> = {
-  encode(
-    message: MacroSummary,
-    writer: BinaryWriter = new BinaryWriter(),
-  ): BinaryWriter {
+  encode(message: MacroSummary, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.slot !== 0) {
       writer.uint32(8).uint32(message.slot);
     }
@@ -309,8 +290,7 @@ export const MacroSummary: MessageFns<MacroSummary> = {
   },
 
   decode(input: BinaryReader | Uint8Array, length?: number): MacroSummary {
-    const reader =
-      input instanceof BinaryReader ? input : new BinaryReader(input);
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
     const end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseMacroSummary();
     while (reader.pos < end) {
@@ -366,10 +346,7 @@ function createBaseBehaviorBinding(): BehaviorBinding {
 }
 
 export const BehaviorBinding: MessageFns<BehaviorBinding> = {
-  encode(
-    message: BehaviorBinding,
-    writer: BinaryWriter = new BinaryWriter(),
-  ): BinaryWriter {
+  encode(message: BehaviorBinding, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.behaviorId !== 0) {
       writer.uint32(8).uint32(message.behaviorId);
     }
@@ -383,8 +360,7 @@ export const BehaviorBinding: MessageFns<BehaviorBinding> = {
   },
 
   decode(input: BinaryReader | Uint8Array, length?: number): BehaviorBinding {
-    const reader =
-      input instanceof BinaryReader ? input : new BinaryReader(input);
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
     const end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseBehaviorBinding();
     while (reader.pos < end) {
@@ -440,10 +416,7 @@ function createBaseDelayStep(): DelayStep {
 }
 
 export const DelayStep: MessageFns<DelayStep> = {
-  encode(
-    message: DelayStep,
-    writer: BinaryWriter = new BinaryWriter(),
-  ): BinaryWriter {
+  encode(message: DelayStep, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.delayMs !== 0) {
       writer.uint32(8).uint32(message.delayMs);
     }
@@ -451,8 +424,7 @@ export const DelayStep: MessageFns<DelayStep> = {
   },
 
   decode(input: BinaryReader | Uint8Array, length?: number): DelayStep {
-    const reader =
-      input instanceof BinaryReader ? input : new BinaryReader(input);
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
     const end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseDelayStep();
     while (reader.pos < end) {
@@ -490,22 +462,15 @@ function createBaseKeyTapSequenceStep(): KeyTapSequenceStep {
 }
 
 export const KeyTapSequenceStep: MessageFns<KeyTapSequenceStep> = {
-  encode(
-    message: KeyTapSequenceStep,
-    writer: BinaryWriter = new BinaryWriter(),
-  ): BinaryWriter {
+  encode(message: KeyTapSequenceStep, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.packedKeys.length !== 0) {
       writer.uint32(10).bytes(message.packedKeys);
     }
     return writer;
   },
 
-  decode(
-    input: BinaryReader | Uint8Array,
-    length?: number,
-  ): KeyTapSequenceStep {
-    const reader =
-      input instanceof BinaryReader ? input : new BinaryReader(input);
+  decode(input: BinaryReader | Uint8Array, length?: number): KeyTapSequenceStep {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
     const end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseKeyTapSequenceStep();
     while (reader.pos < end) {
@@ -539,20 +504,11 @@ export const KeyTapSequenceStep: MessageFns<KeyTapSequenceStep> = {
 };
 
 function createBaseMacroStep(): MacroStep {
-  return {
-    down: undefined,
-    up: undefined,
-    tap: undefined,
-    delay: undefined,
-    keyTapSequence: undefined,
-  };
+  return { down: undefined, up: undefined, tap: undefined, delay: undefined, keyTapSequence: undefined };
 }
 
 export const MacroStep: MessageFns<MacroStep> = {
-  encode(
-    message: MacroStep,
-    writer: BinaryWriter = new BinaryWriter(),
-  ): BinaryWriter {
+  encode(message: MacroStep, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.down !== undefined) {
       BehaviorBinding.encode(message.down, writer.uint32(10).fork()).join();
     }
@@ -566,17 +522,13 @@ export const MacroStep: MessageFns<MacroStep> = {
       DelayStep.encode(message.delay, writer.uint32(34).fork()).join();
     }
     if (message.keyTapSequence !== undefined) {
-      KeyTapSequenceStep.encode(
-        message.keyTapSequence,
-        writer.uint32(42).fork(),
-      ).join();
+      KeyTapSequenceStep.encode(message.keyTapSequence, writer.uint32(42).fork()).join();
     }
     return writer;
   },
 
   decode(input: BinaryReader | Uint8Array, length?: number): MacroStep {
-    const reader =
-      input instanceof BinaryReader ? input : new BinaryReader(input);
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
     const end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseMacroStep();
     while (reader.pos < end) {
@@ -619,10 +571,7 @@ export const MacroStep: MessageFns<MacroStep> = {
             break;
           }
 
-          message.keyTapSequence = KeyTapSequenceStep.decode(
-            reader,
-            reader.uint32(),
-          );
+          message.keyTapSequence = KeyTapSequenceStep.decode(reader, reader.uint32());
           continue;
         }
       }
@@ -639,26 +588,19 @@ export const MacroStep: MessageFns<MacroStep> = {
   },
   fromPartial(object: DeepPartial<MacroStep>): MacroStep {
     const message = createBaseMacroStep();
-    message.down =
-      object.down !== undefined && object.down !== null
-        ? BehaviorBinding.fromPartial(object.down)
-        : undefined;
-    message.up =
-      object.up !== undefined && object.up !== null
-        ? BehaviorBinding.fromPartial(object.up)
-        : undefined;
-    message.tap =
-      object.tap !== undefined && object.tap !== null
-        ? BehaviorBinding.fromPartial(object.tap)
-        : undefined;
-    message.delay =
-      object.delay !== undefined && object.delay !== null
-        ? DelayStep.fromPartial(object.delay)
-        : undefined;
-    message.keyTapSequence =
-      object.keyTapSequence !== undefined && object.keyTapSequence !== null
-        ? KeyTapSequenceStep.fromPartial(object.keyTapSequence)
-        : undefined;
+    message.down = (object.down !== undefined && object.down !== null)
+      ? BehaviorBinding.fromPartial(object.down)
+      : undefined;
+    message.up = (object.up !== undefined && object.up !== null) ? BehaviorBinding.fromPartial(object.up) : undefined;
+    message.tap = (object.tap !== undefined && object.tap !== null)
+      ? BehaviorBinding.fromPartial(object.tap)
+      : undefined;
+    message.delay = (object.delay !== undefined && object.delay !== null)
+      ? DelayStep.fromPartial(object.delay)
+      : undefined;
+    message.keyTapSequence = (object.keyTapSequence !== undefined && object.keyTapSequence !== null)
+      ? KeyTapSequenceStep.fromPartial(object.keyTapSequence)
+      : undefined;
     return message;
   },
 };
@@ -668,10 +610,7 @@ function createBaseMacroDetail(): MacroDetail {
 }
 
 export const MacroDetail: MessageFns<MacroDetail> = {
-  encode(
-    message: MacroDetail,
-    writer: BinaryWriter = new BinaryWriter(),
-  ): BinaryWriter {
+  encode(message: MacroDetail, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.slot !== 0) {
       writer.uint32(8).uint32(message.slot);
     }
@@ -688,8 +627,7 @@ export const MacroDetail: MessageFns<MacroDetail> = {
   },
 
   decode(input: BinaryReader | Uint8Array, length?: number): MacroDetail {
-    const reader =
-      input instanceof BinaryReader ? input : new BinaryReader(input);
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
     const end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseMacroDetail();
     while (reader.pos < end) {
@@ -754,10 +692,7 @@ function createBaseSetMacroStepCountRequest(): SetMacroStepCountRequest {
 }
 
 export const SetMacroStepCountRequest: MessageFns<SetMacroStepCountRequest> = {
-  encode(
-    message: SetMacroStepCountRequest,
-    writer: BinaryWriter = new BinaryWriter(),
-  ): BinaryWriter {
+  encode(message: SetMacroStepCountRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.slot !== 0) {
       writer.uint32(8).uint32(message.slot);
     }
@@ -770,12 +705,8 @@ export const SetMacroStepCountRequest: MessageFns<SetMacroStepCountRequest> = {
     return writer;
   },
 
-  decode(
-    input: BinaryReader | Uint8Array,
-    length?: number,
-  ): SetMacroStepCountRequest {
-    const reader =
-      input instanceof BinaryReader ? input : new BinaryReader(input);
+  decode(input: BinaryReader | Uint8Array, length?: number): SetMacroStepCountRequest {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
     const end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseSetMacroStepCountRequest();
     while (reader.pos < end) {
@@ -814,14 +745,10 @@ export const SetMacroStepCountRequest: MessageFns<SetMacroStepCountRequest> = {
     return message;
   },
 
-  create(
-    base?: DeepPartial<SetMacroStepCountRequest>,
-  ): SetMacroStepCountRequest {
+  create(base?: DeepPartial<SetMacroStepCountRequest>): SetMacroStepCountRequest {
     return SetMacroStepCountRequest.fromPartial(base ?? {});
   },
-  fromPartial(
-    object: DeepPartial<SetMacroStepCountRequest>,
-  ): SetMacroStepCountRequest {
+  fromPartial(object: DeepPartial<SetMacroStepCountRequest>): SetMacroStepCountRequest {
     const message = createBaseSetMacroStepCountRequest();
     message.slot = object.slot ?? 0;
     message.stepCount = object.stepCount ?? 0;
@@ -835,10 +762,7 @@ function createBaseSetMacroStepRequest(): SetMacroStepRequest {
 }
 
 export const SetMacroStepRequest: MessageFns<SetMacroStepRequest> = {
-  encode(
-    message: SetMacroStepRequest,
-    writer: BinaryWriter = new BinaryWriter(),
-  ): BinaryWriter {
+  encode(message: SetMacroStepRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.slot !== 0) {
       writer.uint32(8).uint32(message.slot);
     }
@@ -854,12 +778,8 @@ export const SetMacroStepRequest: MessageFns<SetMacroStepRequest> = {
     return writer;
   },
 
-  decode(
-    input: BinaryReader | Uint8Array,
-    length?: number,
-  ): SetMacroStepRequest {
-    const reader =
-      input instanceof BinaryReader ? input : new BinaryReader(input);
+  decode(input: BinaryReader | Uint8Array, length?: number): SetMacroStepRequest {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
     const end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseSetMacroStepRequest();
     while (reader.pos < end) {
@@ -913,10 +833,7 @@ export const SetMacroStepRequest: MessageFns<SetMacroStepRequest> = {
     const message = createBaseSetMacroStepRequest();
     message.slot = object.slot ?? 0;
     message.stepIndex = object.stepIndex ?? 0;
-    message.step =
-      object.step !== undefined && object.step !== null
-        ? MacroStep.fromPartial(object.step)
-        : undefined;
+    message.step = (object.step !== undefined && object.step !== null) ? MacroStep.fromPartial(object.step) : undefined;
     message.persist = object.persist ?? false;
     return message;
   },
@@ -927,10 +844,7 @@ function createBaseAppendMacroStepRequest(): AppendMacroStepRequest {
 }
 
 export const AppendMacroStepRequest: MessageFns<AppendMacroStepRequest> = {
-  encode(
-    message: AppendMacroStepRequest,
-    writer: BinaryWriter = new BinaryWriter(),
-  ): BinaryWriter {
+  encode(message: AppendMacroStepRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.slot !== 0) {
       writer.uint32(8).uint32(message.slot);
     }
@@ -943,12 +857,8 @@ export const AppendMacroStepRequest: MessageFns<AppendMacroStepRequest> = {
     return writer;
   },
 
-  decode(
-    input: BinaryReader | Uint8Array,
-    length?: number,
-  ): AppendMacroStepRequest {
-    const reader =
-      input instanceof BinaryReader ? input : new BinaryReader(input);
+  decode(input: BinaryReader | Uint8Array, length?: number): AppendMacroStepRequest {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
     const end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseAppendMacroStepRequest();
     while (reader.pos < end) {
@@ -990,15 +900,10 @@ export const AppendMacroStepRequest: MessageFns<AppendMacroStepRequest> = {
   create(base?: DeepPartial<AppendMacroStepRequest>): AppendMacroStepRequest {
     return AppendMacroStepRequest.fromPartial(base ?? {});
   },
-  fromPartial(
-    object: DeepPartial<AppendMacroStepRequest>,
-  ): AppendMacroStepRequest {
+  fromPartial(object: DeepPartial<AppendMacroStepRequest>): AppendMacroStepRequest {
     const message = createBaseAppendMacroStepRequest();
     message.slot = object.slot ?? 0;
-    message.step =
-      object.step !== undefined && object.step !== null
-        ? MacroStep.fromPartial(object.step)
-        : undefined;
+    message.step = (object.step !== undefined && object.step !== null) ? MacroStep.fromPartial(object.step) : undefined;
     message.persist = object.persist ?? false;
     return message;
   },
@@ -1009,10 +914,7 @@ function createBaseSetTapMsRequest(): SetTapMsRequest {
 }
 
 export const SetTapMsRequest: MessageFns<SetTapMsRequest> = {
-  encode(
-    message: SetTapMsRequest,
-    writer: BinaryWriter = new BinaryWriter(),
-  ): BinaryWriter {
+  encode(message: SetTapMsRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.tapMs !== 0) {
       writer.uint32(8).uint32(message.tapMs);
     }
@@ -1023,8 +925,7 @@ export const SetTapMsRequest: MessageFns<SetTapMsRequest> = {
   },
 
   decode(input: BinaryReader | Uint8Array, length?: number): SetTapMsRequest {
-    const reader =
-      input instanceof BinaryReader ? input : new BinaryReader(input);
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
     const end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseSetTapMsRequest();
     while (reader.pos < end) {
@@ -1071,16 +972,12 @@ function createBaseSaveMacrosRequest(): SaveMacrosRequest {
 }
 
 export const SaveMacrosRequest: MessageFns<SaveMacrosRequest> = {
-  encode(
-    _: SaveMacrosRequest,
-    writer: BinaryWriter = new BinaryWriter(),
-  ): BinaryWriter {
+  encode(_: SaveMacrosRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     return writer;
   },
 
   decode(input: BinaryReader | Uint8Array, length?: number): SaveMacrosRequest {
-    const reader =
-      input instanceof BinaryReader ? input : new BinaryReader(input);
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
     const end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseSaveMacrosRequest();
     while (reader.pos < end) {
@@ -1109,19 +1006,12 @@ function createBaseDiscardMacrosRequest(): DiscardMacrosRequest {
 }
 
 export const DiscardMacrosRequest: MessageFns<DiscardMacrosRequest> = {
-  encode(
-    _: DiscardMacrosRequest,
-    writer: BinaryWriter = new BinaryWriter(),
-  ): BinaryWriter {
+  encode(_: DiscardMacrosRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     return writer;
   },
 
-  decode(
-    input: BinaryReader | Uint8Array,
-    length?: number,
-  ): DiscardMacrosRequest {
-    const reader =
-      input instanceof BinaryReader ? input : new BinaryReader(input);
+  decode(input: BinaryReader | Uint8Array, length?: number): DiscardMacrosRequest {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
     const end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseDiscardMacrosRequest();
     while (reader.pos < end) {
@@ -1150,10 +1040,7 @@ function createBaseCreateMacroRequest(): CreateMacroRequest {
 }
 
 export const CreateMacroRequest: MessageFns<CreateMacroRequest> = {
-  encode(
-    message: CreateMacroRequest,
-    writer: BinaryWriter = new BinaryWriter(),
-  ): BinaryWriter {
+  encode(message: CreateMacroRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.name !== "") {
       writer.uint32(10).string(message.name);
     }
@@ -1163,12 +1050,8 @@ export const CreateMacroRequest: MessageFns<CreateMacroRequest> = {
     return writer;
   },
 
-  decode(
-    input: BinaryReader | Uint8Array,
-    length?: number,
-  ): CreateMacroRequest {
-    const reader =
-      input instanceof BinaryReader ? input : new BinaryReader(input);
+  decode(input: BinaryReader | Uint8Array, length?: number): CreateMacroRequest {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
     const end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseCreateMacroRequest();
     while (reader.pos < end) {
@@ -1178,6 +1061,7 @@ export const CreateMacroRequest: MessageFns<CreateMacroRequest> = {
           if (tag !== 10) {
             break;
           }
+
           message.name = reader.string();
           continue;
         }
@@ -1185,6 +1069,7 @@ export const CreateMacroRequest: MessageFns<CreateMacroRequest> = {
           if (tag !== 16) {
             break;
           }
+
           message.persist = reader.bool();
           continue;
         }
@@ -1213,22 +1098,15 @@ function createBaseDeleteMacroRequest(): DeleteMacroRequest {
 }
 
 export const DeleteMacroRequest: MessageFns<DeleteMacroRequest> = {
-  encode(
-    message: DeleteMacroRequest,
-    writer: BinaryWriter = new BinaryWriter(),
-  ): BinaryWriter {
+  encode(message: DeleteMacroRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.name !== "") {
       writer.uint32(10).string(message.name);
     }
     return writer;
   },
 
-  decode(
-    input: BinaryReader | Uint8Array,
-    length?: number,
-  ): DeleteMacroRequest {
-    const reader =
-      input instanceof BinaryReader ? input : new BinaryReader(input);
+  decode(input: BinaryReader | Uint8Array, length?: number): DeleteMacroRequest {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
     const end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseDeleteMacroRequest();
     while (reader.pos < end) {
@@ -1238,6 +1116,7 @@ export const DeleteMacroRequest: MessageFns<DeleteMacroRequest> = {
           if (tag !== 10) {
             break;
           }
+
           message.name = reader.string();
           continue;
         }
@@ -1265,10 +1144,7 @@ function createBaseRenameMacroRequest(): RenameMacroRequest {
 }
 
 export const RenameMacroRequest: MessageFns<RenameMacroRequest> = {
-  encode(
-    message: RenameMacroRequest,
-    writer: BinaryWriter = new BinaryWriter(),
-  ): BinaryWriter {
+  encode(message: RenameMacroRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.oldName !== "") {
       writer.uint32(10).string(message.oldName);
     }
@@ -1281,12 +1157,8 @@ export const RenameMacroRequest: MessageFns<RenameMacroRequest> = {
     return writer;
   },
 
-  decode(
-    input: BinaryReader | Uint8Array,
-    length?: number,
-  ): RenameMacroRequest {
-    const reader =
-      input instanceof BinaryReader ? input : new BinaryReader(input);
+  decode(input: BinaryReader | Uint8Array, length?: number): RenameMacroRequest {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
     const end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseRenameMacroRequest();
     while (reader.pos < end) {
@@ -1296,6 +1168,7 @@ export const RenameMacroRequest: MessageFns<RenameMacroRequest> = {
           if (tag !== 10) {
             break;
           }
+
           message.oldName = reader.string();
           continue;
         }
@@ -1303,6 +1176,7 @@ export const RenameMacroRequest: MessageFns<RenameMacroRequest> = {
           if (tag !== 18) {
             break;
           }
+
           message.newName = reader.string();
           continue;
         }
@@ -1310,6 +1184,7 @@ export const RenameMacroRequest: MessageFns<RenameMacroRequest> = {
           if (tag !== 24) {
             break;
           }
+
           message.persist = reader.bool();
           continue;
         }
@@ -1352,82 +1227,48 @@ function createBaseRequest(): Request {
 }
 
 export const Request: MessageFns<Request> = {
-  encode(
-    message: Request,
-    writer: BinaryWriter = new BinaryWriter(),
-  ): BinaryWriter {
+  encode(message: Request, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.listMacros !== undefined) {
-      ListMacrosRequest.encode(
-        message.listMacros,
-        writer.uint32(10).fork(),
-      ).join();
+      ListMacrosRequest.encode(message.listMacros, writer.uint32(10).fork()).join();
     }
     if (message.getMacro !== undefined) {
       GetMacroRequest.encode(message.getMacro, writer.uint32(18).fork()).join();
     }
     if (message.setMacroStepCount !== undefined) {
-      SetMacroStepCountRequest.encode(
-        message.setMacroStepCount,
-        writer.uint32(34).fork(),
-      ).join();
+      SetMacroStepCountRequest.encode(message.setMacroStepCount, writer.uint32(34).fork()).join();
     }
     if (message.getMacroGlobalSettings !== undefined) {
-      GetMacroGlobalSettingsRequest.encode(
-        message.getMacroGlobalSettings,
-        writer.uint32(42).fork(),
-      ).join();
+      GetMacroGlobalSettingsRequest.encode(message.getMacroGlobalSettings, writer.uint32(42).fork()).join();
     }
     if (message.setTapMs !== undefined) {
       SetTapMsRequest.encode(message.setTapMs, writer.uint32(50).fork()).join();
     }
     if (message.setMacroStep !== undefined) {
-      SetMacroStepRequest.encode(
-        message.setMacroStep,
-        writer.uint32(58).fork(),
-      ).join();
+      SetMacroStepRequest.encode(message.setMacroStep, writer.uint32(58).fork()).join();
     }
     if (message.saveMacros !== undefined) {
-      SaveMacrosRequest.encode(
-        message.saveMacros,
-        writer.uint32(74).fork(),
-      ).join();
+      SaveMacrosRequest.encode(message.saveMacros, writer.uint32(74).fork()).join();
     }
     if (message.discardMacros !== undefined) {
-      DiscardMacrosRequest.encode(
-        message.discardMacros,
-        writer.uint32(82).fork(),
-      ).join();
+      DiscardMacrosRequest.encode(message.discardMacros, writer.uint32(82).fork()).join();
     }
     if (message.appendMacroStep !== undefined) {
-      AppendMacroStepRequest.encode(
-        message.appendMacroStep,
-        writer.uint32(90).fork(),
-      ).join();
+      AppendMacroStepRequest.encode(message.appendMacroStep, writer.uint32(90).fork()).join();
     }
     if (message.createMacro !== undefined) {
-      CreateMacroRequest.encode(
-        message.createMacro,
-        writer.uint32(98).fork(),
-      ).join();
+      CreateMacroRequest.encode(message.createMacro, writer.uint32(98).fork()).join();
     }
     if (message.deleteMacro !== undefined) {
-      DeleteMacroRequest.encode(
-        message.deleteMacro,
-        writer.uint32(106).fork(),
-      ).join();
+      DeleteMacroRequest.encode(message.deleteMacro, writer.uint32(106).fork()).join();
     }
     if (message.renameMacro !== undefined) {
-      RenameMacroRequest.encode(
-        message.renameMacro,
-        writer.uint32(114).fork(),
-      ).join();
+      RenameMacroRequest.encode(message.renameMacro, writer.uint32(114).fork()).join();
     }
     return writer;
   },
 
   decode(input: BinaryReader | Uint8Array, length?: number): Request {
-    const reader =
-      input instanceof BinaryReader ? input : new BinaryReader(input);
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
     const end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseRequest();
     while (reader.pos < end) {
@@ -1438,10 +1279,7 @@ export const Request: MessageFns<Request> = {
             break;
           }
 
-          message.listMacros = ListMacrosRequest.decode(
-            reader,
-            reader.uint32(),
-          );
+          message.listMacros = ListMacrosRequest.decode(reader, reader.uint32());
           continue;
         }
         case 2: {
@@ -1457,10 +1295,7 @@ export const Request: MessageFns<Request> = {
             break;
           }
 
-          message.setMacroStepCount = SetMacroStepCountRequest.decode(
-            reader,
-            reader.uint32(),
-          );
+          message.setMacroStepCount = SetMacroStepCountRequest.decode(reader, reader.uint32());
           continue;
         }
         case 5: {
@@ -1468,10 +1303,7 @@ export const Request: MessageFns<Request> = {
             break;
           }
 
-          message.getMacroGlobalSettings = GetMacroGlobalSettingsRequest.decode(
-            reader,
-            reader.uint32(),
-          );
+          message.getMacroGlobalSettings = GetMacroGlobalSettingsRequest.decode(reader, reader.uint32());
           continue;
         }
         case 6: {
@@ -1487,10 +1319,7 @@ export const Request: MessageFns<Request> = {
             break;
           }
 
-          message.setMacroStep = SetMacroStepRequest.decode(
-            reader,
-            reader.uint32(),
-          );
+          message.setMacroStep = SetMacroStepRequest.decode(reader, reader.uint32());
           continue;
         }
         case 9: {
@@ -1498,10 +1327,7 @@ export const Request: MessageFns<Request> = {
             break;
           }
 
-          message.saveMacros = SaveMacrosRequest.decode(
-            reader,
-            reader.uint32(),
-          );
+          message.saveMacros = SaveMacrosRequest.decode(reader, reader.uint32());
           continue;
         }
         case 10: {
@@ -1509,10 +1335,7 @@ export const Request: MessageFns<Request> = {
             break;
           }
 
-          message.discardMacros = DiscardMacrosRequest.decode(
-            reader,
-            reader.uint32(),
-          );
+          message.discardMacros = DiscardMacrosRequest.decode(reader, reader.uint32());
           continue;
         }
         case 11: {
@@ -1520,10 +1343,7 @@ export const Request: MessageFns<Request> = {
             break;
           }
 
-          message.appendMacroStep = AppendMacroStepRequest.decode(
-            reader,
-            reader.uint32(),
-          );
+          message.appendMacroStep = AppendMacroStepRequest.decode(reader, reader.uint32());
           continue;
         }
         case 12: {
@@ -1531,10 +1351,7 @@ export const Request: MessageFns<Request> = {
             break;
           }
 
-          message.createMacro = CreateMacroRequest.decode(
-            reader,
-            reader.uint32(),
-          );
+          message.createMacro = CreateMacroRequest.decode(reader, reader.uint32());
           continue;
         }
         case 13: {
@@ -1542,10 +1359,7 @@ export const Request: MessageFns<Request> = {
             break;
           }
 
-          message.deleteMacro = DeleteMacroRequest.decode(
-            reader,
-            reader.uint32(),
-          );
+          message.deleteMacro = DeleteMacroRequest.decode(reader, reader.uint32());
           continue;
         }
         case 14: {
@@ -1553,10 +1367,7 @@ export const Request: MessageFns<Request> = {
             break;
           }
 
-          message.renameMacro = RenameMacroRequest.decode(
-            reader,
-            reader.uint32(),
-          );
+          message.renameMacro = RenameMacroRequest.decode(reader, reader.uint32());
           continue;
         }
       }
@@ -1573,58 +1384,43 @@ export const Request: MessageFns<Request> = {
   },
   fromPartial(object: DeepPartial<Request>): Request {
     const message = createBaseRequest();
-    message.listMacros =
-      object.listMacros !== undefined && object.listMacros !== null
-        ? ListMacrosRequest.fromPartial(object.listMacros)
-        : undefined;
-    message.getMacro =
-      object.getMacro !== undefined && object.getMacro !== null
-        ? GetMacroRequest.fromPartial(object.getMacro)
-        : undefined;
-    message.setMacroStepCount =
-      object.setMacroStepCount !== undefined &&
-      object.setMacroStepCount !== null
-        ? SetMacroStepCountRequest.fromPartial(object.setMacroStepCount)
-        : undefined;
+    message.listMacros = (object.listMacros !== undefined && object.listMacros !== null)
+      ? ListMacrosRequest.fromPartial(object.listMacros)
+      : undefined;
+    message.getMacro = (object.getMacro !== undefined && object.getMacro !== null)
+      ? GetMacroRequest.fromPartial(object.getMacro)
+      : undefined;
+    message.setMacroStepCount = (object.setMacroStepCount !== undefined && object.setMacroStepCount !== null)
+      ? SetMacroStepCountRequest.fromPartial(object.setMacroStepCount)
+      : undefined;
     message.getMacroGlobalSettings =
-      object.getMacroGlobalSettings !== undefined &&
-      object.getMacroGlobalSettings !== null
-        ? GetMacroGlobalSettingsRequest.fromPartial(
-            object.getMacroGlobalSettings,
-          )
+      (object.getMacroGlobalSettings !== undefined && object.getMacroGlobalSettings !== null)
+        ? GetMacroGlobalSettingsRequest.fromPartial(object.getMacroGlobalSettings)
         : undefined;
-    message.setTapMs =
-      object.setTapMs !== undefined && object.setTapMs !== null
-        ? SetTapMsRequest.fromPartial(object.setTapMs)
-        : undefined;
-    message.setMacroStep =
-      object.setMacroStep !== undefined && object.setMacroStep !== null
-        ? SetMacroStepRequest.fromPartial(object.setMacroStep)
-        : undefined;
-    message.saveMacros =
-      object.saveMacros !== undefined && object.saveMacros !== null
-        ? SaveMacrosRequest.fromPartial(object.saveMacros)
-        : undefined;
-    message.discardMacros =
-      object.discardMacros !== undefined && object.discardMacros !== null
-        ? DiscardMacrosRequest.fromPartial(object.discardMacros)
-        : undefined;
-    message.appendMacroStep =
-      object.appendMacroStep !== undefined && object.appendMacroStep !== null
-        ? AppendMacroStepRequest.fromPartial(object.appendMacroStep)
-        : undefined;
-    message.createMacro =
-      object.createMacro !== undefined && object.createMacro !== null
-        ? CreateMacroRequest.fromPartial(object.createMacro)
-        : undefined;
-    message.deleteMacro =
-      object.deleteMacro !== undefined && object.deleteMacro !== null
-        ? DeleteMacroRequest.fromPartial(object.deleteMacro)
-        : undefined;
-    message.renameMacro =
-      object.renameMacro !== undefined && object.renameMacro !== null
-        ? RenameMacroRequest.fromPartial(object.renameMacro)
-        : undefined;
+    message.setTapMs = (object.setTapMs !== undefined && object.setTapMs !== null)
+      ? SetTapMsRequest.fromPartial(object.setTapMs)
+      : undefined;
+    message.setMacroStep = (object.setMacroStep !== undefined && object.setMacroStep !== null)
+      ? SetMacroStepRequest.fromPartial(object.setMacroStep)
+      : undefined;
+    message.saveMacros = (object.saveMacros !== undefined && object.saveMacros !== null)
+      ? SaveMacrosRequest.fromPartial(object.saveMacros)
+      : undefined;
+    message.discardMacros = (object.discardMacros !== undefined && object.discardMacros !== null)
+      ? DiscardMacrosRequest.fromPartial(object.discardMacros)
+      : undefined;
+    message.appendMacroStep = (object.appendMacroStep !== undefined && object.appendMacroStep !== null)
+      ? AppendMacroStepRequest.fromPartial(object.appendMacroStep)
+      : undefined;
+    message.createMacro = (object.createMacro !== undefined && object.createMacro !== null)
+      ? CreateMacroRequest.fromPartial(object.createMacro)
+      : undefined;
+    message.deleteMacro = (object.deleteMacro !== undefined && object.deleteMacro !== null)
+      ? DeleteMacroRequest.fromPartial(object.deleteMacro)
+      : undefined;
+    message.renameMacro = (object.renameMacro !== undefined && object.renameMacro !== null)
+      ? RenameMacroRequest.fromPartial(object.renameMacro)
+      : undefined;
     return message;
   },
 };
@@ -1634,10 +1430,7 @@ function createBaseErrorResponse(): ErrorResponse {
 }
 
 export const ErrorResponse: MessageFns<ErrorResponse> = {
-  encode(
-    message: ErrorResponse,
-    writer: BinaryWriter = new BinaryWriter(),
-  ): BinaryWriter {
+  encode(message: ErrorResponse, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.message !== "") {
       writer.uint32(10).string(message.message);
     }
@@ -1645,8 +1438,7 @@ export const ErrorResponse: MessageFns<ErrorResponse> = {
   },
 
   decode(input: BinaryReader | Uint8Array, length?: number): ErrorResponse {
-    const reader =
-      input instanceof BinaryReader ? input : new BinaryReader(input);
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
     const end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseErrorResponse();
     while (reader.pos < end) {
@@ -1684,10 +1476,7 @@ function createBaseStatusResponse(): StatusResponse {
 }
 
 export const StatusResponse: MessageFns<StatusResponse> = {
-  encode(
-    message: StatusResponse,
-    writer: BinaryWriter = new BinaryWriter(),
-  ): BinaryWriter {
+  encode(message: StatusResponse, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.affectedCount !== 0) {
       writer.uint32(8).uint32(message.affectedCount);
     }
@@ -1698,8 +1487,7 @@ export const StatusResponse: MessageFns<StatusResponse> = {
   },
 
   decode(input: BinaryReader | Uint8Array, length?: number): StatusResponse {
-    const reader =
-      input instanceof BinaryReader ? input : new BinaryReader(input);
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
     const end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseStatusResponse();
     while (reader.pos < end) {
@@ -1746,10 +1534,7 @@ function createBaseListMacrosResponse(): ListMacrosResponse {
 }
 
 export const ListMacrosResponse: MessageFns<ListMacrosResponse> = {
-  encode(
-    message: ListMacrosResponse,
-    writer: BinaryWriter = new BinaryWriter(),
-  ): BinaryWriter {
+  encode(message: ListMacrosResponse, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     for (const v of message.macros) {
       MacroSummary.encode(v!, writer.uint32(10).fork()).join();
     }
@@ -1762,12 +1547,8 @@ export const ListMacrosResponse: MessageFns<ListMacrosResponse> = {
     return writer;
   },
 
-  decode(
-    input: BinaryReader | Uint8Array,
-    length?: number,
-  ): ListMacrosResponse {
-    const reader =
-      input instanceof BinaryReader ? input : new BinaryReader(input);
+  decode(input: BinaryReader | Uint8Array, length?: number): ListMacrosResponse {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
     const end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseListMacrosResponse();
     while (reader.pos < end) {
@@ -1811,8 +1592,7 @@ export const ListMacrosResponse: MessageFns<ListMacrosResponse> = {
   },
   fromPartial(object: DeepPartial<ListMacrosResponse>): ListMacrosResponse {
     const message = createBaseListMacrosResponse();
-    message.macros =
-      object.macros?.map((e) => MacroSummary.fromPartial(e)) || [];
+    message.macros = object.macros?.map((e) => MacroSummary.fromPartial(e)) || [];
     message.maxMacroBytes = object.maxMacroBytes ?? 0;
     message.maxNameLength = object.maxNameLength ?? 0;
     return message;
@@ -1824,10 +1604,7 @@ function createBaseGetMacroResponse(): GetMacroResponse {
 }
 
 export const GetMacroResponse: MessageFns<GetMacroResponse> = {
-  encode(
-    message: GetMacroResponse,
-    writer: BinaryWriter = new BinaryWriter(),
-  ): BinaryWriter {
+  encode(message: GetMacroResponse, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.macro !== undefined) {
       MacroDetail.encode(message.macro, writer.uint32(10).fork()).join();
     }
@@ -1835,8 +1612,7 @@ export const GetMacroResponse: MessageFns<GetMacroResponse> = {
   },
 
   decode(input: BinaryReader | Uint8Array, length?: number): GetMacroResponse {
-    const reader =
-      input instanceof BinaryReader ? input : new BinaryReader(input);
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
     const end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseGetMacroResponse();
     while (reader.pos < end) {
@@ -1864,29 +1640,19 @@ export const GetMacroResponse: MessageFns<GetMacroResponse> = {
   },
   fromPartial(object: DeepPartial<GetMacroResponse>): GetMacroResponse {
     const message = createBaseGetMacroResponse();
-    message.macro =
-      object.macro !== undefined && object.macro !== null
-        ? MacroDetail.fromPartial(object.macro)
-        : undefined;
+    message.macro = (object.macro !== undefined && object.macro !== null)
+      ? MacroDetail.fromPartial(object.macro)
+      : undefined;
     return message;
   },
 };
 
 function createBaseMacroGlobalSettings(): MacroGlobalSettings {
-  return {
-    tapMs: 0,
-    maxEntries: 0,
-    keyPressBehaviorId: 0,
-    poolBytesTotal: 0,
-    poolBytesUsed: 0,
-  };
+  return { tapMs: 0, maxEntries: 0, keyPressBehaviorId: 0, poolBytesTotal: 0, poolBytesUsed: 0 };
 }
 
 export const MacroGlobalSettings: MessageFns<MacroGlobalSettings> = {
-  encode(
-    message: MacroGlobalSettings,
-    writer: BinaryWriter = new BinaryWriter(),
-  ): BinaryWriter {
+  encode(message: MacroGlobalSettings, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.tapMs !== 0) {
       writer.uint32(8).uint32(message.tapMs);
     }
@@ -1905,12 +1671,8 @@ export const MacroGlobalSettings: MessageFns<MacroGlobalSettings> = {
     return writer;
   },
 
-  decode(
-    input: BinaryReader | Uint8Array,
-    length?: number,
-  ): MacroGlobalSettings {
-    const reader =
-      input instanceof BinaryReader ? input : new BinaryReader(input);
+  decode(input: BinaryReader | Uint8Array, length?: number): MacroGlobalSettings {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
     const end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseMacroGlobalSettings();
     while (reader.pos < end) {
@@ -1983,68 +1745,49 @@ function createBaseGetMacroGlobalSettingsResponse(): GetMacroGlobalSettingsRespo
   return { settings: undefined };
 }
 
-export const GetMacroGlobalSettingsResponse: MessageFns<GetMacroGlobalSettingsResponse> =
-  {
-    encode(
-      message: GetMacroGlobalSettingsResponse,
-      writer: BinaryWriter = new BinaryWriter(),
-    ): BinaryWriter {
-      if (message.settings !== undefined) {
-        MacroGlobalSettings.encode(
-          message.settings,
-          writer.uint32(10).fork(),
-        ).join();
-      }
-      return writer;
-    },
+export const GetMacroGlobalSettingsResponse: MessageFns<GetMacroGlobalSettingsResponse> = {
+  encode(message: GetMacroGlobalSettingsResponse, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    if (message.settings !== undefined) {
+      MacroGlobalSettings.encode(message.settings, writer.uint32(10).fork()).join();
+    }
+    return writer;
+  },
 
-    decode(
-      input: BinaryReader | Uint8Array,
-      length?: number,
-    ): GetMacroGlobalSettingsResponse {
-      const reader =
-        input instanceof BinaryReader ? input : new BinaryReader(input);
-      const end = length === undefined ? reader.len : reader.pos + length;
-      const message = createBaseGetMacroGlobalSettingsResponse();
-      while (reader.pos < end) {
-        const tag = reader.uint32();
-        switch (tag >>> 3) {
-          case 1: {
-            if (tag !== 10) {
-              break;
-            }
-
-            message.settings = MacroGlobalSettings.decode(
-              reader,
-              reader.uint32(),
-            );
-            continue;
+  decode(input: BinaryReader | Uint8Array, length?: number): GetMacroGlobalSettingsResponse {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseGetMacroGlobalSettingsResponse();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
           }
-        }
-        if ((tag & 7) === 4 || tag === 0) {
-          break;
-        }
-        reader.skip(tag & 7);
-      }
-      return message;
-    },
 
-    create(
-      base?: DeepPartial<GetMacroGlobalSettingsResponse>,
-    ): GetMacroGlobalSettingsResponse {
-      return GetMacroGlobalSettingsResponse.fromPartial(base ?? {});
-    },
-    fromPartial(
-      object: DeepPartial<GetMacroGlobalSettingsResponse>,
-    ): GetMacroGlobalSettingsResponse {
-      const message = createBaseGetMacroGlobalSettingsResponse();
-      message.settings =
-        object.settings !== undefined && object.settings !== null
-          ? MacroGlobalSettings.fromPartial(object.settings)
-          : undefined;
-      return message;
-    },
-  };
+          message.settings = MacroGlobalSettings.decode(reader, reader.uint32());
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  create(base?: DeepPartial<GetMacroGlobalSettingsResponse>): GetMacroGlobalSettingsResponse {
+    return GetMacroGlobalSettingsResponse.fromPartial(base ?? {});
+  },
+  fromPartial(object: DeepPartial<GetMacroGlobalSettingsResponse>): GetMacroGlobalSettingsResponse {
+    const message = createBaseGetMacroGlobalSettingsResponse();
+    message.settings = (object.settings !== undefined && object.settings !== null)
+      ? MacroGlobalSettings.fromPartial(object.settings)
+      : undefined;
+    return message;
+  },
+};
 
 function createBaseResponse(): Response {
   return {
@@ -2057,10 +1800,7 @@ function createBaseResponse(): Response {
 }
 
 export const Response: MessageFns<Response> = {
-  encode(
-    message: Response,
-    writer: BinaryWriter = new BinaryWriter(),
-  ): BinaryWriter {
+  encode(message: Response, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.error !== undefined) {
       ErrorResponse.encode(message.error, writer.uint32(10).fork()).join();
     }
@@ -2068,29 +1808,19 @@ export const Response: MessageFns<Response> = {
       StatusResponse.encode(message.status, writer.uint32(18).fork()).join();
     }
     if (message.listMacros !== undefined) {
-      ListMacrosResponse.encode(
-        message.listMacros,
-        writer.uint32(26).fork(),
-      ).join();
+      ListMacrosResponse.encode(message.listMacros, writer.uint32(26).fork()).join();
     }
     if (message.getMacro !== undefined) {
-      GetMacroResponse.encode(
-        message.getMacro,
-        writer.uint32(34).fork(),
-      ).join();
+      GetMacroResponse.encode(message.getMacro, writer.uint32(34).fork()).join();
     }
     if (message.getMacroGlobalSettings !== undefined) {
-      GetMacroGlobalSettingsResponse.encode(
-        message.getMacroGlobalSettings,
-        writer.uint32(42).fork(),
-      ).join();
+      GetMacroGlobalSettingsResponse.encode(message.getMacroGlobalSettings, writer.uint32(42).fork()).join();
     }
     return writer;
   },
 
   decode(input: BinaryReader | Uint8Array, length?: number): Response {
-    const reader =
-      input instanceof BinaryReader ? input : new BinaryReader(input);
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
     const end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseResponse();
     while (reader.pos < end) {
@@ -2117,10 +1847,7 @@ export const Response: MessageFns<Response> = {
             break;
           }
 
-          message.listMacros = ListMacrosResponse.decode(
-            reader,
-            reader.uint32(),
-          );
+          message.listMacros = ListMacrosResponse.decode(reader, reader.uint32());
           continue;
         }
         case 4: {
@@ -2136,8 +1863,7 @@ export const Response: MessageFns<Response> = {
             break;
           }
 
-          message.getMacroGlobalSettings =
-            GetMacroGlobalSettingsResponse.decode(reader, reader.uint32());
+          message.getMacroGlobalSettings = GetMacroGlobalSettingsResponse.decode(reader, reader.uint32());
           continue;
         }
       }
@@ -2154,51 +1880,33 @@ export const Response: MessageFns<Response> = {
   },
   fromPartial(object: DeepPartial<Response>): Response {
     const message = createBaseResponse();
-    message.error =
-      object.error !== undefined && object.error !== null
-        ? ErrorResponse.fromPartial(object.error)
-        : undefined;
-    message.status =
-      object.status !== undefined && object.status !== null
-        ? StatusResponse.fromPartial(object.status)
-        : undefined;
-    message.listMacros =
-      object.listMacros !== undefined && object.listMacros !== null
-        ? ListMacrosResponse.fromPartial(object.listMacros)
-        : undefined;
-    message.getMacro =
-      object.getMacro !== undefined && object.getMacro !== null
-        ? GetMacroResponse.fromPartial(object.getMacro)
-        : undefined;
+    message.error = (object.error !== undefined && object.error !== null)
+      ? ErrorResponse.fromPartial(object.error)
+      : undefined;
+    message.status = (object.status !== undefined && object.status !== null)
+      ? StatusResponse.fromPartial(object.status)
+      : undefined;
+    message.listMacros = (object.listMacros !== undefined && object.listMacros !== null)
+      ? ListMacrosResponse.fromPartial(object.listMacros)
+      : undefined;
+    message.getMacro = (object.getMacro !== undefined && object.getMacro !== null)
+      ? GetMacroResponse.fromPartial(object.getMacro)
+      : undefined;
     message.getMacroGlobalSettings =
-      object.getMacroGlobalSettings !== undefined &&
-      object.getMacroGlobalSettings !== null
-        ? GetMacroGlobalSettingsResponse.fromPartial(
-            object.getMacroGlobalSettings,
-          )
+      (object.getMacroGlobalSettings !== undefined && object.getMacroGlobalSettings !== null)
+        ? GetMacroGlobalSettingsResponse.fromPartial(object.getMacroGlobalSettings)
         : undefined;
     return message;
   },
 };
 
-type Builtin =
-  | Date
-  | Function
-  | Uint8Array
-  | string
-  | number
-  | boolean
-  | undefined;
+type Builtin = Date | Function | Uint8Array | string | number | boolean | undefined;
 
-export type DeepPartial<T> = T extends Builtin
-  ? T
-  : T extends globalThis.Array<infer U>
-    ? globalThis.Array<DeepPartial<U>>
-    : T extends ReadonlyArray<infer U>
-      ? ReadonlyArray<DeepPartial<U>>
-      : T extends {}
-        ? { [K in keyof T]?: DeepPartial<T[K]> }
-        : Partial<T>;
+export type DeepPartial<T> = T extends Builtin ? T
+  : T extends globalThis.Array<infer U> ? globalThis.Array<DeepPartial<U>>
+  : T extends ReadonlyArray<infer U> ? ReadonlyArray<DeepPartial<U>>
+  : T extends {} ? { [K in keyof T]?: DeepPartial<T[K]> }
+  : Partial<T>;
 
 export interface MessageFns<T> {
   encode(message: T, writer?: BinaryWriter): BinaryWriter;


### PR DESCRIPTION
## Summary

- Switch macro lifecycle operations from the `cormoran_custom_settings` subsystem to the native RPCs added in [zmk-feature-runtime-macro#13](https://github.com/cormoran/zmk-feature-runtime-macro/pull/13)
- Fixes the known "No keyspace registered for this key" bug that could occur with the old approach
- The `renameMacro` signature no longer requires passing `steps` — the firmware copies the body server-side

## Changes

- **Proto** (`runtime_macro.ts`): Added `CreateMacroRequest`, `DeleteMacroRequest`, `RenameMacroRequest` message types with full encode/decode/fromPartial support
- **Hook** (`useRuntimeMacro.ts`): Rewired `createMacro`/`deleteMacro`/`renameMacro` to call the runtime-macro subsystem directly; removed `useCustomSettings` dependency and the `steps` parameter from `renameMacro`
- **Demo handler** (`demo-runtime-macro.ts`): Added native create/delete/rename handlers; the legacy keyspace-change path (`syncFromKeyspace`) is kept for backwards compat
- **Tests**: Added native RPC tests for all three operations (create/delete/rename); legacy path tests kept and labelled
- **MacroPage**: Removed the now-unnecessary `steps` argument from the `renameMacro` call

## Test plan

- [ ] All 12 unit tests pass (`npm test -- --testPathPattern=demo-runtime-macro`)
- [ ] `tsc --noEmit` clean
- [ ] Create / delete / rename macros on a device with zmk-feature-runtime-macro#13 firmware

🤖 Generated with [Claude Code](https://claude.com/claude-code)