### PR TITLE
feat(watchdog): ELF symbol resolution for PC/LR crash addresses

### DIFF
--- a/src/components/troubleshooting/WatchdogSection.tsx
+++ b/src/components/troubleshooting/WatchdogSection.tsx
@@ -1,14 +1,17 @@
-import { useState } from "react";
+import { useRef, useState } from "react";
 import {
   IconAlertTriangle,
   IconCircleCheck,
   IconHeartRateMonitor,
   IconRefresh,
   IconTrash,
+  IconUpload,
+  IconX,
 } from "@tabler/icons-react";
 import type { Incident } from "../../proto/cormoran/watchdog/watchdog";
 import { IncidentType } from "../../proto/cormoran/watchdog/watchdog";
 import type { UseWatchdogReturn } from "../../hooks/useWatchdog";
+import type { UseElfAnalysisReturn } from "../../hooks/useElfAnalysis";
 import { useLanguage } from "../../hooks/useLanguage";
 import {
   formatFatalReason,
@@ -78,7 +81,102 @@ function incidentDetail(
   return "";
 }
 
-export function WatchdogSection({ watchdog }: { watchdog: UseWatchdogReturn }) {
+/** Format a resolved address as "funcName+0x4 (path/to/file.c:42)". */
+function formatResolved(
+  resolve: UseElfAnalysisReturn["resolve"],
+  rawAddr: number,
+  label: string,
+): string | null {
+  const r = resolve(rawAddr);
+  if (!r?.functionName) return null;
+  let s = `${label} → ${r.functionName}`;
+  if (r.offset !== undefined && r.offset > 0)
+    s += `+0x${r.offset.toString(16)}`;
+  if (r.file) {
+    const parts = r.file.replace(/\\/g, "/").split("/");
+    const shortFile = parts.slice(-3).join("/");
+    s += ` (${shortFile}${r.line !== undefined ? `:${r.line}` : ""})`;
+  }
+  return s;
+}
+
+function ElfUploadBar({
+  elfAnalysis,
+  t,
+}: {
+  elfAnalysis: UseElfAnalysisReturn;
+  t: (key: string, params?: Record<string, string | number>) => string;
+}) {
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (file) void elfAnalysis.loadFile(file);
+    e.target.value = "";
+  };
+
+  return (
+    <div className="mb-4 p-3 rounded-lg border border-[var(--color-border)] bg-[var(--color-surface)]">
+      <div className="flex items-center gap-2 flex-wrap">
+        <IconUpload
+          size={14}
+          className="text-[var(--color-text-muted)] flex-shrink-0"
+        />
+        {elfAnalysis.hasElf ? (
+          <>
+            <span className="text-xs text-[var(--color-text-secondary)] flex-1 min-w-0 truncate">
+              {t("ELF: {{name}}", { name: elfAnalysis.fileName! })}
+              {elfAnalysis.hasLineInfo
+                ? ` (${t("{{n}} symbols, line info", { n: elfAnalysis.symbolCount })})`
+                : ` (${t("{{n}} symbols", { n: elfAnalysis.symbolCount })})`}
+            </span>
+            <button
+              onClick={() => elfAnalysis.clear()}
+              className="btn-ghost p-1 text-[var(--color-text-muted)] hover:text-[var(--color-text)]"
+              aria-label={t("Remove ELF")}
+            >
+              <IconX size={14} />
+            </button>
+          </>
+        ) : (
+          <span className="text-xs text-[var(--color-text-muted)] flex-1">
+            {t("Upload ELF to resolve PC/LR symbols")}
+          </span>
+        )}
+        <input
+          ref={inputRef}
+          type="file"
+          accept=".elf,application/octet-stream"
+          className="hidden"
+          onChange={handleChange}
+          disabled={elfAnalysis.isLoading}
+        />
+        <button
+          onClick={() => inputRef.current?.click()}
+          disabled={elfAnalysis.isLoading}
+          className="btn-ghost text-xs px-2 py-1 text-[var(--color-electric)] border border-[var(--color-electric)]/30 rounded"
+        >
+          {elfAnalysis.isLoading
+            ? t("Loading…")
+            : elfAnalysis.hasElf
+              ? t("Change ELF")
+              : t("Upload ELF")}
+        </button>
+      </div>
+      {elfAnalysis.error && (
+        <p className="mt-2 text-xs text-red-400">{elfAnalysis.error}</p>
+      )}
+    </div>
+  );
+}
+
+export function WatchdogSection({
+  watchdog,
+  elfAnalysis,
+}: {
+  watchdog: UseWatchdogReturn;
+  elfAnalysis?: UseElfAnalysisReturn;
+}) {
   const { t } = useLanguage();
   const {
     isAvailable,
@@ -98,6 +196,8 @@ export function WatchdogSection({ watchdog }: { watchdog: UseWatchdogReturn }) {
     setShowDeleteAllConfirm(false);
     await deleteAll();
   };
+
+  const hasFatalIncidents = incidents.some((i) => i.fatal);
 
   return (
     <SectionCard
@@ -204,6 +304,11 @@ export function WatchdogSection({ watchdog }: { watchdog: UseWatchdogReturn }) {
             </div>
           )}
 
+          {/* ELF upload — shown when there are crash incidents */}
+          {hasFatalIncidents && elfAnalysis && (
+            <ElfUploadBar elfAnalysis={elfAnalysis} t={t} />
+          )}
+
           {/* Incident table / empty state */}
           {incidents.length === 0 ? (
             <div className="p-4 rounded-lg border border-dashed border-[var(--color-border)] flex items-center gap-2">
@@ -228,40 +333,64 @@ export function WatchdogSection({ watchdog }: { watchdog: UseWatchdogReturn }) {
                     </tr>
                   </thead>
                   <tbody>
-                    {incidents.map((incident) => (
-                      <tr
-                        key={incident.id}
-                        className="border-b border-[var(--color-border)] last:border-b-0"
-                      >
-                        <td className="py-2 pr-3 font-mono">{incident.id}</td>
-                        <td className="py-2 pr-3">
-                          <span
-                            className={`inline-block px-2 py-0.5 rounded border ${incidentTypeBadgeClass(incident.type)}`}
-                          >
-                            {incidentTypeLabel(incident.type, t)}
-                          </span>
-                        </td>
-                        <td className="py-2 pr-3 font-mono">
-                          #{incident.bootOrdinal} @{" "}
-                          {formatUptime(incident.uptimeS * 1000)}
-                        </td>
-                        <td className="py-2 pr-3 text-[var(--color-text-secondary)] break-all">
-                          {incidentDetail(incident, t)}
-                        </td>
-                        <td className="py-2 text-right">
-                          <button
-                            onClick={() => void deleteOne(incident.id)}
-                            disabled={isLoading}
-                            className="btn-ghost p-1 text-red-400 hover:text-red-300"
-                            aria-label={t("Delete incident {{id}}", {
-                              id: incident.id,
-                            })}
-                          >
-                            <IconTrash size={14} />
-                          </button>
-                        </td>
-                      </tr>
-                    ))}
+                    {incidents.map((incident) => {
+                      const hasElfData = elfAnalysis?.hasElf && incident.fatal;
+                      const resolvedPc = hasElfData
+                        ? formatResolved(
+                            elfAnalysis!.resolve,
+                            incident.fatal!.pc,
+                            "PC",
+                          )
+                        : null;
+                      const resolvedLr = hasElfData
+                        ? formatResolved(
+                            elfAnalysis!.resolve,
+                            incident.fatal!.lr,
+                            "LR",
+                          )
+                        : null;
+
+                      return (
+                        <tr
+                          key={incident.id}
+                          className="border-b border-[var(--color-border)] last:border-b-0"
+                        >
+                          <td className="py-2 pr-3 font-mono">{incident.id}</td>
+                          <td className="py-2 pr-3">
+                            <span
+                              className={`inline-block px-2 py-0.5 rounded border ${incidentTypeBadgeClass(incident.type)}`}
+                            >
+                              {incidentTypeLabel(incident.type, t)}
+                            </span>
+                          </td>
+                          <td className="py-2 pr-3 font-mono">
+                            #{incident.bootOrdinal} @{" "}
+                            {formatUptime(incident.uptimeS * 1000)}
+                          </td>
+                          <td className="py-2 pr-3 text-[var(--color-text-secondary)] break-all">
+                            <div>{incidentDetail(incident, t)}</div>
+                            {(resolvedPc || resolvedLr) && (
+                              <div className="mt-1 font-mono text-[10px] text-[var(--color-electric)] space-y-0.5">
+                                {resolvedPc && <div>{resolvedPc}</div>}
+                                {resolvedLr && <div>{resolvedLr}</div>}
+                              </div>
+                            )}
+                          </td>
+                          <td className="py-2 text-right">
+                            <button
+                              onClick={() => void deleteOne(incident.id)}
+                              disabled={isLoading}
+                              className="btn-ghost p-1 text-red-400 hover:text-red-300"
+                              aria-label={t("Delete incident {{id}}", {
+                                id: incident.id,
+                              })}
+                            >
+                              <IconTrash size={14} />
+                            </button>
+                          </td>
+                        </tr>
+                      );
+                    })}
                   </tbody>
                 </table>
               </div>

--- a/src/hooks/useElfAnalysis.ts
+++ b/src/hooks/useElfAnalysis.ts
@@ -1,0 +1,70 @@
+import { useCallback, useState } from "react";
+import { ElfParseError, parseElf, resolveAddress } from "../lib/elfAnalysis";
+import type { ElfInfo, ResolvedAddress } from "../lib/elfAnalysis";
+
+export type { ResolvedAddress };
+
+export interface UseElfAnalysisReturn {
+  fileName: string | null;
+  hasElf: boolean;
+  symbolCount: number;
+  hasLineInfo: boolean;
+  isLoading: boolean;
+  error: string | null;
+  resolve: (address: number) => ResolvedAddress | null;
+  loadFile: (file: File) => Promise<void>;
+  clear: () => void;
+}
+
+const NULL_RESOLVE = (): ResolvedAddress | null => null;
+
+export function useElfAnalysis(): UseElfAnalysisReturn {
+  const [elfInfo, setElfInfo] = useState<ElfInfo | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const loadFile = useCallback(async (file: File) => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const buffer = await file.arrayBuffer();
+      const info = parseElf(buffer, file.name);
+      if (info.symbols.length === 0 && info.lines.length === 0) {
+        throw new ElfParseError(
+          "No symbols found — try a non-stripped debug ELF (zephyr.elf)",
+        );
+      }
+      setElfInfo(info);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to parse ELF file");
+      setElfInfo(null);
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  const clear = useCallback(() => {
+    setElfInfo(null);
+    setError(null);
+  }, []);
+
+  const resolve = useCallback(
+    (address: number): ResolvedAddress | null => {
+      if (!elfInfo) return null;
+      return resolveAddress(elfInfo, address);
+    },
+    [elfInfo],
+  );
+
+  return {
+    fileName: elfInfo?.fileName ?? null,
+    hasElf: elfInfo !== null,
+    symbolCount: elfInfo?.symbols.length ?? 0,
+    hasLineInfo: (elfInfo?.lines.length ?? 0) > 0,
+    isLoading,
+    error,
+    resolve: elfInfo ? resolve : NULL_RESOLVE,
+    loadFile,
+    clear,
+  };
+}

--- a/src/i18n/translations.ts
+++ b/src/i18n/translations.ts
@@ -794,6 +794,17 @@ const ja: Record<string, string> = {
   thread: "スレッド",
   "Unknown fault": "不明な障害",
 
+  // ELF analysis
+  "Upload ELF to resolve PC/LR symbols":
+    "ELFをアップロードしてPC/LRシンボルを解決",
+  "Upload ELF": "ELFをアップロード",
+  "Change ELF": "ELFを変更",
+  "Remove ELF": "ELFを削除",
+  "Loading…": "読み込み中…",
+  "ELF: {{name}}": "ELF: {{name}}",
+  "{{n}} symbols, line info": "{{n}} シンボル（行情報あり）",
+  "{{n}} symbols": "{{n}} シンボル",
+
   // Reset cause bits (Zephyr hwinfo)
   "External Pin": "外部ピン",
   Software: "ソフトウェア",

--- a/src/lib/elfAnalysis.ts
+++ b/src/lib/elfAnalysis.ts
@@ -1,0 +1,605 @@
+/**
+ * Minimal ELF/DWARF parser for resolving ARM Cortex-M PC/LR addresses to
+ * function names and source locations — a browser-native addr2line.
+ *
+ * Supports: ELF32 little-endian, DWARF 2/3/4 .debug_line (uncompressed).
+ * Falls back gracefully when sections are missing or compressed.
+ */
+
+// ELF section types (STT = symbol type)
+const STT_FUNC = 2;
+const SHN_UNDEF = 0;
+
+// DWARF line number opcodes
+const DW_LNS_copy = 1;
+const DW_LNS_advance_pc = 2;
+const DW_LNS_advance_line = 3;
+const DW_LNS_set_file = 4;
+const DW_LNS_set_column = 5;
+const DW_LNS_negate_stmt = 6;
+const DW_LNS_set_basic_block = 7;
+const DW_LNS_const_add_pc = 8;
+const DW_LNS_fixed_advance_pc = 9;
+const DW_LNS_set_prologue_end = 10;
+const DW_LNS_set_epilogue_begin = 11;
+const DW_LNS_set_isa = 12;
+const DW_LNE_end_sequence = 1;
+const DW_LNE_set_address = 2;
+const DW_LNE_define_file = 3;
+
+export interface SymbolEntry {
+  name: string;
+  address: number;
+  size: number;
+}
+
+export interface LineEntry {
+  address: number;
+  file: string;
+  line: number;
+}
+
+export interface ElfInfo {
+  fileName: string;
+  /** Function symbols sorted by address (Thumb bit cleared). */
+  symbols: SymbolEntry[];
+  /** DWARF line table sorted by address; empty when .debug_line is absent/compressed. */
+  lines: LineEntry[];
+}
+
+export interface ResolvedAddress {
+  functionName?: string;
+  /** Byte offset from function start. */
+  offset?: number;
+  file?: string;
+  line?: number;
+}
+
+export class ElfParseError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ElfParseError";
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Low-level readers
+// ---------------------------------------------------------------------------
+
+function readNullString(data: Uint8Array, offset: number): string {
+  let end = offset;
+  while (end < data.length && data[end] !== 0) end++;
+  return new TextDecoder().decode(data.subarray(offset, end));
+}
+
+function readULEB128(
+  data: Uint8Array,
+  offset: number,
+): { value: number; bytesRead: number } {
+  let result = 0,
+    shift = 0,
+    pos = offset;
+  while (pos < data.length) {
+    const byte = data[pos++];
+    result |= (byte & 0x7f) << shift;
+    shift += 7;
+    if (!(byte & 0x80)) break;
+  }
+  return { value: result, bytesRead: pos - offset };
+}
+
+function readSLEB128(
+  data: Uint8Array,
+  offset: number,
+): { value: number; bytesRead: number } {
+  let result = 0,
+    shift = 0,
+    pos = offset;
+  let byte = 0;
+  do {
+    byte = data[pos++];
+    result |= (byte & 0x7f) << shift;
+    shift += 7;
+  } while (pos < data.length && byte & 0x80);
+  if (shift < 32 && byte & 0x40) result |= -(1 << shift);
+  return { value: result, bytesRead: pos - offset };
+}
+
+// ---------------------------------------------------------------------------
+// ELF parser
+// ---------------------------------------------------------------------------
+
+interface SectionHeader {
+  name: string;
+  sh_type: number;
+  sh_offset: number;
+  sh_size: number;
+  sh_link: number;
+  sh_entsize: number;
+}
+
+function parseSectionHeaders(
+  bytes: Uint8Array,
+  view: DataView,
+): SectionHeader[] {
+  const e_shoff = view.getUint32(32, true);
+  const e_shentsize = view.getUint16(46, true);
+  const e_shnum = view.getUint16(48, true);
+  const e_shstrndx = view.getUint16(50, true);
+
+  if (e_shoff === 0 || e_shnum === 0) return [];
+
+  // Read raw section headers first (names resolved after)
+  const rawSections: Omit<SectionHeader, "name">[] = [];
+  for (let i = 0; i < e_shnum; i++) {
+    const base = e_shoff + i * e_shentsize;
+    if (base + 40 > bytes.length) break;
+    rawSections.push({
+      sh_type: view.getUint32(base + 4, true),
+      sh_offset: view.getUint32(base + 16, true),
+      sh_size: view.getUint32(base + 20, true),
+      sh_link: view.getUint32(base + 24, true),
+      sh_entsize: view.getUint32(base + 36, true),
+      // sh_name offset temporarily stored; resolved below
+      _nameIdx: view.getUint32(base + 0, true),
+    } as Omit<SectionHeader, "name"> & { _nameIdx: number });
+  }
+
+  // Resolve section names via .shstrtab
+  let shstrtab: Uint8Array | null = null;
+  if (e_shstrndx < rawSections.length) {
+    const s = rawSections[e_shstrndx] as Omit<SectionHeader, "name"> & {
+      _nameIdx: number;
+    };
+    shstrtab = bytes.subarray(s.sh_offset, s.sh_offset + s.sh_size);
+  }
+
+  return rawSections.map((s) => {
+    const raw = s as Omit<SectionHeader, "name"> & { _nameIdx: number };
+    const name = shstrtab ? readNullString(shstrtab, raw._nameIdx) : "";
+    return { ...raw, name } as SectionHeader;
+  });
+}
+
+function parseSymbols(
+  bytes: Uint8Array,
+  sections: SectionHeader[],
+): SymbolEntry[] {
+  const symtabSection = sections.find((s) => s.name === ".symtab");
+  if (!symtabSection || symtabSection.sh_size === 0) return [];
+
+  const strtabSection = sections[symtabSection.sh_link];
+  if (!strtabSection) return [];
+
+  const symtab = bytes.subarray(
+    symtabSection.sh_offset,
+    symtabSection.sh_offset + symtabSection.sh_size,
+  );
+  const strtab = bytes.subarray(
+    strtabSection.sh_offset,
+    strtabSection.sh_offset + strtabSection.sh_size,
+  );
+
+  const entSize = symtabSection.sh_entsize || 16;
+  const symbols: SymbolEntry[] = [];
+
+  for (let i = 0; i < Math.floor(symtab.length / entSize); i++) {
+    const base = i * entSize;
+    if (base + 16 > symtab.length) break;
+
+    const symView = new DataView(
+      symtab.buffer,
+      symtab.byteOffset + base,
+      entSize,
+    );
+    const st_name = symView.getUint32(0, true);
+    const st_value = symView.getUint32(4, true);
+    const st_size = symView.getUint32(8, true);
+    const st_info = symView.getUint8(12);
+    const st_shndx = symView.getUint16(14, true);
+
+    const stType = st_info & 0x0f;
+
+    if (stType === STT_FUNC && st_shndx !== SHN_UNDEF && st_value !== 0) {
+      const name = readNullString(strtab, st_name);
+      if (name) {
+        symbols.push({
+          name,
+          address: st_value & ~1, // clear Thumb mode bit
+          size: st_size,
+        });
+      }
+    }
+  }
+
+  symbols.sort((a, b) => a.address - b.address);
+  return symbols;
+}
+
+// ---------------------------------------------------------------------------
+// DWARF .debug_line parser
+// ---------------------------------------------------------------------------
+
+function parseDebugLine(data: Uint8Array): LineEntry[] {
+  const view = new DataView(data.buffer, data.byteOffset, data.byteLength);
+  const lines: LineEntry[] = [];
+  let offset = 0;
+
+  while (offset < data.length) {
+    const unitStart = offset;
+    if (offset + 4 > data.length) break;
+
+    const unitLength = view.getUint32(offset, true);
+    offset += 4;
+
+    if (unitLength === 0xffffffff) break; // 64-bit DWARF not supported
+
+    const unitEnd = unitStart + 4 + unitLength;
+    if (unitEnd > data.length) break;
+
+    if (offset + 2 > unitEnd) {
+      offset = unitEnd;
+      continue;
+    }
+    const version = view.getUint16(offset, true);
+    offset += 2;
+
+    if (version < 2 || version > 4) {
+      // DWARF 5 header layout differs significantly — skip
+      offset = unitEnd;
+      continue;
+    }
+
+    if (offset + 4 > unitEnd) {
+      offset = unitEnd;
+      continue;
+    }
+    const headerLength = view.getUint32(offset, true);
+    offset += 4;
+
+    const programStart = offset + headerLength;
+    if (programStart > unitEnd) {
+      offset = unitEnd;
+      continue;
+    }
+
+    if (offset >= unitEnd) {
+      offset = unitEnd;
+      continue;
+    }
+    const minInsnLength = data[offset++];
+
+    let maxOpsPerInsn = 1;
+    if (version >= 4) {
+      if (offset >= unitEnd) {
+        offset = unitEnd;
+        continue;
+      }
+      maxOpsPerInsn = data[offset++];
+    }
+
+    if (offset >= unitEnd) {
+      offset = unitEnd;
+      continue;
+    }
+    const defaultIsStmt = data[offset++] !== 0;
+
+    if (offset >= unitEnd) {
+      offset = unitEnd;
+      continue;
+    }
+    const lineBase = new DataView(
+      data.buffer,
+      data.byteOffset + offset,
+      1,
+    ).getInt8(0);
+    offset++;
+
+    if (offset >= unitEnd) {
+      offset = unitEnd;
+      continue;
+    }
+    const lineRange = data[offset++];
+    if (lineRange === 0) {
+      offset = unitEnd;
+      continue;
+    }
+
+    if (offset >= unitEnd) {
+      offset = unitEnd;
+      continue;
+    }
+    const opcodeBase = data[offset++];
+
+    // Standard opcode lengths (opcodeBase - 1 entries)
+    const stdOpLengths: number[] = [];
+    for (let i = 1; i < opcodeBase; i++) {
+      if (offset >= programStart) break;
+      stdOpLengths.push(data[offset++]);
+    }
+
+    // Include directories (DWARF 4 format: null-terminated strings)
+    const includeDirs: string[] = [""]; // index 0 = compilation dir (ignored)
+    while (offset < programStart) {
+      if (data[offset] === 0) {
+        offset++;
+        break;
+      }
+      const dir = readNullString(data, offset);
+      offset += dir.length + 1;
+      includeDirs.push(dir);
+    }
+
+    // File name entries (DWARF 4 format)
+    const fileNames: string[] = [""]; // index 0 unused (DWARF 4 is 1-based)
+    while (offset < programStart) {
+      if (data[offset] === 0) {
+        offset++;
+        break;
+      }
+      const fname = readNullString(data, offset);
+      offset += fname.length + 1;
+
+      const dirIdxR = readULEB128(data, offset);
+      offset += dirIdxR.bytesRead;
+      const timeR = readULEB128(data, offset);
+      offset += timeR.bytesRead;
+      const lenR = readULEB128(data, offset);
+      offset += lenR.bytesRead;
+
+      const dir =
+        dirIdxR.value > 0 && dirIdxR.value < includeDirs.length
+          ? includeDirs[dirIdxR.value]
+          : "";
+      fileNames.push(dir ? `${dir}/${fname}` : fname);
+    }
+
+    // Execute line number program
+    offset = programStart;
+
+    let address = 0;
+    let fileIdx = 1;
+    let line = 1;
+    let isStmt = defaultIsStmt;
+
+    const emitRow = () => {
+      const fname =
+        fileIdx > 0 && fileIdx < fileNames.length
+          ? fileNames[fileIdx]
+          : `file${fileIdx}`;
+      lines.push({ address, file: fname, line });
+    };
+
+    while (offset < unitEnd) {
+      const opcode = data[offset++];
+
+      if (opcode === 0) {
+        // Extended opcode
+        const extLenR = readULEB128(data, offset);
+        offset += extLenR.bytesRead;
+        if (offset >= unitEnd) break;
+        const extOp = data[offset++];
+        const extEnd = offset + extLenR.value - 1;
+
+        switch (extOp) {
+          case DW_LNE_end_sequence:
+            emitRow();
+            address = 0;
+            fileIdx = 1;
+            line = 1;
+            isStmt = defaultIsStmt;
+            break;
+          case DW_LNE_set_address:
+            if (offset + 4 <= extEnd) {
+              address = view.getUint32(offset, true);
+            }
+            break;
+          case DW_LNE_define_file: {
+            const fn = readNullString(data, offset);
+            let fnOff = offset + fn.length + 1;
+            const dirIdxR = readULEB128(data, fnOff);
+            fnOff += dirIdxR.bytesRead;
+            const timeR = readULEB128(data, fnOff);
+            fnOff += timeR.bytesRead;
+            const _lenR = readULEB128(data, fnOff);
+            void _lenR;
+            const dir =
+              dirIdxR.value > 0 && dirIdxR.value < includeDirs.length
+                ? includeDirs[dirIdxR.value]
+                : "";
+            fileNames.push(dir ? `${dir}/${fn}` : fn);
+            break;
+          }
+        }
+
+        offset = extEnd;
+        continue;
+      }
+
+      if (opcode < opcodeBase) {
+        // Standard opcode
+        switch (opcode) {
+          case DW_LNS_copy:
+            emitRow();
+            break;
+          case DW_LNS_advance_pc: {
+            const r = readULEB128(data, offset);
+            offset += r.bytesRead;
+            address += (r.value * minInsnLength) / Math.max(maxOpsPerInsn, 1);
+            break;
+          }
+          case DW_LNS_advance_line: {
+            const r = readSLEB128(data, offset);
+            offset += r.bytesRead;
+            line += r.value;
+            break;
+          }
+          case DW_LNS_set_file: {
+            const r = readULEB128(data, offset);
+            offset += r.bytesRead;
+            fileIdx = r.value;
+            break;
+          }
+          case DW_LNS_set_column: {
+            const r = readULEB128(data, offset);
+            offset += r.bytesRead;
+            void r; // column not used in output
+            break;
+          }
+          case DW_LNS_negate_stmt:
+            isStmt = !isStmt;
+            break;
+          case DW_LNS_set_basic_block:
+            break;
+          case DW_LNS_const_add_pc:
+            address +=
+              Math.floor((255 - opcodeBase) / lineRange) * minInsnLength;
+            break;
+          case DW_LNS_fixed_advance_pc:
+            if (offset + 2 <= unitEnd) {
+              address += view.getUint16(offset, true);
+              offset += 2;
+            }
+            break;
+          case DW_LNS_set_prologue_end:
+            break;
+          case DW_LNS_set_epilogue_begin:
+            break;
+          case DW_LNS_set_isa: {
+            const r = readULEB128(data, offset);
+            offset += r.bytesRead;
+            void r;
+            break;
+          }
+          default:
+            // Unknown standard opcode: skip its operands
+            if (opcode - 1 < stdOpLengths.length) {
+              for (let i = 0; i < stdOpLengths[opcode - 1]; i++) {
+                const r = readULEB128(data, offset);
+                offset += r.bytesRead;
+              }
+            }
+        }
+      } else {
+        // Special opcode
+        const adj = opcode - opcodeBase;
+        address += Math.floor(adj / lineRange) * minInsnLength;
+        line += lineBase + (adj % lineRange);
+        emitRow();
+      }
+    }
+
+    offset = unitEnd;
+  }
+
+  lines.sort((a, b) => a.address - b.address);
+  return lines;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export function parseElf(buffer: ArrayBuffer, fileName: string): ElfInfo {
+  const bytes = new Uint8Array(buffer);
+
+  if (
+    bytes.length < 52 ||
+    bytes[0] !== 0x7f ||
+    bytes[1] !== 0x45 ||
+    bytes[2] !== 0x4c ||
+    bytes[3] !== 0x46
+  ) {
+    throw new ElfParseError("Not an ELF file");
+  }
+
+  const elfClass = bytes[4]; // 1 = 32-bit
+  const elfData = bytes[5]; // 1 = little-endian
+
+  if (elfClass !== 1) throw new ElfParseError("Only 32-bit ELF is supported");
+  if (elfData !== 1)
+    throw new ElfParseError("Only little-endian ELF is supported");
+
+  const view = new DataView(buffer);
+  const sections = parseSectionHeaders(bytes, view);
+  const symbols = parseSymbols(bytes, sections);
+
+  // Parse .debug_line (best-effort; skip if absent or compressed)
+  let lines: LineEntry[] = [];
+  const debugLineSection = sections.find((s) => s.name === ".debug_line");
+  if (debugLineSection && debugLineSection.sh_size > 0) {
+    try {
+      const data = bytes.subarray(
+        debugLineSection.sh_offset,
+        debugLineSection.sh_offset + debugLineSection.sh_size,
+      );
+      lines = parseDebugLine(data);
+    } catch {
+      // Best-effort: silently ignore DWARF parse errors
+    }
+  }
+
+  return { fileName, symbols, lines };
+}
+
+/** Resolve a raw register value (PC or LR) to function/source info. */
+export function resolveAddress(
+  elf: ElfInfo,
+  rawAddress: number,
+): ResolvedAddress | null {
+  const address = rawAddress & ~1; // clear ARM Thumb mode bit
+
+  let functionName: string | undefined;
+  let offset: number | undefined;
+
+  // Binary search: largest symbol.address <= address
+  let lo = 0,
+    hi = elf.symbols.length - 1,
+    symIdx = -1;
+  while (lo <= hi) {
+    const mid = (lo + hi) >> 1;
+    if (elf.symbols[mid].address <= address) {
+      symIdx = mid;
+      lo = mid + 1;
+    } else {
+      hi = mid - 1;
+    }
+  }
+
+  if (symIdx >= 0) {
+    const sym = elf.symbols[symIdx];
+    if (sym.size === 0 || address < sym.address + sym.size) {
+      functionName = sym.name;
+      offset = address - sym.address;
+    } else {
+      // Outside the symbol's size range but closest — still useful
+      functionName = sym.name;
+      offset = address - sym.address;
+    }
+  }
+
+  // Binary search: largest line.address <= address
+  let file: string | undefined;
+  let lineNum: number | undefined;
+
+  let lo2 = 0,
+    hi2 = elf.lines.length - 1,
+    lineIdx = -1;
+  while (lo2 <= hi2) {
+    const mid = (lo2 + hi2) >> 1;
+    if (elf.lines[mid].address <= address) {
+      lineIdx = mid;
+      lo2 = mid + 1;
+    } else {
+      hi2 = mid - 1;
+    }
+  }
+
+  if (lineIdx >= 0) {
+    file = elf.lines[lineIdx].file;
+    lineNum = elf.lines[lineIdx].line;
+  }
+
+  if (!functionName && !file) return null;
+  return { functionName, offset, file, line: lineNum };
+}

--- a/src/lib/troubleshootingReport.ts
+++ b/src/lib/troubleshootingReport.ts
@@ -21,6 +21,7 @@ import type {
   DeviceInfo as Pmw3610Device,
   ReadDiagnosticsResponse,
 } from "../proto/cormoran/pmw3610/pmw3610";
+import type { ResolvedAddress } from "./elfAnalysis";
 
 /** State of one troubleshooting section as fed into the report. */
 export interface ReportSection<T> {
@@ -32,9 +33,18 @@ export interface ReportSection<T> {
   error?: string | null;
 }
 
+export interface ElfResolvedIncident {
+  id: number;
+  pc: ResolvedAddress & { address: number };
+  lr: ResolvedAddress & { address: number };
+}
+
 export interface WatchdogReportData {
   status: StatusResponse | null;
   incidents: Incident[];
+  /** Present when user uploaded a debug ELF for symbol resolution. */
+  elfFileName?: string | null;
+  elfResolved?: ElfResolvedIncident[];
 }
 
 export interface KscanReportData {
@@ -115,6 +125,30 @@ export function buildSupportReport(input: SupportReportInput): string {
         );
       }
       body.push(jsonBlock(data.incidents));
+      if (data.elfResolved && data.elfResolved.length > 0) {
+        body.push("");
+        body.push(
+          `### ELF Symbol Resolution (${data.elfFileName ?? "unknown"})`,
+        );
+        for (const ri of data.elfResolved) {
+          const fmt = (
+            r: ElfResolvedIncident["pc"] | ElfResolvedIncident["lr"],
+          ): string => {
+            let s = `0x${r.address.toString(16).padStart(8, "0")}`;
+            if (r.functionName) {
+              s += ` → ${r.functionName}`;
+              if (r.offset) s += `+0x${r.offset.toString(16)}`;
+              if (r.file) {
+                const parts = r.file.replace(/\\/g, "/").split("/");
+                const shortFile = parts.slice(-3).join("/");
+                s += ` (${shortFile}${r.line ? `:${r.line}` : ""})`;
+              }
+            }
+            return s;
+          };
+          body.push(`- Incident #${ri.id}: PC ${fmt(ri.pc)}, LR ${fmt(ri.lr)}`);
+        }
+      }
       return body;
     }),
     "",

--- a/src/pages/TroubleshootingPage.tsx
+++ b/src/pages/TroubleshootingPage.tsx
@@ -12,6 +12,7 @@ import { useDeviceInfo } from "../hooks/useDeviceInfo";
 import { useWatchdog } from "../hooks/useWatchdog";
 import { useKscanDiagnostics } from "../hooks/useKscanDiagnostics";
 import { usePmw3610 } from "../hooks/usePmw3610";
+import { useElfAnalysis } from "../hooks/useElfAnalysis";
 import { DeviceInfoSection } from "../components/troubleshooting/DeviceInfoSection";
 import { WatchdogSection } from "../components/troubleshooting/WatchdogSection";
 import { KscanDiagnosticsSection } from "../components/troubleshooting/KscanDiagnosticsSection";
@@ -27,6 +28,7 @@ export function TroubleshootingPage() {
   const watchdog = useWatchdog();
   const kscan = useKscanDiagnostics();
   const pmw3610 = usePmw3610();
+  const elfAnalysis = useElfAnalysis();
   const [copied, setCopied] = useState(false);
   const copiedTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -38,6 +40,21 @@ export function TroubleshootingPage() {
   };
 
   const copySupportReport = async () => {
+    // Resolve PC/LR for all fatal incidents when an ELF is loaded
+    const elfResolved = elfAnalysis.hasElf
+      ? watchdog.incidents
+          .filter((i) => i.fatal)
+          .map((i) => {
+            const pcR = elfAnalysis.resolve(i.fatal!.pc);
+            const lrR = elfAnalysis.resolve(i.fatal!.lr);
+            return {
+              id: i.id,
+              pc: { address: i.fatal!.pc, ...pcR },
+              lr: { address: i.fatal!.lr, ...lrR },
+            };
+          })
+      : undefined;
+
     const report = buildSupportReport({
       generatedAt: new Date().toISOString(),
       deviceName: zmkApp?.state.deviceInfo?.name ?? null,
@@ -51,7 +68,12 @@ export function TroubleshootingPage() {
       watchdog: {
         available: watchdog.isAvailable,
         data: watchdog.status
-          ? { status: watchdog.status, incidents: watchdog.incidents }
+          ? {
+              status: watchdog.status,
+              incidents: watchdog.incidents,
+              elfFileName: elfAnalysis.fileName,
+              elfResolved,
+            }
           : null,
         error: watchdog.error,
       },
@@ -149,7 +171,7 @@ export function TroubleshootingPage() {
         {/* Section cards */}
         <div className="space-y-6">
           <DeviceInfoSection deviceInfo={deviceInfo} />
-          <WatchdogSection watchdog={watchdog} />
+          <WatchdogSection watchdog={watchdog} elfAnalysis={elfAnalysis} />
           <KscanDiagnosticsSection kscan={kscan} />
           <Pmw3610Section pmw3610={pmw3610} />
         </div>


### PR DESCRIPTION
## Summary

- **`src/lib/elfAnalysis.ts`** — Browser-native ELF32 LE parser with DWARF 2/3/4 `.debug_line` runner; `parseElf()` extracts function symbols and line tables, `resolveAddress()` maps a raw PC/LR to function name + source file:line (ARM Thumb bit cleared automatically)
- **`src/hooks/useElfAnalysis.ts`** — React hook managing ELF file state (`loadFile`, `clear`, `resolve`)
- **`WatchdogSection`** — Shows an ELF upload bar when fatal crash incidents exist; resolved symbols (`PC → k_timer_expiry_handler+0x4 (kernel/timer.c:342)`) appear beneath each crash row in the table
- **`troubleshootingReport`** — Adds an `### ELF Symbol Resolution` section to the support report when ELF data is available
- **`TroubleshootingPage`** — Wires `useElfAnalysis` into the section and support report builder
- **`translations`** — Japanese strings for ELF upload UI

## How it works

Users upload `zephyr.elf` (the debug ELF produced by ZMK build, **not** the `.uf2` or `.bin` flashed to the device). The parser reads `.symtab` for function names and `.debug_line` for source locations. DWARF 5 and compressed debug sections are skipped gracefully — symbol-table-only resolution still works in that case.

## Test plan

- [ ] Connect keyboard, navigate to Troubleshooting → Stability (Watchdog)
- [ ] With no fatal incidents: confirm ELF upload bar is **not** shown
- [ ] Inject or wait for a fatal crash incident (type = Crash) to appear
- [ ] Confirm "Upload ELF to resolve PC/LR symbols" bar appears above the table
- [ ] Upload a `zephyr.elf` debug build; confirm symbol count badge appears
- [ ] Confirm PC/LR rows in the crash table show resolved function + file:line
- [ ] Click "Copy Support Report"; confirm `### ELF Symbol Resolution` section is present in the copied Markdown
- [ ] Click × / "Change ELF" to verify clear and re-upload work

🤖 Generated with [Claude Code](https://claude.com/claude-code)