### PR TITLE
feat(troubleshooting): Stack Usage section with periodic polling (zmk-module-devtool)

### DIFF
--- a/proto/cormoran/devtool/devtool.proto
+++ b/proto/cormoran/devtool/devtool.proto
@@ -203,6 +203,27 @@ message LogStreamNotification {
     uint32 dropped_count = 2;
 }
 
+// --- Stack usage (per-thread stack high-water inspection). Requires firmware
+// built with CONFIG_ZMK_DEVTOOL_STACK_USAGE (from zmk-module-devtool PR #9). ---
+
+message StackInfo {
+    string name = 1;
+    uint32 size = 2;
+    // Peak bytes used since boot (high-water mark). 0 if the running kernel
+    // could not measure it. Free headroom = size - used.
+    uint32 used = 3;
+}
+
+// Cursor-based pagination: start with cursor 0, pass back next_cursor until
+// it comes back 0. Same shape as get_logs / get_events in the firmware.
+message GetStackUsageRequest { uint32 cursor = 1; }
+
+message GetStackUsageResponse {
+    repeated StackInfo stacks = 1;
+    uint32 next_cursor = 2;
+    uint32 total = 3;
+}
+
 message Request {
     oneof request_type {
         SetStudioLockStateRequest set_studio_lock_state = 1;
@@ -221,6 +242,7 @@ message Request {
         ClearLogsRequest clear_logs = 14;
         SetLogCaptureFilterRequest set_log_capture_filter = 15;
         SetLogStreamingRequest set_log_streaming = 16;
+        GetStackUsageRequest get_stack_usage = 17;
     }
 }
 
@@ -245,6 +267,7 @@ message Response {
         ClearLogsResponse clear_logs = 15;
         SetLogCaptureFilterResponse set_log_capture_filter = 16;
         SetLogStreamingResponse set_log_streaming = 17;
+        GetStackUsageResponse get_stack_usage = 18;
     }
 }
 

