### PR TITLE
feat(kscan): support peripheral diagnostics via QueryPeripheral relay

### DIFF
--- a/proto/cormoran/kscan_diagnostics/kscan_diagnostics.proto
+++ b/proto/cormoran/kscan_diagnostics/kscan_diagnostics.proto
@@ -126,6 +126,27 @@ message ResetStats {}
 
 message Ok {}
 
+// Relay a query to the split peripheral half/halves. `payload` is an encoded
+// Request that the peripheral runs against its own topology/stats tables; the
+// result comes back asynchronously as a PeripheralEvent notification, not in
+// this call's Response (which is just an Ok, or Error if this build is not a
+// split central). The query is broadcast to all connected peripherals and each
+// replies with its `source` stamped; the client correlates by (source, req_id).
+message QueryPeripheral {
+    uint32 req_id = 1;
+    bytes payload = 2;
+}
+
+// Firmware-initiated notification carrying one peripheral's reply to a
+// QueryPeripheral. `source` is the peripheral index (1-based; central is 0),
+// `req_id` echoes the triggering QueryPeripheral, and `payload` is an encoded
+// Response produced by that peripheral's query dispatch.
+message PeripheralEvent {
+    uint32 source = 1;
+    uint32 req_id = 2;
+    bytes payload = 3;
+}
+
 message Request {
     oneof request_type {
         GetInfo get_info = 1;
@@ -135,6 +156,7 @@ message Request {
         GetPositionMap get_position_map = 5;
         GetStats get_stats = 6;
         ResetStats reset_stats = 7;
+        QueryPeripheral query_peripheral = 8;
     }
 }
 

--- a/src/components/troubleshooting/KscanDiagnosticsSection.tsx
+++ b/src/components/troubleshooting/KscanDiagnosticsSection.tsx
@@ -61,6 +61,10 @@ export function KscanDiagnosticsSection({
     isLoadingTopology,
     topologyError,
     loadTopology,
+    peripheralTopologies,
+    isLoadingPeripheralTopologies,
+    peripheralTopologyErrors,
+    loadPeripheralTopologies,
   } = kscan;
   const [showResetConfirm, setShowResetConfirm] = useState(false);
   const [hasRequestedTopology, setHasRequestedTopology] = useState(false);
@@ -81,6 +85,7 @@ export function KscanDiagnosticsSection({
     if (hasRequestedTopology) return;
     setHasRequestedTopology(true);
     void loadTopology();
+    void loadPeripheralTopologies();
     void officialLayouts.load();
   };
 
@@ -210,6 +215,55 @@ export function KscanDiagnosticsSection({
               />
             </div>
           )}
+
+          {/* Peripheral halves */}
+          {isLoadingPeripheralTopologies && peripheralTopologies.size === 0 && (
+            <LoadingIndicator
+              variant="inline"
+              className="mb-4"
+              label={t("Loading peripheral wiring…")}
+            />
+          )}
+          {[...peripheralTopologyErrors.entries()].map(([src, msg]) => (
+            <SectionError
+              key={src}
+              message={t("Peripheral {{src}}: {{msg}}", { src, msg })}
+            />
+          ))}
+          {[...peripheralTopologies.entries()].map(([src, periph]) => {
+            const peripheralActiveLayout =
+              periph.layouts.find(
+                (l) => l.layoutIndex === periph.selectedLayout,
+              ) ??
+              periph.layouts[0] ??
+              null;
+            const peripheralWiring = peripheralActiveLayout
+              ? buildWiringMap(periph, peripheralActiveLayout)
+              : new Map();
+            return (
+              <div key={src} className="mb-4">
+                <p className="text-xs font-medium uppercase tracking-wide text-[var(--color-text-muted)] mb-2">
+                  {t("Peripheral {{src}}", { src })}
+                  {peripheralActiveLayout && (
+                    <span className="ml-2 normal-case font-normal">
+                      — {peripheralActiveLayout.displayName}
+                    </span>
+                  )}
+                </p>
+                {physicalLayout && peripheralActiveLayout ? (
+                  <KscanKeyboardView
+                    layout={physicalLayout}
+                    wiring={peripheralWiring}
+                    statsByPosition={new Map()}
+                  />
+                ) : (
+                  <p className="text-xs text-[var(--color-text-muted)]">
+                    {t("Wiring info received — no matching physical layout.")}
+                  </p>
+                )}
+              </div>
+            );
+          })}
 
           {/* Driver info + suspect-key stats table, collapsed by default */}
           <details className="mt-2">

--- a/src/components/troubleshooting/KscanDiagnosticsSection.tsx
+++ b/src/components/troubleshooting/KscanDiagnosticsSection.tsx
@@ -64,6 +64,7 @@ export function KscanDiagnosticsSection({
     peripheralTopologies,
     isLoadingPeripheralTopologies,
     peripheralTopologyErrors,
+    peripheralDiscoveryError,
     loadPeripheralTopologies,
   } = kscan;
   const [showResetConfirm, setShowResetConfirm] = useState(false);
@@ -223,6 +224,9 @@ export function KscanDiagnosticsSection({
               className="mb-4"
               label={t("Loading peripheral wiring…")}
             />
+          )}
+          {peripheralDiscoveryError && (
+            <SectionError message={t(peripheralDiscoveryError)} />
           )}
           {[...peripheralTopologyErrors.entries()].map(([src, msg]) => (
             <SectionError

--- a/src/components/troubleshooting/__tests__/KscanDiagnosticsSection.test.tsx
+++ b/src/components/troubleshooting/__tests__/KscanDiagnosticsSection.test.tsx
@@ -56,6 +56,7 @@ function baseKscan(
     peripheralTopologies: new Map(),
     isLoadingPeripheralTopologies: false,
     peripheralTopologyErrors: new Map(),
+    peripheralDiscoveryError: null,
     loadPeripheralTopologies: jest.fn(),
     ...overrides,
   };

--- a/src/components/troubleshooting/__tests__/KscanDiagnosticsSection.test.tsx
+++ b/src/components/troubleshooting/__tests__/KscanDiagnosticsSection.test.tsx
@@ -53,6 +53,10 @@ function baseKscan(
     isLoadingTopology: false,
     topologyError: null,
     loadTopology: jest.fn(),
+    peripheralTopologies: new Map(),
+    isLoadingPeripheralTopologies: false,
+    peripheralTopologyErrors: new Map(),
+    loadPeripheralTopologies: jest.fn(),
     ...overrides,
   };
 }
@@ -130,16 +134,22 @@ describe("KscanDiagnosticsSection", () => {
     expect(loadTopology).not.toHaveBeenCalled();
   });
 
-  it("calls loadTopology and the official layouts loader on first expand", async () => {
+  it("calls loadTopology, loadPeripheralTopologies, and the official layouts loader on first expand", async () => {
     const loadTopology = jest.fn();
+    const loadPeripheralTopologies = jest.fn();
     const load = jest.fn();
     mockOfficialLayoutsReturn({ load });
 
-    render(<KscanDiagnosticsSection kscan={baseKscan({ loadTopology })} />);
+    render(
+      <KscanDiagnosticsSection
+        kscan={baseKscan({ loadTopology, loadPeripheralTopologies })}
+      />,
+    );
 
     fireEvent.click(screen.getByRole("button", { name: "Key Switches" }));
 
     await waitFor(() => expect(loadTopology).toHaveBeenCalledTimes(1));
+    expect(loadPeripheralTopologies).toHaveBeenCalledTimes(1);
     expect(load).toHaveBeenCalledTimes(1);
   });
 

--- a/src/hooks/useKscanDiagnostics.ts
+++ b/src/hooks/useKscanDiagnostics.ts
@@ -1,4 +1,4 @@
-import { useCallback, useContext, useEffect, useState } from "react";
+import { type Context, useCallback, useContext, useEffect, useState } from "react";
 import { ZMKAppContext } from "@cormoran/zmk-studio-react-hook";
 import { useCustomSubsystem } from "./useCustomSubsystem";
 import type { UseCustomSubsystemTypedReturn } from "@cormoran/zmk-studio-react-hook";
@@ -258,7 +258,11 @@ async function fetchTopology(call: Caller): Promise<Topology> {
   };
 }
 
-type ZmkApp = ReturnType<typeof useContext<typeof ZMKAppContext>>;
+// Extract the value type from the context (what useContext(ZMKAppContext) returns),
+// then strip null so helpers can assert they receive a connected app instance.
+type ZmkApp = NonNullable<
+  typeof ZMKAppContext extends Context<infer V> ? V : never
+>;
 
 /**
  * Send a QueryPeripheral request wrapping `innerRequest` and collect

--- a/src/hooks/useKscanDiagnostics.ts
+++ b/src/hooks/useKscanDiagnostics.ts
@@ -1,4 +1,10 @@
-import { type Context, useCallback, useContext, useEffect, useState } from "react";
+import {
+  type Context,
+  useCallback,
+  useContext,
+  useEffect,
+  useState,
+} from "react";
 import { ZMKAppContext } from "@cormoran/zmk-studio-react-hook";
 import { useCustomSubsystem } from "./useCustomSubsystem";
 import type { UseCustomSubsystemTypedReturn } from "@cormoran/zmk-studio-react-hook";
@@ -65,6 +71,10 @@ export interface UseKscanDiagnosticsReturn {
   peripheralTopologies: Map<number, Topology>;
   isLoadingPeripheralTopologies: boolean;
   peripheralTopologyErrors: Map<number, string>;
+  /** Set when QueryPeripheral was supported but no peripheral responded within
+   * the discovery timeout. Null when not yet loaded or when the feature is
+   * unsupported (firmware without QueryPeripheral). */
+  peripheralDiscoveryError: string | null;
   /** Discover peripherals and fetch their topologies via QueryPeripheral. */
   loadPeripheralTopologies: () => Promise<void>;
 }
@@ -277,7 +287,7 @@ async function queryPeripheral(
   innerRequest: Request,
   filterSource?: number,
   timeout: number = PERIPHERAL_DISCOVERY_TIMEOUT_MS,
-): Promise<Map<number, Response>> {
+): Promise<{ responses: Map<number, Response>; supported: boolean }> {
   const reqId = nextPeripheralReqId();
   const responses = new Map<number, Response>();
 
@@ -307,6 +317,7 @@ async function queryPeripheral(
     },
   });
 
+  let supported = false;
   try {
     const result = await call(
       Request.create({
@@ -318,6 +329,7 @@ async function queryPeripheral(
     );
 
     if (result && !result.error) {
+      supported = true;
       await Promise.race([
         targetArrived,
         new Promise<void>((r) => setTimeout(r, timeout)),
@@ -327,7 +339,7 @@ async function queryPeripheral(
     unsubscribe();
   }
 
-  return responses;
+  return { responses, supported };
 }
 
 /**
@@ -340,7 +352,7 @@ async function fetchPeripheralTopology(
   subsystemIndex: number,
   source: number,
 ): Promise<Topology> {
-  const infoMap = await queryPeripheral(
+  const { responses: infoMap } = await queryPeripheral(
     call,
     zmkApp,
     subsystemIndex,
@@ -356,7 +368,7 @@ async function fetchPeripheralTopology(
 
   const layouts: KscanLayout[] = [];
   for (let i = 0; i < info.layoutCount; i++) {
-    const layoutMap = await queryPeripheral(
+    const { responses: layoutMap } = await queryPeripheral(
       call,
       zmkApp,
       subsystemIndex,
@@ -392,7 +404,7 @@ async function fetchPeripheralTopology(
 
   const devices: KscanDevice[] = [];
   for (let i = 0; i < info.deviceCount; i++) {
-    const devMap = await queryPeripheral(
+    const { responses: devMap } = await queryPeripheral(
       call,
       zmkApp,
       subsystemIndex,
@@ -447,7 +459,7 @@ async function fetchPeripheralPositionMap(
   const cells: (number | null)[] = [];
   let offset = 0;
   for (let page = 0; page < MAX_PAGES; page++) {
-    const map = await queryPeripheral(
+    const { responses: map } = await queryPeripheral(
       call,
       zmkApp,
       subsystemIndex,
@@ -477,7 +489,7 @@ async function fetchPeripheralGpioPinsOfKind(
   const pins: GpioPin[] = [];
   let offset = 0;
   for (let page = 0; page < MAX_PAGES; page++) {
-    const map = await queryPeripheral(
+    const { responses: map } = await queryPeripheral(
       call,
       zmkApp,
       subsystemIndex,
@@ -613,6 +625,9 @@ export function useKscanDiagnostics(): UseKscanDiagnosticsReturn {
   const [peripheralTopologyErrors, setPeripheralTopologyErrors] = useState<
     Map<number, string>
   >(() => new Map());
+  const [peripheralDiscoveryError, setPeripheralDiscoveryError] = useState<
+    string | null
+  >(null);
 
   const subsystemIndex = subsystem?.index;
 
@@ -621,17 +636,28 @@ export function useKscanDiagnostics(): UseKscanDiagnosticsReturn {
     setIsLoadingPeripheralTopologies(true);
     setPeripheralTopologies(new Map());
     setPeripheralTopologyErrors(new Map());
+    setPeripheralDiscoveryError(null);
 
     // Discovery: send GetInfo to all peripherals, collect responses within timeout.
     let discoveredSources: number[];
     try {
-      const infoMap = await queryPeripheral(
+      const { responses: infoMap, supported } = await queryPeripheral(
         call,
         zmkApp,
         subsystemIndex,
         Request.create({ getInfo: {} }),
       );
+      if (!supported) {
+        // Firmware doesn't support QueryPeripheral — silently skip.
+        setIsLoadingPeripheralTopologies(false);
+        return;
+      }
       discoveredSources = [...infoMap.keys()];
+      if (discoveredSources.length === 0) {
+        setPeripheralDiscoveryError(
+          "No peripheral responded within the discovery timeout.",
+        );
+      }
     } catch {
       setIsLoadingPeripheralTopologies(false);
       return;
@@ -672,6 +698,7 @@ export function useKscanDiagnostics(): UseKscanDiagnosticsReturn {
     peripheralTopologies,
     isLoadingPeripheralTopologies,
     peripheralTopologyErrors,
+    peripheralDiscoveryError,
     loadPeripheralTopologies,
   };
 }

--- a/src/hooks/useKscanDiagnostics.ts
+++ b/src/hooks/useKscanDiagnostics.ts
@@ -1,8 +1,11 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useContext, useEffect, useState } from "react";
+import { ZMKAppContext } from "@cormoran/zmk-studio-react-hook";
 import { useCustomSubsystem } from "./useCustomSubsystem";
 import type { UseCustomSubsystemTypedReturn } from "@cormoran/zmk-studio-react-hook";
+import type { CustomNotification } from "@zmkfirmware/zmk-studio-ts-client/custom";
 import {
   GpioLineKind,
+  PeripheralEvent,
   Request,
   Response,
   type Device,
@@ -25,6 +28,21 @@ type Caller = UseCustomSubsystemTypedReturn<Request, Response>["call"];
 // Safety valve against a misbehaving firmware paginating forever.
 const MAX_PAGES = 2000;
 
+// After QueryPeripheral returns Ok, wait this long for PeripheralEvent
+// notifications before giving up on additional peripheral responses.
+const PERIPHERAL_DISCOVERY_TIMEOUT_MS = 3000;
+
+// When fetching topology for a known source, stop waiting once that source's
+// response arrives (or after this fallback timeout).
+const PERIPHERAL_RESPONSE_TIMEOUT_MS = 3000;
+
+// Monotonic counter for QueryPeripheral req_id — correlates PeripheralEvent
+// notifications to the request that triggered them.
+let _nextPeripheralReqId = 1;
+function nextPeripheralReqId(): number {
+  return _nextPeripheralReqId++;
+}
+
 export interface UseKscanDiagnosticsReturn {
   isAvailable: boolean;
   info: Info | null;
@@ -42,6 +60,13 @@ export interface UseKscanDiagnosticsReturn {
   isLoadingTopology: boolean;
   topologyError: string | null;
   loadTopology: () => Promise<void>;
+  /** Topology for each split peripheral (source 1, 2, …). Keyed by source
+   * index. Populated by `loadPeripheralTopologies()`. */
+  peripheralTopologies: Map<number, Topology>;
+  isLoadingPeripheralTopologies: boolean;
+  peripheralTopologyErrors: Map<number, string>;
+  /** Discover peripherals and fetch their topologies via QueryPeripheral. */
+  loadPeripheralTopologies: () => Promise<void>;
 }
 
 async function callRpc(call: Caller, request: Request): Promise<Response> {
@@ -233,7 +258,269 @@ async function fetchTopology(call: Caller): Promise<Topology> {
   };
 }
 
+type ZmkApp = ReturnType<typeof useContext<typeof ZMKAppContext>>;
+
+/**
+ * Send a QueryPeripheral request wrapping `innerRequest` and collect
+ * PeripheralEvent notification responses. When `filterSource` is provided the
+ * promise resolves as soon as that source's response arrives; otherwise it
+ * waits for `timeout` ms after the RPC returns Ok, collecting all responses.
+ */
+async function queryPeripheral(
+  call: Caller,
+  zmkApp: ZmkApp,
+  subsystemIndex: number,
+  innerRequest: Request,
+  filterSource?: number,
+  timeout: number = PERIPHERAL_DISCOVERY_TIMEOUT_MS,
+): Promise<Map<number, Response>> {
+  const reqId = nextPeripheralReqId();
+  const responses = new Map<number, Response>();
+
+  // Resolves as soon as filterSource's response arrives (used by Promise.race
+  // below). In discovery mode (filterSource undefined) it never resolves and
+  // the timeout side of the race always wins.
+  let resolveTarget!: () => void;
+  const targetArrived = new Promise<void>((r) => {
+    resolveTarget = r;
+  });
+
+  const unsubscribe = zmkApp!.onNotification({
+    type: "custom",
+    subsystemIndex,
+    callback: (customNotification: CustomNotification) => {
+      try {
+        const event = PeripheralEvent.decode(customNotification.payload);
+        if (event.reqId !== reqId) return;
+        const innerResponse = Response.decode(event.payload);
+        responses.set(event.source, innerResponse);
+        if (filterSource !== undefined && event.source === filterSource) {
+          resolveTarget();
+        }
+      } catch {
+        // ignore decode errors from unrelated notifications
+      }
+    },
+  });
+
+  try {
+    const result = await call(
+      Request.create({
+        queryPeripheral: {
+          reqId,
+          payload: Request.encode(innerRequest).finish(),
+        },
+      }),
+    );
+
+    if (result && !result.error) {
+      await Promise.race([
+        targetArrived,
+        new Promise<void>((r) => setTimeout(r, timeout)),
+      ]);
+    }
+  } finally {
+    unsubscribe();
+  }
+
+  return responses;
+}
+
+/**
+ * Fetch full topology for one split peripheral by relaying each inner request
+ * via QueryPeripheral and awaiting the matching PeripheralEvent notification.
+ */
+async function fetchPeripheralTopology(
+  call: Caller,
+  zmkApp: ZmkApp,
+  subsystemIndex: number,
+  source: number,
+): Promise<Topology> {
+  const infoMap = await queryPeripheral(
+    call,
+    zmkApp,
+    subsystemIndex,
+    Request.create({ getInfo: {} }),
+    source,
+    PERIPHERAL_RESPONSE_TIMEOUT_MS,
+  );
+  const infoResp = infoMap.get(source);
+  if (!infoResp?.info) {
+    throw new Error(`No response from peripheral ${source}`);
+  }
+  const info = infoResp.info;
+
+  const layouts: KscanLayout[] = [];
+  for (let i = 0; i < info.layoutCount; i++) {
+    const layoutMap = await queryPeripheral(
+      call,
+      zmkApp,
+      subsystemIndex,
+      Request.create({ getLayout: { layoutIndex: i } }),
+      source,
+      PERIPHERAL_RESPONSE_TIMEOUT_MS,
+    );
+    const layoutResp = layoutMap.get(source)?.layout;
+    if (!layoutResp)
+      throw new Error(`No Layout[${i}] from peripheral ${source}`);
+
+    const posMap = await fetchPeripheralPositionMap(
+      call,
+      zmkApp,
+      subsystemIndex,
+      source,
+      i,
+    );
+    layouts.push({
+      layoutIndex: layoutResp.layoutIndex,
+      displayName: layoutResp.displayName,
+      rows: layoutResp.rows,
+      columns: layoutResp.columns,
+      keyCount: layoutResp.keyCount,
+      deviceIndices: layoutResp.deviceIndices.map((d) => ({
+        leafIndex: d.leafIndex,
+        rowOffset: d.rowOffset,
+        colOffset: d.colOffset,
+      })),
+      positionMap: posMap,
+    });
+  }
+
+  const devices: KscanDevice[] = [];
+  for (let i = 0; i < info.deviceCount; i++) {
+    const devMap = await queryPeripheral(
+      call,
+      zmkApp,
+      subsystemIndex,
+      Request.create({ getDevice: { deviceIndex: i } }),
+      source,
+      PERIPHERAL_RESPONSE_TIMEOUT_MS,
+    );
+    const d = devMap.get(source)?.device;
+    if (!d) throw new Error(`No Device[${i}] from peripheral ${source}`);
+    const gpioLinesByKind = await fetchPeripheralGpioLinesByKind(
+      call,
+      zmkApp,
+      subsystemIndex,
+      source,
+      i,
+    );
+    devices.push({
+      deviceIndex: d.deviceIndex,
+      nodeName: d.nodeName,
+      type: d.type,
+      rows: d.rows,
+      columns: d.columns,
+      inputs: d.inputs,
+      debouncePressMs: d.debouncePressMs,
+      debounceReleaseMs: d.debounceReleaseMs,
+      debounceScanPeriodMs: d.debounceScanPeriodMs,
+      pollPeriodMs: d.pollPeriodMs,
+      diodeRow2col: d.diodeRow2col,
+      toggleMode: d.toggleMode,
+      gpioLinesByKind,
+    });
+  }
+
+  return {
+    protoVersion: info.protoVersion,
+    selectedLayout: info.selectedLayout,
+    statsEnabled: info.statsEnabled,
+    maxPositions: info.maxPositions,
+    uptimeMs: info.uptimeMs,
+    devices,
+    layouts,
+  };
+}
+
+async function fetchPeripheralPositionMap(
+  call: Caller,
+  zmkApp: ZmkApp,
+  subsystemIndex: number,
+  source: number,
+  layoutIndex: number,
+): Promise<(number | null)[]> {
+  const cells: (number | null)[] = [];
+  let offset = 0;
+  for (let page = 0; page < MAX_PAGES; page++) {
+    const map = await queryPeripheral(
+      call,
+      zmkApp,
+      subsystemIndex,
+      Request.create({ getPositionMap: { layoutIndex, offset } }),
+      source,
+      PERIPHERAL_RESPONSE_TIMEOUT_MS,
+    );
+    const chunk = map.get(source)?.positionMap;
+    if (!chunk) throw new Error(`No PositionMap from peripheral ${source}`);
+    for (const cell of chunk.cells) {
+      cells.push(cell === 0 ? null : cell - 1);
+    }
+    offset = chunk.offset + chunk.cells.length;
+    if (chunk.cells.length === 0 || offset >= chunk.total) break;
+  }
+  return cells;
+}
+
+async function fetchPeripheralGpioPinsOfKind(
+  call: Caller,
+  zmkApp: ZmkApp,
+  subsystemIndex: number,
+  source: number,
+  deviceIndex: number,
+  kind: GpioLineKind,
+): Promise<GpioPin[]> {
+  const pins: GpioPin[] = [];
+  let offset = 0;
+  for (let page = 0; page < MAX_PAGES; page++) {
+    const map = await queryPeripheral(
+      call,
+      zmkApp,
+      subsystemIndex,
+      Request.create({ getGpioPins: { deviceIndex, kind, offset } }),
+      source,
+      PERIPHERAL_RESPONSE_TIMEOUT_MS,
+    );
+    const chunk = map.get(source)?.gpioPins;
+    if (!chunk) throw new Error(`No GpioPins from peripheral ${source}`);
+    pins.push(...chunk.pins);
+    offset = chunk.offset + chunk.pins.length;
+    if (chunk.pins.length === 0 || offset >= chunk.total) break;
+  }
+  return pins;
+}
+
+async function fetchPeripheralGpioLinesByKind(
+  call: Caller,
+  zmkApp: ZmkApp,
+  subsystemIndex: number,
+  source: number,
+  deviceIndex: number,
+): Promise<Record<GpioLineKind, GpioPin[]>> {
+  const kinds: GpioLineKind[] = [
+    GpioLineKind.ROW,
+    GpioLineKind.COL,
+    GpioLineKind.INPUT,
+    GpioLineKind.OUTPUT,
+    GpioLineKind.CHARLIE,
+  ];
+  const result = {} as Record<GpioLineKind, GpioPin[]>;
+  result[GpioLineKind.KIND_UNKNOWN] = [];
+  for (const kind of kinds) {
+    result[kind] = await fetchPeripheralGpioPinsOfKind(
+      call,
+      zmkApp,
+      subsystemIndex,
+      source,
+      deviceIndex,
+      kind,
+    );
+  }
+  return result;
+}
+
 export function useKscanDiagnostics(): UseKscanDiagnosticsReturn {
+  const zmkApp = useContext(ZMKAppContext);
   const { subsystem, ready, call } = useCustomSubsystem(
     KSCAN_DIAGNOSTICS_SUBSYSTEM_IDENTIFIER,
     CODEC,
@@ -314,6 +601,57 @@ export function useKscanDiagnostics(): UseKscanDiagnosticsReturn {
     }
   }, [ready, call]);
 
+  const [peripheralTopologies, setPeripheralTopologies] = useState<
+    Map<number, Topology>
+  >(() => new Map());
+  const [isLoadingPeripheralTopologies, setIsLoadingPeripheralTopologies] =
+    useState(false);
+  const [peripheralTopologyErrors, setPeripheralTopologyErrors] = useState<
+    Map<number, string>
+  >(() => new Map());
+
+  const subsystemIndex = subsystem?.index;
+
+  const loadPeripheralTopologies = useCallback(async () => {
+    if (!ready || !zmkApp || subsystemIndex === undefined) return;
+    setIsLoadingPeripheralTopologies(true);
+    setPeripheralTopologies(new Map());
+    setPeripheralTopologyErrors(new Map());
+
+    // Discovery: send GetInfo to all peripherals, collect responses within timeout.
+    let discoveredSources: number[];
+    try {
+      const infoMap = await queryPeripheral(
+        call,
+        zmkApp,
+        subsystemIndex,
+        Request.create({ getInfo: {} }),
+      );
+      discoveredSources = [...infoMap.keys()];
+    } catch {
+      setIsLoadingPeripheralTopologies(false);
+      return;
+    }
+
+    // Fetch topology for each discovered peripheral.
+    for (const source of discoveredSources) {
+      try {
+        const t = await fetchPeripheralTopology(
+          call,
+          zmkApp,
+          subsystemIndex,
+          source,
+        );
+        setPeripheralTopologies((prev) => new Map(prev).set(source, t));
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : "Unknown error";
+        setPeripheralTopologyErrors((prev) => new Map(prev).set(source, msg));
+      }
+    }
+
+    setIsLoadingPeripheralTopologies(false);
+  }, [ready, zmkApp, subsystemIndex, call]);
+
   return {
     isAvailable: subsystem !== null,
     info,
@@ -327,5 +665,9 @@ export function useKscanDiagnostics(): UseKscanDiagnosticsReturn {
     isLoadingTopology,
     topologyError,
     loadTopology,
+    peripheralTopologies,
+    isLoadingPeripheralTopologies,
+    peripheralTopologyErrors,
+    loadPeripheralTopologies,
   };
 }

--- a/src/lib/transport/__tests__/demo-kscan-diagnostics.test.ts
+++ b/src/lib/transport/__tests__/demo-kscan-diagnostics.test.ts
@@ -5,7 +5,9 @@
 import { KscanDiagnosticsHandler } from "../demo-kscan-diagnostics";
 import {
   GpioLineKind,
+  PeripheralEvent,
   Request,
+  Response,
 } from "../../../proto/cormoran/kscan_diagnostics/kscan_diagnostics";
 
 describe("KscanDiagnosticsHandler", () => {
@@ -201,6 +203,55 @@ describe("KscanDiagnosticsHandler", () => {
     it("returns an error for an empty request", () => {
       const response = handler.process(Request.create({}));
       expect(response.error).toBeDefined();
+    });
+  });
+
+  describe("queryPeripheral", () => {
+    it("returns ok and delivers a PeripheralEvent notification", async () => {
+      const notifications: Uint8Array[] = [];
+      handler.notify((data) => notifications.push(data));
+
+      const innerRequest = Request.create({ getInfo: {} });
+      const response = handler.process(
+        Request.create({
+          queryPeripheral: {
+            reqId: 42,
+            payload: Request.encode(innerRequest).finish(),
+          },
+        }),
+      );
+
+      expect(response.ok).toBeDefined();
+
+      // Wait for the async notification (50ms delay in the handler).
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      expect(notifications).toHaveLength(1);
+
+      const event = PeripheralEvent.decode(notifications[0]);
+      expect(event.source).toBe(1);
+      expect(event.reqId).toBe(42);
+
+      const innerResponse = Response.decode(event.payload);
+      expect(innerResponse.info).toBeDefined();
+      expect(innerResponse.info?.deviceCount).toBe(1);
+    });
+
+    it("echoes req_id in the PeripheralEvent", async () => {
+      const notifications: Uint8Array[] = [];
+      handler.notify((data) => notifications.push(data));
+
+      handler.process(
+        Request.create({
+          queryPeripheral: {
+            reqId: 7,
+            payload: Request.encode(Request.create({ getInfo: {} })).finish(),
+          },
+        }),
+      );
+
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      const event = PeripheralEvent.decode(notifications[0]);
+      expect(event.reqId).toBe(7);
     });
   });
 });

--- a/src/lib/transport/demo-kscan-diagnostics.ts
+++ b/src/lib/transport/demo-kscan-diagnostics.ts
@@ -11,12 +11,17 @@
  * the interactive keyboard preview also exercises the "no wiring info"
  * path. Row lines live on "gpio0" pins 4..8, column lines on "gpio1" pins
  * 0..11.
+ *
+ * A simulated split peripheral (source=1) is also provided: a 4x6 DIRECT
+ * half that answers QueryPeripheral requests via a notification. The
+ * peripheral's wiring uses "gpio2" for its 24 direct input pins.
  */
 
 import {
   GpioLineKind,
-  type Request,
-  type Response,
+  PeripheralEvent,
+  Request,
+  Response,
   type GpioPin,
   type PositionStats,
   KscanDriverType,
@@ -44,6 +49,16 @@ const ROW_PORT = "gpio0";
 const ROW_PIN_BASE = 4;
 const COL_PORT = "gpio1";
 const COL_PIN_BASE = 0;
+
+// Simulated peripheral: a 4x6 matrix for the right half.
+const PERIPH_ROWS = 4;
+const PERIPH_COLS = 6;
+const PERIPH_POSITION_COUNT = PERIPH_ROWS * PERIPH_COLS;
+const PERIPH_PIN_PORT = "gpio2";
+const PERIPH_ROW_PIN_BASE = 0;
+const PERIPH_COL_PORT = "gpio3";
+const PERIPH_COL_PIN_BASE = 0;
+const PERIPH_SOURCE = 1;
 
 function buildPositionMap(): number[] {
   // Row-major over ROWS x COLUMNS; cell value is `position + 1`, or 0 for
@@ -118,12 +133,184 @@ function paginate<T>(
   };
 }
 
+// ---- Peripheral simulation (source=1) ----
+
+function buildPeriphPositionMap(): number[] {
+  const cells: number[] = [];
+  for (let i = 0; i < PERIPH_POSITION_COUNT; i++) {
+    cells.push(i + 1);
+  }
+  return cells;
+}
+
+function buildPeriphRowPins(): GpioPin[] {
+  return Array.from({ length: PERIPH_ROWS }, (_, i) => ({
+    index: i,
+    port: PERIPH_PIN_PORT,
+    pin: PERIPH_ROW_PIN_BASE + i,
+    activeLow: false,
+    dtFlags: 0,
+  }));
+}
+
+function buildPeriphColPins(): GpioPin[] {
+  return Array.from({ length: PERIPH_COLS }, (_, i) => ({
+    index: i,
+    port: PERIPH_COL_PORT,
+    pin: PERIPH_COL_PIN_BASE + i,
+    activeLow: false,
+    dtFlags: 0,
+  }));
+}
+
+function generatePeriphStats(): PositionStats[] {
+  return Array.from({ length: PERIPH_POSITION_COUNT }, (_, position) => {
+    const presses = 20 + ((position * 11) % 40);
+    return {
+      position,
+      presses,
+      releases: presses,
+      minPressDurationMs: 30 + (position % 8),
+      minRepressGapMs: 150 + (position % 60),
+      repressLt5: 0,
+      repressLt10: 0,
+      repressLt20: 0,
+      repressLt50: 0,
+      lastSource: PERIPH_SOURCE,
+    };
+  });
+}
+
+class PeripheralKscanHandler {
+  private startedAtMs = Date.now();
+  private stats: PositionStats[] = generatePeriphStats();
+  private positionMap: number[] = buildPeriphPositionMap();
+  private rowPins: GpioPin[] = buildPeriphRowPins();
+  private colPins: GpioPin[] = buildPeriphColPins();
+
+  process(request: Request): Response {
+    if (request.getInfo !== undefined) {
+      return {
+        info: {
+          protoVersion: 1,
+          layoutCount: 1,
+          selectedLayout: 0,
+          deviceCount: 1,
+          statsEnabled: true,
+          maxPositions: PERIPH_POSITION_COUNT,
+          uptimeMs: Date.now() - this.startedAtMs,
+        },
+      };
+    }
+
+    if (request.getLayout !== undefined) {
+      const { layoutIndex } = request.getLayout;
+      if (layoutIndex !== 0) {
+        return { error: { message: "Unknown layout index" } };
+      }
+      return {
+        layout: {
+          layoutIndex: 0,
+          displayName: "Right half",
+          rows: PERIPH_ROWS,
+          columns: PERIPH_COLS,
+          keyCount: PERIPH_POSITION_COUNT,
+          deviceIndices: [{ leafIndex: 0, rowOffset: 0, colOffset: 0 }],
+        },
+      };
+    }
+
+    if (request.getPositionMap !== undefined) {
+      const { layoutIndex, offset } = request.getPositionMap;
+      if (layoutIndex !== 0) {
+        return { error: { message: "Unknown layout index" } };
+      }
+      const { total, page } = paginate(
+        this.positionMap,
+        offset,
+        POSITION_MAP_PAGE_SIZE,
+      );
+      return { positionMap: { total, offset, cells: page } };
+    }
+
+    if (request.getDevice !== undefined) {
+      const { deviceIndex } = request.getDevice;
+      if (deviceIndex !== 0) {
+        return { error: { message: "Unknown device index" } };
+      }
+      return {
+        device: {
+          deviceIndex: 0,
+          nodeName: "kscan_right",
+          type: KscanDriverType.MATRIX,
+          rows: PERIPH_ROWS,
+          columns: PERIPH_COLS,
+          inputs: 0,
+          debouncePressMs: 5,
+          debounceReleaseMs: 5,
+          debounceScanPeriodMs: 1,
+          pollPeriodMs: 0,
+          diodeRow2col: true,
+          toggleMode: false,
+        },
+      };
+    }
+
+    if (request.getGpioPins !== undefined) {
+      const { deviceIndex, kind, offset } = request.getGpioPins;
+      if (deviceIndex !== 0) {
+        return { error: { message: "Unknown device index" } };
+      }
+      let lines: GpioPin[];
+      switch (kind) {
+        case GpioLineKind.ROW:
+          lines = this.rowPins;
+          break;
+        case GpioLineKind.COL:
+          lines = this.colPins;
+          break;
+        default:
+          lines = [];
+      }
+      const { total, page } = paginate(lines, offset, GPIO_PAGE_SIZE);
+      return { gpioPins: { total, offset, pins: page } };
+    }
+
+    if (request.getStats !== undefined) {
+      const { offset } = request.getStats;
+      const { total, page } = paginate(this.stats, offset, STATS_PAGE_SIZE);
+      return { stats: { total, offset, entries: page } };
+    }
+
+    if (request.resetStats !== undefined) {
+      this.stats = this.stats.map((entry) => ({
+        ...entry,
+        presses: 0,
+        releases: 0,
+        minPressDurationMs: 0,
+        minRepressGapMs: 0,
+        repressLt5: 0,
+        repressLt10: 0,
+        repressLt20: 0,
+        repressLt50: 0,
+      }));
+      return { ok: {} };
+    }
+
+    return { error: { message: "Not implemented" } };
+  }
+}
+
+// ---- Main handler ----
+
 export class KscanDiagnosticsHandler {
   private startedAtMs = Date.now();
   private stats: PositionStats[] = generateStats();
   private positionMap: number[] = buildPositionMap();
   private rowPins: GpioPin[] = buildRowPins();
   private colPins: GpioPin[] = buildColPins();
+  private peripheralHandler = new PeripheralKscanHandler();
+  private notifyCallbacks: ((data: Uint8Array) => void)[] = [];
 
   process(request: Request): Response {
     if (request.getInfo !== undefined) {
@@ -234,6 +421,38 @@ export class KscanDiagnosticsHandler {
       return { ok: {} };
     }
 
+    if (request.queryPeripheral !== undefined) {
+      const { reqId, payload } = request.queryPeripheral;
+      // Schedule the simulated peripheral notification asynchronously.
+      setTimeout(() => {
+        this.sendPeripheralEvent(reqId, payload);
+      }, 50);
+      return { ok: {} };
+    }
+
     return { error: { message: "Not implemented" } };
+  }
+
+  private sendPeripheralEvent(reqId: number, encodedRequest: Uint8Array) {
+    try {
+      const innerRequest = Request.decode(encodedRequest);
+      const innerResponse = this.peripheralHandler.process(innerRequest);
+      const eventPayload = PeripheralEvent.encode(
+        PeripheralEvent.create({
+          source: PERIPH_SOURCE,
+          reqId,
+          payload: Response.encode(innerResponse).finish(),
+        }),
+      ).finish();
+      for (const cb of this.notifyCallbacks) {
+        cb(eventPayload);
+      }
+    } catch {
+      // ignore simulation errors
+    }
+  }
+
+  notify(callback: (data: Uint8Array) => void) {
+    this.notifyCallbacks.push(callback);
   }
 }

--- a/src/lib/transport/demo.ts
+++ b/src/lib/transport/demo.ts
@@ -949,6 +949,21 @@ class Keyboard {
         }).finish(),
       );
     });
+
+    this.kscanDiagnosticsHandler.notify((payload: Uint8Array) => {
+      callback(
+        Response.encode({
+          notification: {
+            custom: {
+              customNotification: {
+                subsystemIndex: this.KSCAN_DIAGNOSTICS_SUBSYSTEM_INDEX,
+                payload: payload,
+              },
+            },
+          },
+        }).finish(),
+      );
+    });
   }
 
   /** Stop any demo-side background activity (e.g. the pmw3610 frame

--- a/src/proto/cormoran/kscan_diagnostics/kscan_diagnostics.ts
+++ b/src/proto/cormoran/kscan_diagnostics/kscan_diagnostics.ts
@@ -172,6 +172,31 @@ export interface ResetStats {
 export interface Ok {
 }
 
+/**
+ * Relay a query to the split peripheral half/halves. `payload` is an encoded
+ * Request that the peripheral runs against its own topology/stats tables; the
+ * result comes back asynchronously as a PeripheralEvent notification, not in
+ * this call's Response (which is just an Ok, or Error if this build is not a
+ * split central). The query is broadcast to all connected peripherals and each
+ * replies with its `source` stamped; the client correlates by (source, req_id).
+ */
+export interface QueryPeripheral {
+  reqId: number;
+  payload: Uint8Array;
+}
+
+/**
+ * Firmware-initiated notification carrying one peripheral's reply to a
+ * QueryPeripheral. `source` is the peripheral index (1-based; central is 0),
+ * `req_id` echoes the triggering QueryPeripheral, and `payload` is an encoded
+ * Response produced by that peripheral's query dispatch.
+ */
+export interface PeripheralEvent {
+  source: number;
+  reqId: number;
+  payload: Uint8Array;
+}
+
 export interface Request {
   getInfo?: GetInfo | undefined;
   getLayout?: GetLayout | undefined;
@@ -180,6 +205,7 @@ export interface Request {
   getPositionMap?: GetPositionMap | undefined;
   getStats?: GetStats | undefined;
   resetStats?: ResetStats | undefined;
+  queryPeripheral?: QueryPeripheral | undefined;
 }
 
 export interface Response {
@@ -1581,6 +1607,134 @@ export const Ok: MessageFns<Ok> = {
   },
 };
 
+function createBaseQueryPeripheral(): QueryPeripheral {
+  return { reqId: 0, payload: new Uint8Array(0) };
+}
+
+export const QueryPeripheral: MessageFns<QueryPeripheral> = {
+  encode(message: QueryPeripheral, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    if (message.reqId !== 0) {
+      writer.uint32(8).uint32(message.reqId);
+    }
+    if (message.payload.length !== 0) {
+      writer.uint32(18).bytes(message.payload);
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): QueryPeripheral {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseQueryPeripheral();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 8) {
+            break;
+          }
+
+          message.reqId = reader.uint32();
+          continue;
+        }
+        case 2: {
+          if (tag !== 18) {
+            break;
+          }
+
+          message.payload = reader.bytes();
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  create(base?: DeepPartial<QueryPeripheral>): QueryPeripheral {
+    return QueryPeripheral.fromPartial(base ?? {});
+  },
+  fromPartial(object: DeepPartial<QueryPeripheral>): QueryPeripheral {
+    const message = createBaseQueryPeripheral();
+    message.reqId = object.reqId ?? 0;
+    message.payload = object.payload ?? new Uint8Array(0);
+    return message;
+  },
+};
+
+function createBasePeripheralEvent(): PeripheralEvent {
+  return { source: 0, reqId: 0, payload: new Uint8Array(0) };
+}
+
+export const PeripheralEvent: MessageFns<PeripheralEvent> = {
+  encode(message: PeripheralEvent, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    if (message.source !== 0) {
+      writer.uint32(8).uint32(message.source);
+    }
+    if (message.reqId !== 0) {
+      writer.uint32(16).uint32(message.reqId);
+    }
+    if (message.payload.length !== 0) {
+      writer.uint32(26).bytes(message.payload);
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): PeripheralEvent {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBasePeripheralEvent();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 8) {
+            break;
+          }
+
+          message.source = reader.uint32();
+          continue;
+        }
+        case 2: {
+          if (tag !== 16) {
+            break;
+          }
+
+          message.reqId = reader.uint32();
+          continue;
+        }
+        case 3: {
+          if (tag !== 26) {
+            break;
+          }
+
+          message.payload = reader.bytes();
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  create(base?: DeepPartial<PeripheralEvent>): PeripheralEvent {
+    return PeripheralEvent.fromPartial(base ?? {});
+  },
+  fromPartial(object: DeepPartial<PeripheralEvent>): PeripheralEvent {
+    const message = createBasePeripheralEvent();
+    message.source = object.source ?? 0;
+    message.reqId = object.reqId ?? 0;
+    message.payload = object.payload ?? new Uint8Array(0);
+    return message;
+  },
+};
+
 function createBaseRequest(): Request {
   return {
     getInfo: undefined,
@@ -1590,6 +1744,7 @@ function createBaseRequest(): Request {
     getPositionMap: undefined,
     getStats: undefined,
     resetStats: undefined,
+    queryPeripheral: undefined,
   };
 }
 
@@ -1615,6 +1770,9 @@ export const Request: MessageFns<Request> = {
     }
     if (message.resetStats !== undefined) {
       ResetStats.encode(message.resetStats, writer.uint32(58).fork()).join();
+    }
+    if (message.queryPeripheral !== undefined) {
+      QueryPeripheral.encode(message.queryPeripheral, writer.uint32(66).fork()).join();
     }
     return writer;
   },
@@ -1682,6 +1840,14 @@ export const Request: MessageFns<Request> = {
           message.resetStats = ResetStats.decode(reader, reader.uint32());
           continue;
         }
+        case 8: {
+          if (tag !== 66) {
+            break;
+          }
+
+          message.queryPeripheral = QueryPeripheral.decode(reader, reader.uint32());
+          continue;
+        }
       }
       if ((tag & 7) === 4 || tag === 0) {
         break;
@@ -1716,6 +1882,9 @@ export const Request: MessageFns<Request> = {
       : undefined;
     message.resetStats = (object.resetStats !== undefined && object.resetStats !== null)
       ? ResetStats.fromPartial(object.resetStats)
+      : undefined;
+    message.queryPeripheral = (object.queryPeripheral !== undefined && object.queryPeripheral !== null)
+      ? QueryPeripheral.fromPartial(object.queryPeripheral)
       : undefined;
     return message;
   },


### PR DESCRIPTION
## Summary

Implements the web UI side of [zmk-feature-kscan-diagnostics PR #2](https://github.com/cormoran/zmk-feature-kscan-diagnostics/pull/2) — peripheral kscan diagnostics over the split event-relay.

- **Proto**: add `QueryPeripheral` (request) and `PeripheralEvent` (notification) messages; regenerate TS bindings
- **Hook** (`useKscanDiagnostics`): `loadPeripheralTopologies()` discovers peripheral sources by broadcasting `GetInfo` via `QueryPeripheral`, then relays the full paginated topology fetch (GetInfo/GetLayout/GetDevice/GetGpioPins/GetPositionMap) for each responding peripheral, collecting `PeripheralEvent` notifications per page
- **Demo transport**: `KscanDiagnosticsHandler` handles `queryPeripheral` (returns `Ok`, fires a `PeripheralEvent` notification 50ms later for a simulated 4×6 right-half peripheral at source=1); `demo.ts` wires the notify pipeline
- **UI** (`KscanDiagnosticsSection`): calls `loadPeripheralTopologies()` on expand, shows a loading indicator, and renders each peripheral's wiring as a `KscanKeyboardView` labeled "Peripheral N"

## Test plan

- [ ] TypeScript compiles clean (`npx tsc --noEmit`)
- [ ] `demo-kscan-diagnostics` tests all pass (16 tests, including 2 new `queryPeripheral` tests that verify `Ok` return and notification delivery)
- [ ] Open the app in demo mode → expand "Key Switches" → confirm "Peripheral 1" wiring section appears alongside the central view
- [ ] On real split hardware with zmk-feature-kscan-diagnostics PR #2 flashed: expand "Key Switches" → peripheral wiring loads within ~3s per page

🤖 Generated with [Claude Code](https://claude.com/claude-code)