### PR TITLE
fix(connection): reset loading state when reconnect modal is cancelled

### DIFF
--- a/src/components/DeviceConnection.tsx
+++ b/src/components/DeviceConnection.tsx
@@ -170,7 +170,13 @@ export function DeviceConnectionProvider({
 
   const handleCancelReconnect = useCallback(() => {
     cancelReconnectRef.current();
-  }, []);
+    // If the cancel lands while the auto-reconnect is already awaiting the
+    // RPC handshake, `zmkApp.connect()` has set `isLoading` and won't clear it
+    // until the connect-timeout watchdog fires. Abort that in-flight attempt so
+    // the connect screen doesn't stay stuck in the loading state; `disconnect`
+    // also resets `isLoading`/`error` back to the idle disconnected state.
+    zmkApp.disconnect();
+  }, [zmkApp]);
 
   const connectionValue: ConnectionContextValue = {
     isConnected: zmkApp.isConnected,

--- a/src/components/__tests__/DeviceConnection.test.tsx
+++ b/src/components/__tests__/DeviceConnection.test.tsx
@@ -617,6 +617,64 @@ describe("DeviceConnection", () => {
       expect(screen.queryByTestId("device-name")).not.toBeInTheDocument();
     });
 
+    test("cancelling while the reconnect is awaiting the RPC handshake resets the loading state instead of leaving the connect screen stuck", async () => {
+      const user = userEvent.setup();
+      const consoleErrorSpy = jest.spyOn(console, "error").mockImplementation();
+      const consoleWarnSpy = jest.spyOn(console, "warn").mockImplementation();
+
+      const mockPort = createMockSerialPort();
+      setPairedSerialPorts([mockPort]);
+
+      // The port opens fine, so the reconnect flow reaches `zmkApp.connect()`
+      // (which sets `isLoading`) and hangs on the RPC handshake -- `call_rpc`
+      // only settles once the connection's AbortSignal fires. This mirrors a
+      // real paired-but-unresponsive device sitting in the handshake.
+      let capturedSignal: AbortSignal | undefined;
+      mocks.create_rpc_connection.mockImplementation(
+        (_transport: unknown, opts: { signal: AbortSignal }) => {
+          capturedSignal = opts.signal;
+          return mocks.mockConnection;
+        },
+      );
+      mocks.call_rpc.mockReset();
+      mocks.call_rpc.mockImplementation(
+        () =>
+          new Promise((_resolve, reject) => {
+            capturedSignal?.addEventListener("abort", () =>
+              reject(capturedSignal?.reason ?? new Error("aborted")),
+            );
+          }),
+      );
+
+      render(
+        <DeviceConnectionProvider reconnectMinDisplayMs={0}>
+          <TestComponent />
+        </DeviceConnectionProvider>,
+      );
+
+      // Wait until the handshake is in flight: reconnecting + loading are both
+      // shown while `zmkApp.connect()` awaits `call_rpc`.
+      await waitFor(() => {
+        expect(screen.getByTestId("loading")).toBeInTheDocument();
+      });
+      expect(screen.getByTestId("reconnecting")).toBeInTheDocument();
+
+      await user.click(screen.getByTestId("cancel-reconnect-button"));
+
+      // Cancelling must abort the in-flight connect so neither the reconnecting
+      // overlay nor the connect screen's loading state lingers.
+      expect(screen.queryByTestId("reconnecting")).not.toBeInTheDocument();
+      await waitFor(() => {
+        expect(screen.queryByTestId("loading")).not.toBeInTheDocument();
+      });
+      expect(screen.getByTestId("connection-status")).toHaveTextContent(
+        "Disconnected",
+      );
+
+      consoleErrorSpy.mockRestore();
+      consoleWarnSpy.mockRestore();
+    });
+
     test("keeps the reconnecting indicator visible for at least reconnectMinDisplayMs even on an instant success", async () => {
       mocks.mockSuccessfulConnection({ deviceName: "Fast Reconnect" });
       const mockPort = createMockSerialPort();


### PR DESCRIPTION
## What

Cancelling the auto-reconnect modal no longer leaves the connection screen stuck in a loading state.

## Why

When a paired serial device is present, on page load the app attempts an auto-reconnect and shows the `ReconnectingOverlay`. Once the port opens, the flow calls `zmkApp.connect()`, which sets `isLoading = true` and awaits the RPC handshake.

If the user clicked **Cancel** during that handshake window, the old `handleCancelReconnect` only cleared `isReconnecting` and set the local cancelled flag — it never aborted the in-flight `zmkApp.connect`. So `isLoading` stayed `true` until the connect-timeout watchdog fired (~5s), and since `App.tsx` renders `SplashScreen` with `isConnecting={connection.isLoading}` after the overlay closes, the connect screen appeared stuck loading.

## How

`handleCancelReconnect` now also calls `zmkApp.disconnect()`, which aborts the in-flight handshake and resets `isLoading`/`error` back to the idle disconnected state. When cancel lands earlier (before `zmkApp.connect` is reached), `disconnect()` is a harmless idempotent reset, so the existing cancel behavior is unchanged.

## Tests

- Added a test that drives a paired port to a hanging RPC handshake, clicks cancel, and asserts the loading indicator clears and the screen returns to Disconnected.
- Full `DeviceConnection` suite passes (22 tests); typecheck and lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)