--- a/src/components/troubleshooting/DevtoolStackUsageSection.tsx
+++ b/src/components/troubleshooting/DevtoolStackUsageSection.tsx
@@ -1,0 +1,209 @@
+import { IconActivity, IconRefresh } from "@tabler/icons-react";
+import type { StackInfo } from "../../proto/cormoran/devtool/devtool";
+import type { UseDevtoolStackUsageReturn } from "../../hooks/useDevtoolStackUsage";
+import {
+  usageFraction,
+  formatUsagePercent,
+} from "../../hooks/useDevtoolStackUsage";
+import { useLanguage } from "../../hooks/useLanguage";
+import {
+  NotAvailableNotice,
+  SectionCard,
+  SectionError,
+  SectionSummaryBadge,
+} from "./SectionCard";
+
+const MODULE_NAME = "zmk-module-devtool";
+const MODULE_URL = "https://github.com/cormoran/zmk-module-devtool";
+const KCONFIG_NAME = "CONFIG_ZMK_DEVTOOL_STACK_USAGE";
+
+const POLL_INTERVAL_OPTIONS = [
+  { label: "1s", ms: 1000 },
+  { label: "3s", ms: 3000 },
+  { label: "5s", ms: 5000 },
+  { label: "10s", ms: 10000 },
+];
+
+function usageBarColor(fraction: number): string {
+  if (fraction >= 0.9) return "bg-red-500";
+  if (fraction >= 0.8) return "bg-amber-500";
+  if (fraction >= 0.6) return "bg-yellow-400";
+  return "bg-green-500";
+}
+
+function usageTextColor(fraction: number): string {
+  if (fraction >= 0.9) return "text-red-400";
+  if (fraction >= 0.8) return "text-amber-400";
+  return "text-[var(--color-text-secondary)]";
+}
+
+function StackRow({ stack }: { stack: StackInfo }) {
+  const fraction = usageFraction(stack);
+  const pct = formatUsagePercent(stack);
+  const free = Math.max(0, stack.size - stack.used);
+
+  return (
+    <div className="py-2 border-b border-[var(--color-border)] last:border-b-0">
+      <div className="flex items-center justify-between gap-2 mb-1">
+        <span className="font-mono text-xs text-[var(--color-text)] truncate min-w-0">
+          {stack.name}
+        </span>
+        <div className="flex items-center gap-3 shrink-0 text-xs">
+          <span className="text-[var(--color-text-muted)]">
+            {stack.used}
+            <span className="text-[var(--color-text-muted)] opacity-60">
+              /{stack.size}B
+            </span>
+          </span>
+          <span className="text-[var(--color-text-muted)]">
+            free&nbsp;
+            <span className="font-mono">{free}B</span>
+          </span>
+          <span
+            className={`font-mono font-medium w-12 text-right ${usageTextColor(fraction)}`}
+          >
+            {pct}
+          </span>
+        </div>
+      </div>
+      <div className="h-1.5 w-full rounded-full bg-[var(--color-border)] overflow-hidden">
+        <div
+          className={`h-full rounded-full transition-all duration-500 ${usageBarColor(fraction)}`}
+          style={{ width: `${Math.min(100, fraction * 100).toFixed(1)}%` }}
+        />
+      </div>
+    </div>
+  );
+}
+
+function maxUsageFraction(stacks: StackInfo[]): number {
+  return stacks.reduce((m, s) => Math.max(m, usageFraction(s)), 0);
+}
+
+function summaryBadge(stacks: StackInfo[]) {
+  if (stacks.length === 0) return null;
+  const max = maxUsageFraction(stacks);
+  if (max >= 0.9)
+    return <SectionSummaryBadge tone="red">{`≥90% used`}</SectionSummaryBadge>;
+  if (max >= 0.8)
+    return (
+      <SectionSummaryBadge tone="amber">{`≥80% used`}</SectionSummaryBadge>
+    );
+  return (
+    <SectionSummaryBadge tone="ok">{`${stacks.length} threads`}</SectionSummaryBadge>
+  );
+}
+
+export function DevtoolStackUsageSection({
+  stackUsage,
+}: {
+  stackUsage: UseDevtoolStackUsageReturn;
+}) {
+  const { t } = useLanguage();
+  const {
+    isAvailable,
+    stacks,
+    isLoading,
+    error,
+    isPolling,
+    pollIntervalMs,
+    refresh,
+    setPolling,
+    setPollIntervalMs,
+  } = stackUsage;
+
+  return (
+    <SectionCard
+      icon={<IconActivity size={20} className="text-[var(--color-electric)]" />}
+      title={t("Stack Usage")}
+      subtitle={t("Per-thread stack high-water usage (zmk-module-devtool)")}
+      summary={isAvailable ? summaryBadge(stacks) : undefined}
+      actions={
+        isAvailable && (
+          <button
+            onClick={() => void refresh()}
+            disabled={isLoading}
+            className="btn-ghost flex items-center gap-2 text-sm"
+            aria-label={t("Refresh stack usage")}
+          >
+            <IconRefresh
+              size={14}
+              className={isLoading ? "animate-spin" : ""}
+            />
+            {t("Refresh")}
+          </button>
+        )
+      }
+    >
+      {!isAvailable ? (
+        <NotAvailableNotice module={MODULE_NAME} moduleUrl={MODULE_URL} />
+      ) : (
+        <>
+          {/* Polling controls */}
+          <div className="flex flex-wrap items-center gap-3 mb-4">
+            <label className="flex items-center gap-2 cursor-pointer select-none">
+              <input
+                type="checkbox"
+                checked={isPolling}
+                onChange={(e) => setPolling(e.target.checked)}
+                className="w-4 h-4 rounded accent-[var(--color-electric)]"
+              />
+              <span className="text-xs text-[var(--color-text-muted)]">
+                {t("Auto-refresh")}
+              </span>
+            </label>
+            {isPolling && (
+              <div className="flex items-center gap-1">
+                {POLL_INTERVAL_OPTIONS.map(({ label, ms }) => (
+                  <button
+                    key={ms}
+                    onClick={() => setPollIntervalMs(ms)}
+                    className={`px-2 py-0.5 rounded text-xs border transition-colors ${
+                      pollIntervalMs === ms
+                        ? "bg-[var(--color-electric)]/10 border-[var(--color-electric)]/40 text-[var(--color-electric)]"
+                        : "border-[var(--color-border)] text-[var(--color-text-muted)] hover:border-[var(--color-border-hover)]"
+                    }`}
+                  >
+                    {label}
+                  </button>
+                ))}
+              </div>
+            )}
+          </div>
+
+          {/* Kconfig hint */}
+          <p className="text-xs text-[var(--color-text-muted)] mb-4">
+            {t("Requires")}{" "}
+            <code className="font-mono bg-[var(--color-border)] px-1 py-0.5 rounded text-[10px]">
+              {KCONFIG_NAME}
+            </code>{" "}
+            {t("in your firmware. Without it the RPC returns an error below.")}
+          </p>
+
+          {error && <SectionError message={error} />}
+
+          {/* Stack table */}
+          {stacks.length > 0 ? (
+            <div>
+              {stacks.map((s, i) => (
+                <StackRow key={`${s.name}-${i}`} stack={s} />
+              ))}
+              <p className="text-[10px] text-[var(--color-text-muted)] mt-3">
+                {t("{{count}} thread(s) · sorted by usage", {
+                  count: stacks.length,
+                })}
+              </p>
+            </div>
+          ) : (
+            !isLoading &&
+            !error && (
+              <p className="text-sm text-[var(--color-text-muted)]">
+                {t("No stack data yet — press Refresh or enable Auto-refresh.")}
+              </p>
+            )
+          )}
+        </>
+      )}
+    </SectionCard>
+  );
+}

