### PR TITLE
Adopt react-zmk-studio's handshake-timeout for auto-reconnect

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -842,8 +842,8 @@
       }
     },
     "node_modules/@cormoran/zmk-studio-react-hook": {
-      "version": "0.0.2",
-      "resolved": "git+ssh://git@github.com/cormoran/react-zmk-studio.git#b91561dcaf0ee940cda210a5a52729d55271ee4a",
+      "version": "0.0.3",
+      "resolved": "git+ssh://git@github.com/cormoran/react-zmk-studio.git#8a9903592b61a37bcc209ce8fc17b9d6e545a14b",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/src/components/DeviceConnection.tsx
+++ b/src/components/DeviceConnection.tsx
@@ -7,6 +7,7 @@ import {
   getPairedSerialPorts,
   connectToPairedSerial,
 } from "@cormoran/zmk-studio-react-hook";
+import type { UseZMKAppOptions } from "@cormoran/zmk-studio-react-hook";
 import { connect as connectBLE } from "@zmkfirmware/zmk-studio-ts-client/transport/gatt";
 import { connect as connectUSB } from "../lib/transport/usb";
 import { connect as connectDemo } from "../lib/transport/demo";
@@ -58,13 +59,23 @@ interface DeviceConnectionProviderProps {
    * mainly so tests don't have to wait out the real-world default.
    */
   reconnectMinDisplayMs?: number;
+  /**
+   * How long (ms) to wait for the device to answer the initial RPC handshake
+   * before giving up. Forwarded to `useZMKApp`; defaults to the library's
+   * own default (5000ms) when omitted. Without this, a paired-but-unresponsive
+   * device (e.g. sitting in the bootloader) would hang the page-load
+   * auto-reconnect attempt forever instead of falling back to the connect
+   * screen.
+   */
+  connectTimeoutMs?: UseZMKAppOptions["connectTimeoutMs"];
 }
 
 export function DeviceConnectionProvider({
   children,
   reconnectMinDisplayMs = AUTO_RECONNECT_MIN_DISPLAY_MS,
+  connectTimeoutMs,
 }: DeviceConnectionProviderProps) {
-  const zmkApp = useZMKApp();
+  const zmkApp = useZMKApp({ connectTimeoutMs });
   const [isReconnecting, setIsReconnecting] = useState(false);
 
   // Guards against React StrictMode's double-invoke of effects triggering

--- a/src/components/__tests__/DeviceConnection.test.tsx
+++ b/src/components/__tests__/DeviceConnection.test.tsx
@@ -11,7 +11,10 @@ import {
   ConnectionContext,
 } from "../DeviceConnection";
 import { useContext } from "react";
-import { useZMKApp } from "@cormoran/zmk-studio-react-hook";
+import {
+  useZMKApp,
+  CONNECT_TIMEOUT_ERROR,
+} from "@cormoran/zmk-studio-react-hook";
 import { setupZMKMocks } from "@cormoran/zmk-studio-react-hook/testing";
 
 // Mock the ZMK Studio client
@@ -623,6 +626,58 @@ describe("DeviceConnection", () => {
       expect(screen.getByTestId("connection-status")).toHaveTextContent(
         "Connected",
       );
+    });
+
+    test("gives up reconnecting instead of hanging forever when the paired device never answers the handshake", async () => {
+      const consoleErrorSpy = jest.spyOn(console, "error").mockImplementation();
+      const consoleWarnSpy = jest.spyOn(console, "warn").mockImplementation();
+      const mockPort = createMockSerialPort();
+      setPairedSerialPorts([mockPort]);
+
+      // The device is paired and opens fine, but never responds to the RPC
+      // handshake -- `call_rpc`'s pending read only settles once the
+      // connection is aborted by the `connectTimeoutMs` watchdog.
+      let capturedSignal: AbortSignal | undefined;
+      mocks.create_rpc_connection.mockImplementation(
+        (_transport: unknown, opts: { signal: AbortSignal }) => {
+          capturedSignal = opts.signal;
+          return mocks.mockConnection;
+        },
+      );
+      // Drop any queued `mockResolvedValueOnce` responses left over from a
+      // previous test's `mockSuccessfulConnection` -- `jest.clearAllMocks()`
+      // (run in `beforeEach`) does not clear those queues, only call history.
+      mocks.call_rpc.mockReset();
+      mocks.call_rpc.mockImplementation(
+        () =>
+          new Promise((_resolve, reject) => {
+            capturedSignal?.addEventListener("abort", () =>
+              reject(capturedSignal?.reason ?? new Error("aborted")),
+            );
+          }),
+      );
+
+      render(
+        <DeviceConnectionProvider
+          reconnectMinDisplayMs={0}
+          connectTimeoutMs={20}
+        >
+          <TestComponent />
+        </DeviceConnectionProvider>,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId("error")).toHaveTextContent(
+          CONNECT_TIMEOUT_ERROR,
+        );
+      });
+      expect(screen.getByTestId("connection-status")).toHaveTextContent(
+        "Disconnected",
+      );
+      expect(screen.queryByTestId("reconnecting")).not.toBeInTheDocument();
+
+      consoleErrorSpy.mockRestore();
+      consoleWarnSpy.mockRestore();
     });
   });
 });


### PR DESCRIPTION
## Summary
- Bump `@cormoran/zmk-studio-react-hook` to the commit that gives `useZMKApp` a `connectTimeoutMs` option (default 5000ms): a paired-but-unresponsive device (e.g. sitting in the bootloader) now aborts the connect attempt instead of hanging forever on the RPC mutex.
- Thread `connectTimeoutMs` through `DeviceConnectionProvider` so the page-load auto-reconnect flow benefits from the new timeout.
- Add a regression test covering an unresponsive paired device during auto-reconnect.

## Test plan
- [x] `npx tsc -b --noEmit`
- [x] `npx eslint` / `npx prettier --check`
- [x] `npm test` (all suites pass, including the new timeout test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)