### PR TITLE
chore(deps): bump zmk-studio-react-hook to activity-timeout build

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -842,8 +842,8 @@
       }
     },
     "node_modules/@cormoran/zmk-studio-react-hook": {
-      "version": "0.0.3",
-      "resolved": "git+ssh://git@github.com/cormoran/react-zmk-studio.git#8a9903592b61a37bcc209ce8fc17b9d6e545a14b",
+      "version": "0.0.4",
+      "resolved": "git+ssh://git@github.com/cormoran/react-zmk-studio.git#ceda0a4117078af35aed498c9b3afcb85cc68f62",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/src/components/__tests__/DeviceConnection.test.tsx
+++ b/src/components/__tests__/DeviceConnection.test.tsx
@@ -82,7 +82,16 @@ function createMockSerialPort(overrides: Record<string, unknown> = {}) {
     getInfo: jest
       .fn()
       .mockReturnValue({ usbVendorId: 0x1234, usbProductId: 0x5678 }),
-    readable: { cancel: jest.fn().mockResolvedValue(undefined) },
+    // A real ReadableStream so the connect flow can `pipeThrough` it to track
+    // packet activity (the serial transport forwards `port.readable` verbatim).
+    // `cancel` is stubbed: once the connect flow pipes this stream it becomes
+    // locked, and the serial transport's abort handler awaits
+    // `port.readable.cancel()` during teardown -- which on a locked stream
+    // rejects. In production `create_rpc_connection` drains the pipe so the
+    // lock clears; here it's mocked, so keep teardown a graceful no-op.
+    readable: Object.assign(new ReadableStream(), {
+      cancel: jest.fn().mockResolvedValue(undefined),
+    }),
     writable: { close: jest.fn().mockResolvedValue(undefined) },
     ...overrides,
   };
@@ -106,6 +115,20 @@ describe("DeviceConnection", () => {
     mocks = setupZMKMocks();
     // Auto-reconnect remembers ports in sessionStorage; start each test clean.
     window.sessionStorage.clear();
+
+    // The connect flow now wraps `transport.readable` in a TransformStream to
+    // track packet activity, so a connect function must resolve to a transport
+    // with a real readable stream. Default the app-level transport connectors
+    // to the library's mock transport (which exposes a real ReadableStream);
+    // individual tests override these to simulate failures.
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    require("../../lib/transport/usb").connect.mockResolvedValue(
+      mocks.mockTransport,
+    );
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    require("@zmkfirmware/zmk-studio-ts-client/transport/gatt").connect.mockResolvedValue(
+      mocks.mockTransport,
+    );
   });
 
   afterEach(() => {

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -4,6 +4,11 @@
 // learn more: https://github.com/testing-library/jest-dom
 import "@testing-library/jest-dom";
 import { TextEncoder, TextDecoder } from "util";
+import {
+  ReadableStream,
+  WritableStream,
+  TransformStream,
+} from "stream/web";
 
 // Polyfill TextEncoder and TextDecoder for protobuf support
 global.TextEncoder = TextEncoder;
@@ -16,37 +21,15 @@ Object.defineProperty(navigator, "serial", {
   value: undefined,
 });
 
-// Mock ReadableStream and WritableStream for Web Serial API
-if (typeof global.ReadableStream === "undefined") {
-  global.ReadableStream = class ReadableStream {
-    getReader() {
-      return {
-        read: jest.fn().mockResolvedValue({ done: true, value: undefined }),
-        releaseLock: jest.fn(),
-        cancel: jest.fn(),
-      };
-    }
-    cancel() {
-      return Promise.resolve();
-    }
-  } as unknown as ReadableStream;
-}
-
-if (typeof global.WritableStream === "undefined") {
-  global.WritableStream = class WritableStream {
-    getWriter() {
-      return {
-        write: jest.fn().mockResolvedValue(undefined),
-        close: jest.fn().mockResolvedValue(undefined),
-        releaseLock: jest.fn(),
-        abort: jest.fn(),
-      };
-    }
-    abort() {
-      return Promise.resolve();
-    }
-  } as unknown as WritableStream;
-}
+// Provide the WHATWG stream implementations for the Web Serial API and for the
+// zmk-studio-react-hook connect flow, which pipes `transport.readable` through
+// a `TransformStream` to track packet activity. jsdom does not expose these
+// globals (and lacks `TransformStream` entirely), so pull the real ones from
+// Node's `stream/web` to get proper `pipeThrough` support.
+global.ReadableStream = ReadableStream as unknown as typeof global.ReadableStream;
+global.WritableStream = WritableStream as unknown as typeof global.WritableStream;
+global.TransformStream =
+  TransformStream as unknown as typeof global.TransformStream;
 
 // Mock window.matchMedia
 Object.defineProperty(window, "matchMedia", {


### PR DESCRIPTION
Pulls the activity-based RPC timeout fix into dya-studio by re-resolving the `@cormoran/zmk-studio-react-hook` git dependency.

## What changed

- **package-lock.json**: re-resolve `@cormoran/zmk-studio-react-hook` from `8a99035` (PR #9, v0.0.3) to `ceda0a4` (react-zmk-studio PR #11 merge, v0.0.4).

The upstream fix (react-zmk-studio#11) makes RPC timeouts activity-based: a single request timeout no longer aborts the transport / disconnects the app, and the connect handshake watchdog resets whenever a packet arrives instead of firing on a fixed deadline.

## Test-environment updates

The new connect flow wraps `transport.readable` in a `TransformStream` to track packet activity, so the jsdom test env needs real WHATWG streams:

- **src/setupTests.ts**: replace the minimal fake `ReadableStream`/`WritableStream` with the real implementations from `node:stream/web` and add `TransformStream`, so `pipeThrough` works (jsdom exposes none of these).
- **src/components/__tests__/DeviceConnection.test.tsx**:
  - Default the app-level transport connectors (`usb`, `gatt`) to a mock transport that exposes a real readable stream.
  - Give the mock `SerialPort` a real readable stream, with a graceful `cancel()` for the abort-teardown path (the piped stream is locked and the mocked `create_rpc_connection` never drains it, unlike production).

## Verification

- `npm run lint` — clean
- `npm test` — 418 passed, 1 skipped (pre-existing)
- `npm run build` — succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)