--- a/src/hooks/useDevtoolStackUsage.ts
+++ b/src/hooks/useDevtoolStackUsage.ts
@@ -1,0 +1,113 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useDevtool } from "./useDevtool";
+import { Request, type StackInfo } from "../proto/cormoran/devtool/devtool";
+
+// Safety cap against a misbehaving cursor looping forever.
+const MAX_PAGES = 64;
+
+export interface UseDevtoolStackUsageReturn {
+  isAvailable: boolean;
+  stacks: StackInfo[];
+  isLoading: boolean;
+  error: string | null;
+  isPolling: boolean;
+  pollIntervalMs: number;
+  refresh: () => Promise<void>;
+  setPolling: (enabled: boolean) => void;
+  setPollIntervalMs: (ms: number) => void;
+}
+
+export function useDevtoolStackUsage(): UseDevtoolStackUsageReturn {
+  const { isAvailable, ready, call } = useDevtool();
+  const [stacks, setStacks] = useState<StackInfo[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [isPolling, setIsPolling] = useState(false);
+  const [pollIntervalMs, setPollIntervalMs] = useState(5000);
+
+  // Refs so the interval callback always sees the latest values.
+  const readyRef = useRef(ready);
+  const callRef = useRef(call);
+  useEffect(() => {
+    readyRef.current = ready;
+    callRef.current = call;
+  }, [ready, call]);
+
+  const fetchAllPages = useCallback(async (): Promise<StackInfo[]> => {
+    const collected: StackInfo[] = [];
+    let cursor = 0;
+    for (let page = 0; page < MAX_PAGES; page++) {
+      const resp = await callRef.current(
+        Request.create({ getStackUsage: { cursor } }),
+      );
+      if (!resp) throw new Error("No response from device");
+      if (!resp.getStackUsage) {
+        throw new Error("Unexpected response type");
+      }
+      const usage = resp.getStackUsage;
+      collected.push(...usage.stacks);
+      if (usage.nextCursor === 0) break;
+      cursor = usage.nextCursor;
+    }
+    return collected.sort((a, b) => usageFraction(b) - usageFraction(a));
+  }, []);
+
+  const refresh = useCallback(async () => {
+    if (!readyRef.current) return;
+    setIsLoading(true);
+    setError(null);
+    try {
+      const result = await fetchAllPages();
+      setStacks(result);
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : "Failed to fetch stack usage",
+      );
+    } finally {
+      setIsLoading(false);
+    }
+  }, [fetchAllPages]);
+
+  // Auto-fetch once when the subsystem first becomes available.
+  useEffect(() => {
+    if (ready) {
+      void refresh();
+    }
+  }, [ready, refresh]);
+
+  // Periodic polling.
+  useEffect(() => {
+    if (!isPolling || !ready) return;
+    const id = setInterval(() => {
+      if (readyRef.current) {
+        void refresh();
+      }
+    }, pollIntervalMs);
+    return () => clearInterval(id);
+  }, [isPolling, ready, pollIntervalMs, refresh]);
+
+  const setPolling = useCallback((enabled: boolean) => {
+    setIsPolling(enabled);
+  }, []);
+
+  return {
+    isAvailable,
+    stacks,
+    isLoading,
+    error,
+    isPolling,
+    pollIntervalMs,
+    refresh,
+    setPolling,
+    setPollIntervalMs,
+  };
+}
+
+export function usageFraction(s: StackInfo): number {
+  return s.size > 0 ? s.used / s.size : 0;
+}
+
+export function formatUsagePercent(s: StackInfo): string {
+  if (s.size === 0 || s.used === 0) return "n/a";
+  return `${((s.used / s.size) * 100).toFixed(1)}%`;
+}

