### PR TITLE
fix(macro): show unlock modal instead of error banner when studio locked

### DIFF
--- a/src/pages/MacroPage.tsx
+++ b/src/pages/MacroPage.tsx
@@ -473,7 +473,18 @@ export function MacroPage() {
     selectedName,
   ]);
 
+  // Guard an edit action: if Studio is locked, open the unlock prompt instead
+  // of performing the edit (and let the caller bail out).
+  const requireUnlocked = useCallback((): boolean => {
+    if (locked) {
+      setShowUnlockPrompt(true);
+      return false;
+    }
+    return true;
+  }, [locked]);
+
   const commitRename = useCallback(async () => {
+    if (!requireUnlocked()) return;
     if (!loadedMacro) return;
     const trimmedName = renameDraft.slice(0, runtimeMacro.maxNameLength).trim();
     if (!trimmedName || trimmedName === loadedMacro.name) {
@@ -487,17 +498,7 @@ export function MacroPage() {
     } else {
       setRenameDraft(loadedMacro.name);
     }
-  }, [loadedMacro, renameDraft, runtimeMacro]);
-
-  // Guard an edit action: if Studio is locked, open the unlock prompt instead
-  // of performing the edit (and let the caller bail out).
-  const requireUnlocked = useCallback((): boolean => {
-    if (locked) {
-      setShowUnlockPrompt(true);
-      return false;
-    }
-    return true;
-  }, [locked]);
+  }, [loadedMacro, renameDraft, runtimeMacro, requireUnlocked]);
 
   const commitSteps = useCallback(
     async (steps: MacroStep[]) => {
@@ -900,17 +901,18 @@ export function MacroPage() {
         {(runtimeMacro.error ||
           encodedSizeError ||
           stringConversionError ||
-          keymap.error) && (
-          <div className="glass-card p-4 mb-4 border-red-500/20 bg-red-500/10 flex items-center gap-3">
-            <IconAlertCircle size={20} className="text-red-400" />
-            <p className="text-sm text-red-400">
-              {runtimeMacro.error ||
-                encodedSizeError ||
-                stringConversionError ||
-                keymap.error}
-            </p>
-          </div>
-        )}
+          keymap.error) &&
+          !((showUnlockPrompt && locked) || keymap.unlockRequired) && (
+            <div className="glass-card p-4 mb-4 border-red-500/20 bg-red-500/10 flex items-center gap-3">
+              <IconAlertCircle size={20} className="text-red-400" />
+              <p className="text-sm text-red-400">
+                {runtimeMacro.error ||
+                  encodedSizeError ||
+                  stringConversionError ||
+                  keymap.error}
+              </p>
+            </div>
+          )}
 
         {runtimeMacro.isAvailable && (
           <div className="grid grid-cols-1 tablet:grid-cols-[240px_1fr] gap-4">

--- a/src/pages/MacroPage.tsx
+++ b/src/pages/MacroPage.tsx
@@ -473,6 +473,14 @@ export function MacroPage() {
     selectedName,
   ]);
 
+  // Show unlock modal immediately when the tab is opened while locked, because
+  // even loading macros (listMacros RPC) requires the studio to be unlocked.
+  useEffect(() => {
+    if (locked) {
+      setShowUnlockPrompt(true);
+    }
+  }, [locked]);
+
   // Guard an edit action: if Studio is locked, open the unlock prompt instead
   // of performing the edit (and let the caller bail out).
   const requireUnlocked = useCallback((): boolean => {
@@ -1247,6 +1255,7 @@ export function MacroPage() {
           setShowUnlockPrompt(false);
           keymap.clearUnlockRequired();
           keymap.loadKeymapData();
+          void runtimeMacro.loadMacros();
         }}
       />
     </div>

--- a/src/pages/MacroPage.tsx
+++ b/src/pages/MacroPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useContext, useEffect, useMemo, useState } from "react";
+import { useCallback, useContext, useEffect, useMemo, useRef, useState } from "react";
 import {
   IconAlertCircle,
   IconChevronDown,
@@ -473,13 +473,22 @@ export function MacroPage() {
     selectedName,
   ]);
 
-  // Show unlock modal immediately when the tab is opened while locked, because
-  // even loading macros (listMacros RPC) requires the studio to be unlocked.
+  // listMacros RPC requires unlock, so we manage loading around lock state:
+  // - While locked: show the unlock modal and suppress the error from the
+  //   failed initial load attempt (useRuntimeMacro fires loadMacros on mount
+  //   before we know the studio is locked).
+  // - On locked→unlocked transition: reload macros so data appears immediately
+  //   without requiring the user to manually retry.
+  const prevLockedRef = useRef(locked);
   useEffect(() => {
     if (locked) {
       setShowUnlockPrompt(true);
+      runtimeMacro.clearError();
+    } else if (prevLockedRef.current) {
+      void runtimeMacro.loadMacros();
     }
-  }, [locked]);
+    prevLockedRef.current = locked;
+  }, [locked, runtimeMacro]);
 
   // Guard an edit action: if Studio is locked, open the unlock prompt instead
   // of performing the edit (and let the caller bail out).


### PR DESCRIPTION
## Summary

Loading macros (`listMacros` RPC) requires the studio to be unlocked, so the unlock modal must appear the moment the Macro tab is shown while locked — not only when the user attempts an edit.

- Add `useEffect` that opens the unlock modal whenever `locked` is true (fires on mount if already locked, or if studio locks while the tab is open)
- Add `requireUnlocked()` guard to `commitRename`, which was the only edit action that bypassed the lock check and would fire an RPC while locked
- Call `runtimeMacro.loadMacros()` in `onRetry` so macros load immediately after unlocking
- Suppress the error banner while the unlock modal is open, matching the `ComboPage` pattern
- Move `requireUnlocked` definition before `commitRename` to avoid temporal dead zone

## Test plan

- [ ] Connect a keyboard, lock Studio, navigate to Macro page → unlock modal appears immediately, no error banner
- [ ] Click Retry after unlocking the keyboard → macros load
- [ ] Unlock Studio first, navigate to Macro page → macros load normally
- [ ] Try rename / add step / delete while locked → unlock modal appears
- [ ] Verify errors for non-lock failures (e.g. size limit exceeded) still show the error banner when unlocked

🤖 Generated with [Claude Code](https://claude.com/claude-code)