### PR TITLE
Group already-supported subsystems into a collapsed section

### DIFF
--- a/src/hooks/useBLEProfiles.ts
+++ b/src/hooks/useBLEProfiles.ts
@@ -8,7 +8,8 @@ import {
 
 // Subsystem identifier for ZMK BLE management custom protocol
 // This matches the identifier registered in the ZMK firmware module
-const SUBSYSTEM_IDENTIFIER = "cormoran_ble";
+export const BLE_MANAGEMENT_SUBSYSTEM_IDENTIFIER = "cormoran_ble";
+const SUBSYSTEM_IDENTIFIER = BLE_MANAGEMENT_SUBSYSTEM_IDENTIFIER;
 
 const CODEC = {
   encode: (request: Request) => Request.encode(request).finish(),

--- a/src/hooks/useDefaultLayer.ts
+++ b/src/hooks/useDefaultLayer.ts
@@ -8,7 +8,8 @@ import {
 
 // Subsystem identifier for the ZMK default-layer custom protocol.
 // This matches the identifier registered in the zmk-feature-default-layer module.
-const SUBSYSTEM_IDENTIFIER = "cormoran__default_layer";
+export const DEFAULT_LAYER_SUBSYSTEM_IDENTIFIER = "cormoran__default_layer";
+const SUBSYSTEM_IDENTIFIER = DEFAULT_LAYER_SUBSYSTEM_IDENTIFIER;
 
 const CODEC = {
   encode: (request: Request) => Request.encode(request).finish(),

--- a/src/hooks/useOsDetection.ts
+++ b/src/hooks/useOsDetection.ts
@@ -9,7 +9,8 @@ import {
 
 // Subsystem identifier for the ZMK OS detection custom protocol.
 // This matches the identifier registered in the zmk-feature-os-detection module.
-const SUBSYSTEM_IDENTIFIER = "cormoran__os_detection";
+export const OS_DETECTION_SUBSYSTEM_IDENTIFIER = "cormoran__os_detection";
+const SUBSYSTEM_IDENTIFIER = OS_DETECTION_SUBSYSTEM_IDENTIFIER;
 
 const CODEC = {
   encode: (request: Request) => Request.encode(request).finish(),

--- a/src/hooks/useRuntimeInputProcessor.ts
+++ b/src/hooks/useRuntimeInputProcessor.ts
@@ -16,7 +16,8 @@ export { AxisSnapMode };
 
 // Subsystem identifier for ZMK runtime input processor custom protocol
 // This matches the identifier registered in the ZMK firmware module
-const SUBSYSTEM_IDENTIFIER = "cormoran_rip";
+export const RUNTIME_INPUT_PROCESSOR_SUBSYSTEM_IDENTIFIER = "cormoran_rip";
+const SUBSYSTEM_IDENTIFIER = RUNTIME_INPUT_PROCESSOR_SUBSYSTEM_IDENTIFIER;
 
 const CODEC = {
   encode: (request: Request) => Request.encode(request).finish(),

--- a/src/hooks/useRuntimeSensorRotate.ts
+++ b/src/hooks/useRuntimeSensorRotate.ts
@@ -19,7 +19,8 @@ export type { SensorInfo, LayerBindings, Binding };
 
 // Subsystem identifier for ZMK runtime sensor rotate custom protocol
 // This should match the identifier registered in the ZMK firmware module
-const SUBSYSTEM_IDENTIFIER = "cormoran_rsr";
+export const RUNTIME_SENSOR_ROTATE_SUBSYSTEM_IDENTIFIER = "cormoran_rsr";
+const SUBSYSTEM_IDENTIFIER = RUNTIME_SENSOR_ROTATE_SUBSYSTEM_IDENTIFIER;
 
 const CODEC = {
   encode: (request: Request) => Request.encode(request).finish(),

--- a/src/hooks/useSettings.ts
+++ b/src/hooks/useSettings.ts
@@ -11,7 +11,8 @@ import {
 } from "../proto/zmk/settings/core";
 
 // Subsystem identifier for ZMK settings RPC
-const SUBSYSTEM_IDENTIFIER = "zmk__settings";
+export const SETTINGS_SUBSYSTEM_IDENTIFIER = "zmk__settings";
+const SUBSYSTEM_IDENTIFIER = SETTINGS_SUBSYSTEM_IDENTIFIER;
 
 const CODEC = {
   encode: (request: Request) => Request.encode(request).finish(),

--- a/src/i18n/translations.ts
+++ b/src/i18n/translations.ts
@@ -489,6 +489,11 @@ const ja: Record<string, string> = {
     "このサブシステムで利用可能な Web UI はありません。",
   "No custom subsystems available. Custom subsystems are provided by the keyboard firmware.":
     "利用可能なカスタムサブシステムはありません。カスタムサブシステムはキーボードファームウェアによって提供されます。",
+  "All custom subsystems reported by this device are already supported by DYA Studio.":
+    "このデバイスが報告するカスタムサブシステムは、すべて DYA Studio で既にサポートされています。",
+  "Already supported by DYA Studio": "DYA Studio で既にサポート済み",
+  "These subsystems have a dedicated UI elsewhere in DYA Studio":
+    "これらのサブシステムは、DYA Studio の他の場所に専用の UI があります",
   "Custom subsystems are additional features provided by your keyboard firmware author. Web UI links open external pages supplied by the firmware metadata.":
     "カスタムサブシステムは、キーボードファームウェア作者が提供する追加機能です。Web UI リンクは、ファームウェアメタデータで提供された外部ページを開きます。",
 

--- a/src/pages/CustomSubsystemsPage.tsx
+++ b/src/pages/CustomSubsystemsPage.tsx
@@ -6,8 +6,47 @@ import {
   IconX,
 } from "@tabler/icons-react";
 import { ZMKAppContext } from "@cormoran/zmk-studio-react-hook";
+import type { ListCustomSubsystemResponse } from "@zmkfirmware/zmk-studio-ts-client/custom";
 import { navigateTo } from "../lib/navigate";
 import { useLanguage } from "../hooks/useLanguage";
+import { SectionCard } from "../components/troubleshooting/SectionCard";
+import { DEVICE_INFO_SUBSYSTEM_IDENTIFIER } from "../hooks/useDeviceInfo";
+import { WATCHDOG_SUBSYSTEM_IDENTIFIER } from "../hooks/useWatchdog";
+import { PMW3610_SUBSYSTEM_IDENTIFIER } from "../hooks/usePmw3610";
+import { CUSTOM_SETTINGS_IDENTIFIER } from "../hooks/useCustomSettings";
+import { INPUT_STREAM_IDENTIFIER } from "../hooks/useInputStream";
+import { PHYSICAL_LAYOUTS_IDENTIFIERS } from "../hooks/usePhysicalLayoutModules";
+import { KSCAN_DIAGNOSTICS_SUBSYSTEM_IDENTIFIER } from "../hooks/useKscanDiagnostics";
+import { RUNTIME_COMBO_IDENTIFIER } from "../hooks/useRuntimeCombo";
+import { RUNTIME_MACRO_SUBSYSTEM_IDENTIFIER } from "../hooks/useRuntimeMacro";
+import { RUNTIME_INPUT_PROCESSOR_SUBSYSTEM_IDENTIFIER } from "../hooks/useRuntimeInputProcessor";
+import { RUNTIME_SENSOR_ROTATE_SUBSYSTEM_IDENTIFIER } from "../hooks/useRuntimeSensorRotate";
+import { DEFAULT_LAYER_SUBSYSTEM_IDENTIFIER } from "../hooks/useDefaultLayer";
+import { SETTINGS_SUBSYSTEM_IDENTIFIER } from "../hooks/useSettings";
+import { BLE_MANAGEMENT_SUBSYSTEM_IDENTIFIER } from "../hooks/useBLEProfiles";
+import { OS_DETECTION_SUBSYSTEM_IDENTIFIER } from "../hooks/useOsDetection";
+
+// Identifiers of subsystems DYA Studio already has a dedicated UI for
+// (mirrors the `*_IDENTIFIER` constants exported by src/hooks/*.ts).
+const SUPPORTED_SUBSYSTEM_IDENTIFIERS = new Set<string>([
+  DEVICE_INFO_SUBSYSTEM_IDENTIFIER,
+  WATCHDOG_SUBSYSTEM_IDENTIFIER,
+  PMW3610_SUBSYSTEM_IDENTIFIER,
+  CUSTOM_SETTINGS_IDENTIFIER,
+  INPUT_STREAM_IDENTIFIER,
+  ...PHYSICAL_LAYOUTS_IDENTIFIERS,
+  KSCAN_DIAGNOSTICS_SUBSYSTEM_IDENTIFIER,
+  RUNTIME_COMBO_IDENTIFIER,
+  RUNTIME_MACRO_SUBSYSTEM_IDENTIFIER,
+  RUNTIME_INPUT_PROCESSOR_SUBSYSTEM_IDENTIFIER,
+  RUNTIME_SENSOR_ROTATE_SUBSYSTEM_IDENTIFIER,
+  DEFAULT_LAYER_SUBSYSTEM_IDENTIFIER,
+  SETTINGS_SUBSYSTEM_IDENTIFIER,
+  BLE_MANAGEMENT_SUBSYSTEM_IDENTIFIER,
+  OS_DETECTION_SUBSYSTEM_IDENTIFIER,
+]);
+
+type Subsystem = ListCustomSubsystemResponse["subsystems"][number];
 
 // LocalStorage key for trusted subsystem UI URLs
 const TRUSTED_URLS_KEY = "dya-studio-trusted-subsystem-urls";
@@ -151,12 +190,73 @@ function ExternalLinkWarningDialog({
   );
 }
 
+interface SubsystemCardProps {
+  subsystem: Subsystem;
+  onLinkClick: (url: string) => void;
+}
+
+function SubsystemCard({ subsystem, onLinkClick }: SubsystemCardProps) {
+  const { t } = useLanguage();
+  return (
+    <div className="glass-card p-5">
+      <div className="flex items-start gap-3 mb-3">
+        <div className="w-8 h-8 rounded-lg bg-[var(--color-cyber)]/10 border border-[var(--color-cyber)]/20 flex items-center justify-center flex-shrink-0">
+          <span className="text-xs font-mono text-[var(--color-cyber)]">
+            {subsystem.index}
+          </span>
+        </div>
+        <div className="flex-1 min-w-0">
+          <p className="text-sm font-medium text-[var(--color-text)] font-mono break-all">
+            {subsystem.identifier}
+          </p>
+          <p className="text-xs text-[var(--color-text-muted)] mt-0.5">
+            {t("Subsystem index: {{index}}", {
+              index: subsystem.index,
+            })}
+          </p>
+        </div>
+      </div>
+
+      {subsystem.uiUrl.length > 0 ? (
+        <div className="mt-3 space-y-2">
+          <p className="text-xs font-medium text-[var(--color-text-muted)] uppercase tracking-wide">
+            {t("Web UI")}
+          </p>
+          {subsystem.uiUrl.map((url, urlIndex) => (
+            <button
+              key={urlIndex}
+              className="flex items-center gap-2 text-sm text-[var(--color-electric)] hover:text-[var(--color-neon)] transition-colors group w-full text-left"
+              onClick={() => onLinkClick(url)}
+            >
+              <IconExternalLink
+                size={14}
+                className="flex-shrink-0 group-hover:translate-x-0.5 group-hover:-translate-y-0.5 transition-transform"
+              />
+              <span className="underline break-all">{url}</span>
+            </button>
+          ))}
+        </div>
+      ) : (
+        <p className="text-xs text-[var(--color-text-muted)] mt-2">
+          {t("No web UI available for this subsystem.")}
+        </p>
+      )}
+    </div>
+  );
+}
+
 export function CustomSubsystemsPage() {
   const { t } = useLanguage();
   const zmkApp = useContext(ZMKAppContext);
   const [pendingUrl, setPendingUrl] = useState<string | null>(null);
 
   const subsystems = zmkApp?.state.customSubsystems?.subsystems ?? [];
+  const unsupportedSubsystems = subsystems.filter(
+    (subsystem) => !SUPPORTED_SUBSYSTEM_IDENTIFIERS.has(subsystem.identifier),
+  );
+  const supportedSubsystems = subsystems.filter((subsystem) =>
+    SUPPORTED_SUBSYSTEM_IDENTIFIERS.has(subsystem.identifier),
+  );
 
   const navigate = (url: string) => {
     zmkApp?.disconnect();
@@ -208,54 +308,54 @@ export function CustomSubsystemsPage() {
 
         {/* Subsystem list */}
         {subsystems.length > 0 ? (
-          <div className="space-y-4">
-            {subsystems.map((subsystem) => (
-              <div key={subsystem.index} className="glass-card p-5">
-                <div className="flex items-start gap-3 mb-3">
-                  <div className="w-8 h-8 rounded-lg bg-[var(--color-cyber)]/10 border border-[var(--color-cyber)]/20 flex items-center justify-center flex-shrink-0">
-                    <span className="text-xs font-mono text-[var(--color-cyber)]">
-                      {subsystem.index}
-                    </span>
-                  </div>
-                  <div className="flex-1 min-w-0">
-                    <p className="text-sm font-medium text-[var(--color-text)] font-mono break-all">
-                      {subsystem.identifier}
-                    </p>
-                    <p className="text-xs text-[var(--color-text-muted)] mt-0.5">
-                      {t("Subsystem index: {{index}}", {
-                        index: subsystem.index,
-                      })}
-                    </p>
-                  </div>
-                </div>
+          <>
+            {unsupportedSubsystems.length > 0 ? (
+              <div className="space-y-4">
+                {unsupportedSubsystems.map((subsystem) => (
+                  <SubsystemCard
+                    key={subsystem.index}
+                    subsystem={subsystem}
+                    onLinkClick={handleLinkClick}
+                  />
+                ))}
+              </div>
+            ) : (
+              <div className="glass-card p-6">
+                <p className="text-sm text-[var(--color-text-muted)]">
+                  {t(
+                    "All custom subsystems reported by this device are already supported by DYA Studio.",
+                  )}
+                </p>
+              </div>
+            )}
 
-                {subsystem.uiUrl.length > 0 ? (
-                  <div className="mt-3 space-y-2">
-                    <p className="text-xs font-medium text-[var(--color-text-muted)] uppercase tracking-wide">
-                      {t("Web UI")}
-                    </p>
-                    {subsystem.uiUrl.map((url, urlIndex) => (
-                      <button
-                        key={urlIndex}
-                        className="flex items-center gap-2 text-sm text-[var(--color-electric)] hover:text-[var(--color-neon)] transition-colors group w-full text-left"
-                        onClick={() => handleLinkClick(url)}
-                      >
-                        <IconExternalLink
-                          size={14}
-                          className="flex-shrink-0 group-hover:translate-x-0.5 group-hover:-translate-y-0.5 transition-transform"
-                        />
-                        <span className="underline break-all">{url}</span>
-                      </button>
+            {supportedSubsystems.length > 0 && (
+              <div className="mt-4">
+                <SectionCard
+                  icon={
+                    <IconPuzzle
+                      size={20}
+                      className="text-[var(--color-electric)]"
+                    />
+                  }
+                  title={t("Already supported by DYA Studio")}
+                  subtitle={t(
+                    "These subsystems have a dedicated UI elsewhere in DYA Studio",
+                  )}
+                >
+                  <div className="space-y-4">
+                    {supportedSubsystems.map((subsystem) => (
+                      <SubsystemCard
+                        key={subsystem.index}
+                        subsystem={subsystem}
+                        onLinkClick={handleLinkClick}
+                      />
                     ))}
                   </div>
-                ) : (
-                  <p className="text-xs text-[var(--color-text-muted)] mt-2">
-                    {t("No web UI available for this subsystem.")}
-                  </p>
-                )}
+                </SectionCard>
               </div>
-            ))}
-          </div>
+            )}
+          </>
         ) : (
           <div className="glass-card p-6">
             <p className="text-sm text-[var(--color-text-muted)]">

--- a/src/pages/__tests__/CustomSubsystemsPage.test.tsx
+++ b/src/pages/__tests__/CustomSubsystemsPage.test.tsx
@@ -59,7 +59,7 @@ describe("CustomSubsystemsPage", () => {
   describe("Subsystem Listing", () => {
     it("should render subsystems with identifier and index", () => {
       const subsystems = createMockSubsystems([
-        { index: 0, identifier: "zmk__settings", uiUrl: [] },
+        { index: 0, identifier: "zmk__unsupported_a", uiUrl: [] },
         { index: 1, identifier: "zmk__battery", uiUrl: [] },
       ]);
       renderComponent({
@@ -72,7 +72,7 @@ describe("CustomSubsystemsPage", () => {
         },
       });
 
-      expect(screen.getByText("zmk__settings")).toBeInTheDocument();
+      expect(screen.getByText("zmk__unsupported_a")).toBeInTheDocument();
       expect(screen.getByText("zmk__battery")).toBeInTheDocument();
     });
 
@@ -95,7 +95,7 @@ describe("CustomSubsystemsPage", () => {
 
     it("should show 'no web UI' message when uiUrl is empty", () => {
       const subsystems = createMockSubsystems([
-        { index: 0, identifier: "zmk__settings", uiUrl: [] },
+        { index: 0, identifier: "zmk__unsupported_b", uiUrl: [] },
       ]);
       renderComponent({
         state: {
@@ -154,6 +154,92 @@ describe("CustomSubsystemsPage", () => {
       expect(screen.getByText("https://example.com/ui")).toBeInTheDocument();
       expect(
         screen.getByText("https://another.example.com/app"),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe("Supported subsystem grouping", () => {
+    it("should list unsupported subsystems directly and hide already-supported ones inside a collapsed section", () => {
+      const subsystems = createMockSubsystems([
+        { index: 0, identifier: "zmk__unsupported", uiUrl: [] },
+        { index: 1, identifier: "zmk__settings", uiUrl: [] },
+      ]);
+      renderComponent({
+        state: {
+          connection: null,
+          deviceInfo: null,
+          customSubsystems: subsystems,
+          isLoading: false,
+          error: null,
+        },
+      });
+
+      // Unsupported subsystem is visible right away.
+      expect(screen.getByText("zmk__unsupported")).toBeInTheDocument();
+      // Already-supported subsystem is tucked inside a collapsed section.
+      expect(screen.queryByText("zmk__settings")).not.toBeInTheDocument();
+      expect(
+        screen.getByText("Already supported by DYA Studio"),
+      ).toBeInTheDocument();
+    });
+
+    it("should reveal already-supported subsystems when the section is expanded", () => {
+      const subsystems = createMockSubsystems([
+        { index: 0, identifier: "zmk__unsupported", uiUrl: [] },
+        { index: 1, identifier: "zmk__settings", uiUrl: [] },
+      ]);
+      renderComponent({
+        state: {
+          connection: null,
+          deviceInfo: null,
+          customSubsystems: subsystems,
+          isLoading: false,
+          error: null,
+        },
+      });
+
+      fireEvent.click(screen.getByText("Already supported by DYA Studio"));
+
+      expect(screen.getByText("zmk__settings")).toBeInTheDocument();
+    });
+
+    it("should not show the collapsed section when no subsystems are already supported", () => {
+      const subsystems = createMockSubsystems([
+        { index: 0, identifier: "zmk__unsupported", uiUrl: [] },
+      ]);
+      renderComponent({
+        state: {
+          connection: null,
+          deviceInfo: null,
+          customSubsystems: subsystems,
+          isLoading: false,
+          error: null,
+        },
+      });
+
+      expect(
+        screen.queryByText("Already supported by DYA Studio"),
+      ).not.toBeInTheDocument();
+    });
+
+    it("should show a message when every reported subsystem is already supported", () => {
+      const subsystems = createMockSubsystems([
+        { index: 0, identifier: "zmk__settings", uiUrl: [] },
+      ]);
+      renderComponent({
+        state: {
+          connection: null,
+          deviceInfo: null,
+          customSubsystems: subsystems,
+          isLoading: false,
+          error: null,
+        },
+      });
+
+      expect(
+        screen.getByText(
+          "All custom subsystems reported by this device are already supported by DYA Studio.",
+        ),
       ).toBeInTheDocument();
     });
   });


### PR DESCRIPTION
## Summary
- The Subsystems tab listed every device-reported subsystem the same way, even ones DYA Studio already has a dedicated UI for (device info, watchdog, kscan diagnostics, PMW3610, settings, etc).
- Subsystems not yet supported by DYA Studio are now listed directly at the top; subsystems already supported are grouped into a collapsed "Already supported by DYA Studio" section at the bottom, matching the collapsible section pattern already used on the Troubleshooting tab.
- The "supported" identifier list is built from the `*_IDENTIFIER` constants exported by each feature hook (`src/hooks/*.ts`), exporting a few that were previously module-local so there's a single source of truth instead of a duplicated list of identifier strings.
- Added Japanese translations for the new copy.

## Test plan
- [x] `npx jest` — all 389 tests pass (added 4 new tests covering the supported/unsupported split, section expand/collapse, and the "all supported" empty state)
- [x] `npx tsc --noEmit` — no type errors
- [x] `npx eslint .` — clean
- [x] `npx prettier --check` — clean
- [x] Manually verified in the browser via Demo Mode: unsupported subsystems show directly, the "Already supported by DYA Studio" section starts collapsed and reveals the 15 already-supported demo subsystems on expand

🤖 Generated with [Claude Code](https://claude.com/claude-code)