--- a/src/i18n/translations.ts
+++ b/src/i18n/translations.ts
@@ -951,6 +951,18 @@ const ja: Record<string, string> = {
   "Capture time": "キャプチャ時間",
   "FPS (streaming)": "FPS（ストリーミング中）",
   "Debug Tool": "デバッグツール",
+
+  "Stack Usage": "スタック使用量",
+  "Per-thread stack high-water usage (zmk-module-devtool)":
+    "スレッドごとのスタック最高水位使用量（zmk-module-devtool）",
+  "Refresh stack usage": "スタック使用量を更新",
+  "Auto-refresh": "自動更新",
+  Requires: "必須：",
+  "in your firmware. Without it the RPC returns an error below.":
+    "がファームウェアで有効になっている必要があります。有効でない場合、下に RPC エラーが表示されます。",
+  "{{count}} thread(s) · sorted by usage": "{{count}} スレッド · 使用率順",
+  "No stack data yet — press Refresh or enable Auto-refresh.":
+    "まだデータがありません。「更新」ボタンを押すか「自動更新」を有効にしてください。",
 };
 
 const dictionaries: Record<Language, Record<string, string>> = {

--- a/src/pages/CustomSubsystemsPage.tsx
+++ b/src/pages/CustomSubsystemsPage.tsx
@@ -33,6 +33,7 @@ import { DEFAULT_LAYER_SUBSYSTEM_IDENTIFIER } from "../hooks/useDefaultLayer";
 import { SETTINGS_SUBSYSTEM_IDENTIFIER } from "../hooks/useSettings";
 import { BLE_MANAGEMENT_SUBSYSTEM_IDENTIFIER } from "../hooks/useBLEProfiles";
 import { OS_DETECTION_SUBSYSTEM_IDENTIFIER } from "../hooks/useOsDetection";
+import { DEVTOOL_SUBSYSTEM_IDENTIFIER } from "../hooks/useDevtool";
 
 // Identifiers of subsystems DYA Studio already has a dedicated UI for
 // (mirrors the `*_IDENTIFIER` constants exported by src/hooks/*.ts).
@@ -52,6 +53,7 @@ const SUPPORTED_SUBSYSTEM_IDENTIFIERS = new Set<string>([
   SETTINGS_SUBSYSTEM_IDENTIFIER,
   BLE_MANAGEMENT_SUBSYSTEM_IDENTIFIER,
   OS_DETECTION_SUBSYSTEM_IDENTIFIER,
+  DEVTOOL_SUBSYSTEM_IDENTIFIER,
 ]);
 
 type Subsystem = ListCustomSubsystemResponse["subsystems"][number];

--- a/src/pages/TroubleshootingPage.tsx
+++ b/src/pages/TroubleshootingPage.tsx
@@ -13,10 +13,12 @@ import { useWatchdog } from "../hooks/useWatchdog";
 import { useKscanDiagnostics } from "../hooks/useKscanDiagnostics";
 import { usePmw3610 } from "../hooks/usePmw3610";
 import { useElfAnalysis } from "../hooks/useElfAnalysis";
+import { useDevtoolStackUsage } from "../hooks/useDevtoolStackUsage";
 import { DeviceInfoSection } from "../components/troubleshooting/DeviceInfoSection";
 import { WatchdogSection } from "../components/troubleshooting/WatchdogSection";
 import { KscanDiagnosticsSection } from "../components/troubleshooting/KscanDiagnosticsSection";
 import { Pmw3610Section } from "../components/troubleshooting/Pmw3610Section";
+import { DevtoolStackUsageSection } from "../components/troubleshooting/DevtoolStackUsageSection";
 import { buildSupportReport } from "../lib/troubleshootingReport";
 
 const COPIED_FEEDBACK_MS = 2000;
@@ -29,6 +31,7 @@ export function TroubleshootingPage() {
   const kscan = useKscanDiagnostics();
   const pmw3610 = usePmw3610();
   const elfAnalysis = useElfAnalysis();
+  const stackUsage = useDevtoolStackUsage();
   const [copied, setCopied] = useState(false);
   const copiedTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -37,6 +40,7 @@ export function TroubleshootingPage() {
     if (watchdog.isAvailable) void watchdog.refresh();
     if (kscan.isAvailable) void kscan.refresh();
     if (pmw3610.isAvailable) void pmw3610.refresh();
+    if (stackUsage.isAvailable) void stackUsage.refresh();
   };
 
   const copySupportReport = async () => {
@@ -174,6 +178,7 @@ export function TroubleshootingPage() {
           <WatchdogSection watchdog={watchdog} elfAnalysis={elfAnalysis} />
           <KscanDiagnosticsSection kscan={kscan} />
           <Pmw3610Section pmw3610={pmw3610} />
+          <DevtoolStackUsageSection stackUsage={stackUsage} />
         </div>
       </div>
     </div>

--- a/src/proto/cormoran/devtool/devtool.ts
+++ b/src/proto/cormoran/devtool/devtool.ts
@@ -282,6 +282,30 @@ export interface LogStreamNotification {
   droppedCount: number;
 }
 
+export interface StackInfo {
+  name: string;
+  size: number;
+  /**
+   * Peak bytes used since boot (high-water mark). 0 if the running kernel
+   * could not measure it. Free headroom = size - used.
+   */
+  used: number;
+}
+
+/**
+ * Cursor-based pagination: start with cursor 0, pass back next_cursor until
+ * it comes back 0. Same shape as get_logs / get_events in the firmware.
+ */
+export interface GetStackUsageRequest {
+  cursor: number;
+}
+
+export interface GetStackUsageResponse {
+  stacks: StackInfo[];
+  nextCursor: number;
+  total: number;
+}
+
 export interface Request {
   setStudioLockState?: SetStudioLockStateRequest | undefined;
   enterBootloader?: EnterBootloaderRequest | undefined;
@@ -299,6 +323,7 @@ export interface Request {
   clearLogs?: ClearLogsRequest | undefined;
   setLogCaptureFilter?: SetLogCaptureFilterRequest | undefined;
   setLogStreaming?: SetLogStreamingRequest | undefined;
+  getStackUsage?: GetStackUsageRequest | undefined;
 }
 
 export interface ErrorResponse {
@@ -323,6 +348,7 @@ export interface Response {
   clearLogs?: ClearLogsResponse | undefined;
   setLogCaptureFilter?: SetLogCaptureFilterResponse | undefined;
   setLogStreaming?: SetLogStreamingResponse | undefined;
+  getStackUsage?: GetStackUsageResponse | undefined;
 }
 
 /**
@@ -2324,6 +2350,192 @@ export const LogStreamNotification: MessageFns<LogStreamNotification> = {
   },
 };
 
+function createBaseStackInfo(): StackInfo {
+  return { name: "", size: 0, used: 0 };
+}
+
+export const StackInfo: MessageFns<StackInfo> = {
+  encode(message: StackInfo, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    if (message.name !== "") {
+      writer.uint32(10).string(message.name);
+    }
+    if (message.size !== 0) {
+      writer.uint32(16).uint32(message.size);
+    }
+    if (message.used !== 0) {
+      writer.uint32(24).uint32(message.used);
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): StackInfo {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseStackInfo();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          message.name = reader.string();
+          continue;
+        }
+        case 2: {
+          if (tag !== 16) {
+            break;
+          }
+
+          message.size = reader.uint32();
+          continue;
+        }
+        case 3: {
+          if (tag !== 24) {
+            break;
+          }
+
+          message.used = reader.uint32();
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  create(base?: DeepPartial<StackInfo>): StackInfo {
+    return StackInfo.fromPartial(base ?? {});
+  },
+  fromPartial(object: DeepPartial<StackInfo>): StackInfo {
+    const message = createBaseStackInfo();
+    message.name = object.name ?? "";
+    message.size = object.size ?? 0;
+    message.used = object.used ?? 0;
+    return message;
+  },
+};
+
+function createBaseGetStackUsageRequest(): GetStackUsageRequest {
+  return { cursor: 0 };
+}
+
+export const GetStackUsageRequest: MessageFns<GetStackUsageRequest> = {
+  encode(message: GetStackUsageRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    if (message.cursor !== 0) {
+      writer.uint32(8).uint32(message.cursor);
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): GetStackUsageRequest {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseGetStackUsageRequest();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 8) {
+            break;
+          }
+
+          message.cursor = reader.uint32();
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  create(base?: DeepPartial<GetStackUsageRequest>): GetStackUsageRequest {
+    return GetStackUsageRequest.fromPartial(base ?? {});
+  },
+  fromPartial(object: DeepPartial<GetStackUsageRequest>): GetStackUsageRequest {
+    const message = createBaseGetStackUsageRequest();
+    message.cursor = object.cursor ?? 0;
+    return message;
+  },
+};
+
+function createBaseGetStackUsageResponse(): GetStackUsageResponse {
+  return { stacks: [], nextCursor: 0, total: 0 };
+}
+
+export const GetStackUsageResponse: MessageFns<GetStackUsageResponse> = {
+  encode(message: GetStackUsageResponse, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    for (const v of message.stacks) {
+      StackInfo.encode(v!, writer.uint32(10).fork()).join();
+    }
+    if (message.nextCursor !== 0) {
+      writer.uint32(16).uint32(message.nextCursor);
+    }
+    if (message.total !== 0) {
+      writer.uint32(24).uint32(message.total);
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): GetStackUsageResponse {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseGetStackUsageResponse();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          message.stacks.push(StackInfo.decode(reader, reader.uint32()));
+          continue;
+        }
+        case 2: {
+          if (tag !== 16) {
+            break;
+          }
+
+          message.nextCursor = reader.uint32();
+          continue;
+        }
+        case 3: {
+          if (tag !== 24) {
+            break;
+          }
+
+          message.total = reader.uint32();
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  create(base?: DeepPartial<GetStackUsageResponse>): GetStackUsageResponse {
+    return GetStackUsageResponse.fromPartial(base ?? {});
+  },
+  fromPartial(object: DeepPartial<GetStackUsageResponse>): GetStackUsageResponse {
+    const message = createBaseGetStackUsageResponse();
+    message.stacks = object.stacks?.map((e) => StackInfo.fromPartial(e)) || [];
+    message.nextCursor = object.nextCursor ?? 0;
+    message.total = object.total ?? 0;
+    return message;
+  },
+};
+
 function createBaseRequest(): Request {
   return {
     setStudioLockState: undefined,
@@ -2342,6 +2554,7 @@ function createBaseRequest(): Request {
     clearLogs: undefined,
     setLogCaptureFilter: undefined,
     setLogStreaming: undefined,
+    getStackUsage: undefined,
   };
 }
 
@@ -2394,6 +2607,9 @@ export const Request: MessageFns<Request> = {
     }
     if (message.setLogStreaming !== undefined) {
       SetLogStreamingRequest.encode(message.setLogStreaming, writer.uint32(130).fork()).join();
+    }
+    if (message.getStackUsage !== undefined) {
+      GetStackUsageRequest.encode(message.getStackUsage, writer.uint32(138).fork()).join();
     }
     return writer;
   },
@@ -2533,6 +2749,14 @@ export const Request: MessageFns<Request> = {
           message.setLogStreaming = SetLogStreamingRequest.decode(reader, reader.uint32());
           continue;
         }
+        case 17: {
+          if (tag !== 138) {
+            break;
+          }
+
+          message.getStackUsage = GetStackUsageRequest.decode(reader, reader.uint32());
+          continue;
+        }
       }
       if ((tag & 7) === 4 || tag === 0) {
         break;
@@ -2594,6 +2818,9 @@ export const Request: MessageFns<Request> = {
       : undefined;
     message.setLogStreaming = (object.setLogStreaming !== undefined && object.setLogStreaming !== null)
       ? SetLogStreamingRequest.fromPartial(object.setLogStreaming)
+      : undefined;
+    message.getStackUsage = (object.getStackUsage !== undefined && object.getStackUsage !== null)
+      ? GetStackUsageRequest.fromPartial(object.getStackUsage)
       : undefined;
     return message;
   },
@@ -2664,6 +2891,7 @@ function createBaseResponse(): Response {
     clearLogs: undefined,
     setLogCaptureFilter: undefined,
     setLogStreaming: undefined,
+    getStackUsage: undefined,
   };
 }
 
@@ -2719,6 +2947,9 @@ export const Response: MessageFns<Response> = {
     }
     if (message.setLogStreaming !== undefined) {
       SetLogStreamingResponse.encode(message.setLogStreaming, writer.uint32(138).fork()).join();
+    }
+    if (message.getStackUsage !== undefined) {
+      GetStackUsageResponse.encode(message.getStackUsage, writer.uint32(146).fork()).join();
     }
     return writer;
   },
@@ -2866,6 +3097,14 @@ export const Response: MessageFns<Response> = {
           message.setLogStreaming = SetLogStreamingResponse.decode(reader, reader.uint32());
           continue;
         }
+        case 18: {
+          if (tag !== 146) {
+            break;
+          }
+
+          message.getStackUsage = GetStackUsageResponse.decode(reader, reader.uint32());
+          continue;
+        }
       }
       if ((tag & 7) === 4 || tag === 0) {
         break;
@@ -2930,6 +3169,9 @@ export const Response: MessageFns<Response> = {
       : undefined;
     message.setLogStreaming = (object.setLogStreaming !== undefined && object.setLogStreaming !== null)
       ? SetLogStreamingResponse.fromPartial(object.setLogStreaming)
+      : undefined;
+    message.getStackUsage = (object.getStackUsage !== undefined && object.getStackUsage !== null)
+      ? GetStackUsageResponse.fromPartial(object.getStackUsage)
       : undefined;
     return message;
   },


### PR DESCRIPTION
## Summary

- Adds a **Stack Usage** card to the Troubleshooting page that connects to the `cormoran__devtool` custom subsystem ([zmk-module-devtool PR #9](https://github.com/cormoran/zmk-module-devtool/pull/9)) and polls per-thread stack high-water marks
- Drains all cursor-paginated pages of `get_stack_usage` and visualises results as colour-coded progress bars sorted by usage (green → yellow → amber → red at 60/80/90%)
- Auto-refresh toggle with 1 s / 3 s / 5 s / 10 s interval selector
- Collapsed-header summary badge shows worst-case usage at a glance
- Registers `cormoran__devtool` in the "Already supported" set on the Custom Subsystems page

**New files:**
- `proto/cormoran/devtool/devtool.proto` — minimal proto covering only `get_stack_usage` (field 17/18 to match firmware wire format)
- `src/proto/cormoran/devtool/devtool.ts` — generated TypeScript
- `src/hooks/useDevtoolStackUsage.ts` — hook with pagination + polling
- `src/components/troubleshooting/DevtoolStackUsageSection.tsx` — UI component

**Depends on:** zmk-module-devtool PR #9 being merged and `CONFIG_ZMK_DEVTOOL_STACK_USAGE=y` in firmware. Without it, the RPC returns an error which is displayed in the section (not available state is handled gracefully).

## Test plan

- [ ] Build passes (`npm run build`)
- [ ] Type check passes (`npx tsc -b --noEmit`, no new errors)
- [ ] Lint passes (`npm run lint`)
- [ ] Connect a keyboard with `CONFIG_ZMK_DEVTOOL_STACK_USAGE=y` — Stack Usage section shows threads with progress bars
- [ ] Enable Auto-refresh at 1s interval — bars update in real time
- [ ] Connect keyboard without the Kconfig — section shows error message from RPC
- [ ] Without `cormoran__devtool` subsystem — section shows "Not available" notice

🤖 Generated with [Claude Code](https://claude.com/claude-code)