### PR TITLE
perf(fast-keymap): paint keymap preview before loading behaviors

### DIFF
--- a/src/hooks/__tests__/useKeymap.test.tsx
+++ b/src/hooks/__tests__/useKeymap.test.tsx
@@ -122,6 +122,7 @@ describe("useKeymap", () => {
       expect(result.current.behaviors.size).toBe(0);
       expect(result.current.hasUnsavedChanges).toBe(false);
       expect(result.current.isLoading).toBe(false);
+      expect(result.current.isFullyLoaded).toBe(false);
       expect(result.current.error).toBeNull();
       expect(result.current.unlockRequired).toBe(false);
     });
@@ -173,6 +174,9 @@ describe("useKeymap", () => {
       expect(result.current.physicalLayouts).toEqual(mockPhysicalLayouts);
       expect(result.current.keymap).toEqual(mockKeymap);
       expect(result.current.behaviors.size).toBe(3);
+      // Official path defers nothing to the background, so the load is fully
+      // complete as soon as it finishes.
+      expect(result.current.isFullyLoaded).toBe(true);
     });
 
     it("should handle unlock required error", async () => {

--- a/src/hooks/__tests__/useKeymapSource.test.tsx
+++ b/src/hooks/__tests__/useKeymapSource.test.tsx
@@ -142,6 +142,7 @@ describe("useKeymapSource — fast path", () => {
     availableLayers: 8,
     maxLayerNameLength: 20,
     pendingLayerIds: [],
+    behaviorsDeferred: false,
     stats: {
       behaviorsFromCache: false,
       behaviorsBundled: 1,
@@ -240,6 +241,54 @@ describe("useKeymapSource — fast path", () => {
     await waitFor(() => expect(onLayersLoaded).toHaveBeenCalledTimes(1));
     const fullLayers = onLayersLoaded.mock.calls[0][0];
     expect(fullLayers[1].bindings).toHaveLength(1);
+    expect(mockLoadFastKeymap).toHaveBeenCalledTimes(2);
+  });
+
+  it("defers behaviors so the preview paints first, then fills them via onBehaviorsLoaded", async () => {
+    // Phase 1 (firstLayerOnly + deferBehaviors) returns no behaviors; phase 2
+    // (full) hands them back mid-load via the onBehaviorsLoaded callback.
+    mockLoadFastKeymap.mockImplementation(
+      async (
+        _call: unknown,
+        opts: {
+          firstLayerOnly?: boolean;
+          deferBehaviors?: boolean;
+          onBehaviorsLoaded?: (b: FastKeymapModel["behaviors"]) => void;
+        },
+      ) => {
+        if (opts?.firstLayerOnly) {
+          return { ...fastModel, behaviors: [], behaviorsDeferred: true };
+        }
+        opts?.onBehaviorsLoaded?.(fastModel.behaviors);
+        return { ...fastModel, behaviorsDeferred: false };
+      },
+    );
+
+    const onBehaviorsLoaded = jest.fn();
+    const { result } = renderHook(() => useKeymapSource(), { wrapper });
+    const data = await result.current.loadKeymapData(
+      undefined,
+      undefined,
+      onBehaviorsLoaded,
+    );
+
+    // Phase 1 asks the loader to defer behaviors alongside the first layer.
+    expect(mockLoadFastKeymap).toHaveBeenNthCalledWith(
+      1,
+      expect.anything(),
+      expect.objectContaining({ firstLayerOnly: true, deferBehaviors: true }),
+    );
+    // The preview data comes back with behaviors still empty.
+    expect(data.behaviorsDeferred).toBe(true);
+    expect(data.behaviors.size).toBe(0);
+
+    // Phase 2 resolves them and hands back the official-shaped map.
+    await waitFor(() => expect(onBehaviorsLoaded).toHaveBeenCalledTimes(1));
+    const behaviors = onBehaviorsLoaded.mock.calls[0][0] as Map<
+      number,
+      { displayName: string }
+    >;
+    expect(behaviors.get(42)?.displayName).toBe("Key Press");
     expect(mockLoadFastKeymap).toHaveBeenCalledTimes(2);
   });
 

--- a/src/hooks/__tests__/useRuntimeMacro.test.tsx
+++ b/src/hooks/__tests__/useRuntimeMacro.test.tsx
@@ -1,0 +1,57 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { useRuntimeMacro } from "../useRuntimeMacro";
+
+// Mock the custom-subsystem transport so we can observe the RPCs the hook
+// issues (and whether it issues any on mount).
+const mockCall = jest.fn();
+const mockUseCustomSubsystem = jest.fn();
+jest.mock("../useCustomSubsystem", () => ({
+  useCustomSubsystem: (...args: unknown[]) => mockUseCustomSubsystem(...args),
+}));
+
+function primeSubsystem() {
+  mockCall.mockImplementation(async (req: Record<string, unknown>) => {
+    if (req.listMacros) {
+      return {
+        listMacros: { macros: [], maxMacroBytes: 64, maxNameLength: 64 },
+      };
+    }
+    if (req.getMacroGlobalSettings) {
+      return { getMacroGlobalSettings: { settings: { tapMs: 0 } } };
+    }
+    return {};
+  });
+  mockUseCustomSubsystem.mockReturnValue({
+    subsystem: { index: 0, identifier: "cormoran__runtime_macro" },
+    ready: true,
+    call: mockCall,
+  });
+}
+
+function listMacrosCalls() {
+  return mockCall.mock.calls.filter(([req]) => req?.listMacros);
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  primeSubsystem();
+});
+
+describe("useRuntimeMacro autoLoad", () => {
+  it("loads the macro list on mount by default", async () => {
+    renderHook(() => useRuntimeMacro());
+    await waitFor(() => expect(listMacrosCalls().length).toBe(1));
+  });
+
+  it("does NOT load on mount when autoLoad is false", async () => {
+    const { result } = renderHook(() => useRuntimeMacro({ autoLoad: false }));
+
+    // Give the mount effect's setTimeout(0) a chance to fire.
+    await new Promise((r) => setTimeout(r, 20));
+    expect(listMacrosCalls().length).toBe(0);
+
+    // The caller can still drive the load explicitly.
+    await result.current.loadMacros();
+    expect(listMacrosCalls().length).toBe(1);
+  });
+});

--- a/src/hooks/useKeymap.ts
+++ b/src/hooks/useKeymap.ts
@@ -358,6 +358,16 @@ export function useKeymap(): UseKeymapReturn {
       }
     };
 
+    // Called when the fast path finishes loading the behaviors it deferred (see
+    // useKeymapSource's incremental load): swap in the resolved map so bindings
+    // that were rendering with a placeholder label now show their real names.
+    const applyBackgroundBehaviors = (
+      behaviors: Map<number, BehaviorDefinition>,
+    ) => {
+      if (loadIdRef.current !== loadId) return;
+      setBehaviors(behaviors);
+    };
+
     try {
       // Load the keymap data. Only a failure HERE means unlock is actually
       // required: the fast-keymap subsystem is unsecured and loads while the
@@ -368,6 +378,7 @@ export function useKeymap(): UseKeymapReturn {
         const data = await loadFromSource(
           (progress) => setLoadingProgress(progress),
           applyBackgroundLayers,
+          applyBackgroundBehaviors,
         );
         pendingLayerIds = data.pendingLayerIds;
 

--- a/src/hooks/useKeymap.ts
+++ b/src/hooks/useKeymap.ts
@@ -90,6 +90,13 @@ export interface KeymapState {
   hasUnsavedChanges: boolean;
   /** Whether loading data */
   isLoading: boolean;
+  /** True once the keymap tab has fully finished loading -- the foreground
+   * preview AND any background incremental load (deferred behaviors + remaining
+   * layers) have all settled. `isLoading` goes false as soon as the preview is
+   * painted; this stays false until nothing keymap-related is still fetching,
+   * so callers can defer non-preview work (e.g. runtime-macro loading) to the
+   * very end. */
+  isFullyLoaded: boolean;
   /** Progress of the in-flight load (what/how-far), or null when idle */
   loadingProgress: KeymapLoadProgress | null;
   /** Error message if any */
@@ -181,6 +188,10 @@ export function useKeymap(): UseKeymapReturn {
   >(new Map());
   const [hasUnsavedChanges, setHasUnsavedChanges] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
+  // True only once the foreground preview AND the background incremental load
+  // (deferred behaviors + remaining layers) have all settled. See the
+  // UseKeymapReturn.isFullyLoaded doc.
+  const [isFullyLoaded, setIsFullyLoaded] = useState(false);
   const [loadingProgress, setLoadingProgress] =
     useState<KeymapLoadProgress | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -310,6 +321,7 @@ export function useKeymap(): UseKeymapReturn {
     }
 
     setIsLoading(true);
+    setIsFullyLoaded(false);
     setLoadingProgress({ phase: "layouts" });
     setError(null);
     setUnlockRequired(false);
@@ -327,6 +339,10 @@ export function useKeymap(): UseKeymapReturn {
     // and record their original bindings (first load only).
     const applyBackgroundLayers = (fullLayers: Layer[]) => {
       if (loadIdRef.current !== loadId) return;
+      // This is the final callback of the background load (it runs after the
+      // deferred behaviors are delivered), so the keymap tab is now fully
+      // loaded -- even when there were no pending layers to fill in.
+      setIsFullyLoaded(true);
       const pending = new Set(pendingLayerIds);
       if (pending.size === 0) return;
       const bindingsById = new Map(fullLayers.map((l) => [l.id, l.bindings]));
@@ -390,6 +406,12 @@ export function useKeymap(): UseKeymapReturn {
           dataLoadedRef.current = true;
         }
         setBehaviors(data.behaviors);
+        // If nothing was deferred to the background, the load is already
+        // complete here; otherwise applyBackgroundLayers flips this when the
+        // background (deferred behaviors + remaining layers) settles.
+        if (data.pendingLayerIds.length === 0 && !data.behaviorsDeferred) {
+          setIsFullyLoaded(true);
+        }
         loaded = true;
       } catch (err) {
         if (isKeymapUnlockRequired(err)) {
@@ -938,6 +960,7 @@ export function useKeymap(): UseKeymapReturn {
     originalBindings,
     hasUnsavedChanges,
     isLoading,
+    isFullyLoaded,
     loadingProgress,
     error,
     unlockRequired,

--- a/src/hooks/useKeymapSource.ts
+++ b/src/hooks/useKeymapSource.ts
@@ -83,12 +83,24 @@ export interface KeymapData {
    * are filled in via the `onLayersLoaded` callback. Empty for the official
    * path and for single-layer / warm-cache fast loads. */
   pendingLayerIds: number[];
+  /** True when `behaviors` is still loading in the background (fast incremental
+   * load): it comes back empty here and is filled in via the
+   * `onBehaviorsLoaded` callback. False for the official path and for
+   * warm-cache fast loads (where behaviors were served without a round-trip). */
+  behaviorsDeferred: boolean;
 }
 
 /** Called when the background load of the deferred layers completes, with the
  * full set of layers (real bindings). Only fires when a fast incremental load
  * left layers pending. */
 export type OnLayersLoadedCallback = (layers: Keymap["layers"]) => void;
+
+/** Called when the background load of the deferred behaviors completes, with
+ * the full behaviors map. Only fires when a fast incremental load deferred
+ * behaviors (see {@link KeymapData.behaviorsDeferred}). */
+export type OnBehaviorsLoadedCallback = (
+  behaviors: Map<number, BehaviorDefinition>,
+) => void;
 
 /**
  * Phases of a full keymap-data load. Behaviors are loaded one at a time on the
@@ -160,14 +172,19 @@ export interface UseKeymapSourceReturn {
   source: KeymapSource;
   /** Load layouts + keymap + behaviors as one uniform {@link KeymapData}.
    *
-   * On the fast path this returns as soon as the FIRST layer is ready (other
-   * layers come back as empty placeholders listed in
-   * {@link KeymapData.pendingLayerIds}); the remaining layers load in the
-   * background and arrive via `onLayersLoaded`. On the official path everything
-   * is loaded before returning and `onLayersLoaded` never fires. */
+   * On the fast path this returns as soon as the layout + FIRST layer are ready
+   * so the keymap preview can paint immediately. Two things load in the
+   * background afterwards: the remaining layers (empty placeholders listed in
+   * {@link KeymapData.pendingLayerIds}, filled via `onLayersLoaded`) and the
+   * behaviors (deferred unless a warm cache served them for free — see
+   * {@link KeymapData.behaviorsDeferred} — filled via `onBehaviorsLoaded`).
+   * While behaviors are deferred, bindings render with a placeholder label. On
+   * the official path everything is loaded before returning and neither
+   * background callback fires. */
   loadKeymapData: (
     onProgress?: KeymapLoadProgressCallback,
     onLayersLoaded?: OnLayersLoadedCallback,
+    onBehaviorsLoaded?: OnBehaviorsLoadedCallback,
   ) => Promise<KeymapData>;
   /** Load just the physical layouts (with full geometry for every layout). */
   loadPhysicalLayouts: () => Promise<PhysicalLayouts>;
@@ -220,6 +237,23 @@ function toKeyPhysicalAttrs(keys: KeyPhysicalAttrs[]): KeyPhysicalAttrs[] {
  * time is exactly what made "Finalizing" take seconds. A non-active layout's
  * geometry is fetched lazily via {@link UseKeymapSourceReturn.loadLayoutGeometry}
  * only when the user switches to it (see useKeymap.setActiveLayout). */
+/** Maps the fast loader's behavior list onto the official
+ * `Map<local_id, BehaviorDefinition>` shape every consumer expects. Shared by
+ * {@link mapFastModel} and the background `onBehaviorsLoaded` delivery. */
+function mapFastBehaviors(
+  behaviors: FastKeymapModel["behaviors"],
+): Map<number, BehaviorDefinition> {
+  const map = new Map<number, BehaviorDefinition>();
+  for (const b of behaviors) {
+    map.set(b.localId, {
+      id: b.localId,
+      displayName: b.displayName,
+      metadata: b.metadata,
+    });
+  }
+  return map;
+}
+
 function mapFastModel(model: FastKeymapModel): KeymapData {
   const keymap: Keymap = {
     layers: model.layers.map((layer) => ({
@@ -245,21 +279,13 @@ function mapFastModel(model: FastKeymapModel): KeymapData {
     layouts,
   };
 
-  const behaviors = new Map<number, BehaviorDefinition>();
-  for (const b of model.behaviors) {
-    behaviors.set(b.localId, {
-      id: b.localId,
-      displayName: b.displayName,
-      metadata: b.metadata,
-    });
-  }
-
   return {
     physicalLayouts,
     keymap,
-    behaviors,
+    behaviors: mapFastBehaviors(model.behaviors),
     source: "fast",
     pendingLayerIds: model.pendingLayerIds,
+    behaviorsDeferred: model.behaviorsDeferred,
   };
 }
 
@@ -324,29 +350,41 @@ export function useKeymapSource(): UseKeymapSourceReturn {
     async (
       onProgress?: KeymapLoadProgressCallback,
       onLayersLoaded?: OnLayersLoadedCallback,
+      onBehaviorsLoaded?: OnBehaviorsLoadedCallback,
     ): Promise<KeymapData> => {
       if (isFastAvailable) {
         onProgress?.({ phase: "keymap" });
-        // Phase 1: fetch only the FIRST layer so the UI can render immediately;
-        // behaviors + layouts are fully loaded here too. Other uncached layers
-        // come back as empty placeholders (model.pendingLayerIds).
+        // Phase 1: fetch only the layout + FIRST layer so the keymap preview can
+        // paint as fast as possible. Behaviors are deferred (unless a warm cache
+        // serves them for free) and other uncached layers come back as empty
+        // placeholders (model.pendingLayerIds / model.behaviorsDeferred).
         const model = await loadFastKeymap(call, {
           deviceKey,
           firstLayerOnly: true,
+          deferBehaviors: true,
         });
         // Remember each layout's fingerprint so a later lazy geometry load can
         // hit the fp-keyed cache (mapFastModel drops the fps).
         layoutFpsRef.current = model.layouts.map((l) => l.fp);
         const data = mapFastModel(model);
 
-        // Phase 2 (background): load the deferred layers. behaviors/layouts and
-        // the first layer are cache-warm now, so this fetches only the pending
-        // layers (one batched get_layers round-trip) and hands them back.
-        if (data.pendingLayerIds.length > 0 && onLayersLoaded) {
-          void loadFastKeymap(call, { deviceKey })
-            .then((full) => onLayersLoaded(mapFastModel(full).keymap.layers))
+        // Phase 2 (background): resolve whatever phase 1 deferred — the behavior
+        // labels and/or the remaining layers. layouts and the first layer are
+        // cache-warm now, so this pays only for the behaviors round-trip(s) and
+        // one batched get_layers. Behaviors are handed back first (onBehaviorsLoaded,
+        // mid-load) so labels appear before the remaining layers arrive.
+        const needsBackground =
+          data.pendingLayerIds.length > 0 || data.behaviorsDeferred;
+        if (needsBackground && (onLayersLoaded || onBehaviorsLoaded)) {
+          void loadFastKeymap(call, {
+            deviceKey,
+            onBehaviorsLoaded: onBehaviorsLoaded
+              ? (behaviors) => onBehaviorsLoaded(mapFastBehaviors(behaviors))
+              : undefined,
+          })
+            .then((full) => onLayersLoaded?.(mapFastModel(full).keymap.layers))
             .catch((err) => {
-              console.error("Background layer load failed:", err);
+              console.error("Background keymap load failed:", err);
             });
         }
 
@@ -398,6 +436,7 @@ export function useKeymapSource(): UseKeymapSourceReturn {
         behaviors,
         source: "official",
         pendingLayerIds: [],
+        behaviorsDeferred: false,
       };
     },
     [isFastAvailable, call, deviceKey, officialRpc],

--- a/src/hooks/useRuntimeMacro.ts
+++ b/src/hooks/useRuntimeMacro.ts
@@ -55,7 +55,20 @@ export interface UseRuntimeMacroReturn {
   discardMacros: () => Promise<boolean>;
 }
 
-export function useRuntimeMacro(): UseRuntimeMacroReturn {
+export interface UseRuntimeMacroOptions {
+  /** Whether to load the macro list automatically on mount / when the
+   * subsystem becomes available. Defaults to `true`. Pass `false` when the
+   * caller wants to control load timing itself -- e.g. the Keymap tab defers
+   * `loadMacros()` until the keymap preview has finished loading so the macro
+   * RPCs don't compete with (and slow down) the preview. State is still
+   * cleared when the subsystem is absent regardless of this flag. */
+  autoLoad?: boolean;
+}
+
+export function useRuntimeMacro(
+  options: UseRuntimeMacroOptions = {},
+): UseRuntimeMacroReturn {
+  const autoLoad = options.autoLoad ?? true;
   const { subsystem, ready, call } = useCustomSubsystem(
     RUNTIME_MACRO_SUBSYSTEM_IDENTIFIER,
     CODEC,
@@ -332,10 +345,12 @@ export function useRuntimeMacro(): UseRuntimeMacroReturn {
         setHasUnsavedChanges(false);
         return;
       }
-      void loadMacros();
+      // Skip the automatic load when the caller drives load timing itself
+      // (autoLoad: false) -- the clear-on-absent above still runs.
+      if (autoLoad) void loadMacros();
     }, 0);
     return () => window.clearTimeout(timer);
-  }, [loadMacros, subsystemIndex]);
+  }, [autoLoad, loadMacros, subsystemIndex]);
 
   return {
     isAvailable: subsystem !== null,

--- a/src/lib/fastKeymap/__tests__/deferBehaviors.test.ts
+++ b/src/lib/fastKeymap/__tests__/deferBehaviors.test.ts
@@ -1,0 +1,173 @@
+import { loadFastKeymap, FastKeymapCacheKeys } from "../fastKeymap";
+import { FK_DEFINITION_VERSION } from "../standardBehaviors";
+import type {
+  Request,
+  Response,
+  Snapshot,
+} from "../../../proto/cormoran/fast_keymap/fast_keymap";
+
+function memoryStorage(): Storage {
+  const map = new Map<string, string>();
+  return {
+    get length() {
+      return map.size;
+    },
+    clear: () => map.clear(),
+    getItem: (k: string) => map.get(k) ?? null,
+    key: (i: number) => [...map.keys()][i] ?? null,
+    removeItem: (k: string) => map.delete(k),
+    setItem: (k: string, v: string) => {
+      map.set(k, v);
+    },
+  };
+}
+
+const DEVICE = "kbd";
+const BEHAVIORS_FP = 111;
+const PHYS_FP = 222;
+const LAYER_FP = 333;
+
+const SNAPSHOT: Snapshot = {
+  definitionVersion: FK_DEFINITION_VERSION,
+  behaviorsFp: BEHAVIORS_FP,
+  defaultKeymapFp: 0,
+  keymapFp: 0,
+  physicalLayoutFp: PHYS_FP,
+  behaviorCount: 1,
+  maxLayerNameLength: 16,
+  availableLayers: 4,
+  activeLayoutIndex: 0,
+  layers: [
+    {
+      id: 1,
+      name: "base",
+      bindingCount: 1,
+      fp: LAYER_FP,
+      defaultFp: LAYER_FP,
+      editedCount: 0,
+    },
+  ],
+  defFpBits: 16,
+};
+
+/** A `call` that only knows how to answer `get_snapshot`; any other request
+ * (a behavior/layer/layout round-trip) throws, so a test can assert those were
+ * avoided. The layer + layout caches are seeded so only the behaviors decision
+ * is exercised. */
+function snapshotOnlyCall(): jest.Mock<Promise<Response>, [Request]> {
+  return jest.fn(async (req: Request): Promise<Response> => {
+    if (req.getSnapshot) {
+      return { snapshot: SNAPSHOT } as Response;
+    }
+    throw new Error(
+      `unexpected RPC: ${Object.keys(req).join(",")} (should have been cached / deferred)`,
+    );
+  });
+}
+
+function seedLayerAndLayoutCaches(storage: Storage) {
+  // First (only) layer resolves from cache -> no get_layers.
+  storage.setItem(
+    FastKeymapCacheKeys.layer(DEVICE, LAYER_FP),
+    JSON.stringify([{ behaviorId: 42, param1: 4, param2: 0 }]),
+  );
+  // Whole-set layouts cache hit -> no get_physical_layouts.
+  storage.setItem(
+    FastKeymapCacheKeys.layouts(DEVICE),
+    JSON.stringify({
+      fp: PHYS_FP,
+      activeLayoutIndex: 0,
+      layouts: [{ name: "active", fp: 1, keys: [] }],
+    }),
+  );
+}
+
+describe("loadFastKeymap deferBehaviors", () => {
+  it("defers behaviors (no list_behaviors RPC) when the cache is cold", async () => {
+    const storage = memoryStorage();
+    seedLayerAndLayoutCaches(storage);
+    const call = snapshotOnlyCall();
+
+    const model = await loadFastKeymap(call, {
+      deviceKey: DEVICE,
+      storage,
+      firstLayerOnly: true,
+      deferBehaviors: true,
+    });
+
+    expect(model.behaviorsDeferred).toBe(true);
+    expect(model.behaviors).toEqual([]);
+    // The ONLY round-trip was get_snapshot; behaviors were not fetched.
+    expect(call).toHaveBeenCalledTimes(1);
+  });
+
+  it("serves behaviors from the whole-set cache for free (no RPC, not deferred)", async () => {
+    const storage = memoryStorage();
+    seedLayerAndLayoutCaches(storage);
+    // Warm behaviors cache whose fp still matches the snapshot's.
+    storage.setItem(
+      FastKeymapCacheKeys.behaviors(DEVICE),
+      JSON.stringify({
+        fp: BEHAVIORS_FP,
+        defFpBits: 16,
+        behaviors: [
+          {
+            localId: 42,
+            alias: "kp",
+            displayName: "Key Press",
+            defFp: 5,
+            metadata: [],
+          },
+        ],
+      }),
+    );
+    const call = snapshotOnlyCall();
+
+    const model = await loadFastKeymap(call, {
+      deviceKey: DEVICE,
+      storage,
+      firstLayerOnly: true,
+      deferBehaviors: true,
+    });
+
+    expect(model.behaviorsDeferred).toBe(false);
+    expect(model.behaviors).toHaveLength(1);
+    expect(model.behaviors[0].displayName).toBe("Key Press");
+    // Still no behaviors round-trip: only get_snapshot.
+    expect(call).toHaveBeenCalledTimes(1);
+  });
+
+  it("invokes onBehaviorsLoaded before layers on a full (non-deferred) load", async () => {
+    const storage = memoryStorage();
+    seedLayerAndLayoutCaches(storage);
+    // Warm behaviors cache so the full load resolves them without an RPC too.
+    storage.setItem(
+      FastKeymapCacheKeys.behaviors(DEVICE),
+      JSON.stringify({
+        fp: BEHAVIORS_FP,
+        defFpBits: 16,
+        behaviors: [
+          {
+            localId: 42,
+            alias: "kp",
+            displayName: "Key Press",
+            defFp: 5,
+            metadata: [],
+          },
+        ],
+      }),
+    );
+    const call = snapshotOnlyCall();
+    const onBehaviorsLoaded = jest.fn();
+
+    const model = await loadFastKeymap(call, {
+      deviceKey: DEVICE,
+      storage,
+      onBehaviorsLoaded,
+    });
+
+    expect(model.behaviorsDeferred).toBe(false);
+    expect(onBehaviorsLoaded).toHaveBeenCalledTimes(1);
+    expect(onBehaviorsLoaded.mock.calls[0][0]).toHaveLength(1);
+  });
+});

--- a/src/lib/fastKeymap/fastKeymap.ts
+++ b/src/lib/fastKeymap/fastKeymap.ts
@@ -152,6 +152,14 @@ export interface FastKeymapModel {
    * drive incremental "show the first layer, load the rest in the background"
    * loading. */
   pendingLayerIds: number[];
+  /** True when `deferBehaviors` skipped the behavior load this round because it
+   * couldn't be served from the whole-set cache for free -- `behaviors` came
+   * back empty and must be filled by a later (background) full load. False when
+   * behaviors are populated (either not deferred, or a warm-cache hit served
+   * them without an RPC). NOTE: local addition to the vendored upstream model,
+   * used to drive "show the keymap first, resolve behavior labels in the
+   * background" loading. */
+  behaviorsDeferred: boolean;
   stats: FastKeymapLoadStats;
 }
 
@@ -185,6 +193,20 @@ export interface LoadFastKeymapOptions {
    * background with a second (cache-warm) load. NOTE: local addition to the
    * vendored upstream loader. */
   firstLayerOnly?: boolean;
+  /** When `true`, the behavior load is skipped UNLESS the whole set can be
+   * served from cache for free (behaviors_fp still matches -- no `list_behaviors`
+   * / `get_behaviors` round-trip). On a miss, `behaviors` comes back empty and
+   * `FastKeymapModel.behaviorsDeferred` is set, so a consumer can render the
+   * keymap immediately (unresolved bindings show a placeholder) and resolve the
+   * labels via a later (background) full load. NOTE: local addition to the
+   * vendored upstream loader. */
+  deferBehaviors?: boolean;
+  /** Invoked with the resolved behaviors the moment they finish loading, BEFORE
+   * the (slower) layer fetch that follows -- lets a background full load hand
+   * behavior labels to the UI as soon as they're ready rather than at the end.
+   * Not called when the load was deferred to an empty set. NOTE: local addition
+   * to the vendored upstream loader. */
+  onBehaviorsLoaded?: (behaviors: FastKeymapBehavior[]) => void;
 }
 
 function defaultStorage(): Storage | undefined {
@@ -245,15 +267,48 @@ export async function loadFastKeymap(
   // doc comment. A mismatch just means every behavior gets fetched.
   const bundleTrusted = snapshot.definitionVersion === FK_DEFINITION_VERSION;
 
-  const behaviorsResult = await loadBehaviors(
-    call,
-    storage,
-    deviceKey,
-    snapshot,
-    bundleTrusted,
-    includeAliases,
-    includeDisplayNames,
-  );
+  // Behaviors: normally a full load, but with `deferBehaviors` we only take a
+  // free whole-set cache hit and otherwise defer -- so the caller can paint the
+  // keymap before paying for the behavior round-trips (unresolved bindings show
+  // a placeholder until a background full load fills them in).
+  const emptyBehaviorsResult = {
+    behaviors: [] as FastKeymapBehavior[],
+    fromCache: false,
+    bundledCount: 0,
+    cachedCount: 0,
+    fetchedCount: 0,
+  };
+  let behaviorsResult;
+  let behaviorsDeferred = false;
+  if (options.deferBehaviors) {
+    const wholeSet = readWholeSetBehaviorCache(storage, deviceKey, snapshot);
+    if (wholeSet) {
+      behaviorsResult = {
+        ...emptyBehaviorsResult,
+        behaviors: wholeSet,
+        fromCache: true,
+      };
+    } else {
+      behaviorsResult = emptyBehaviorsResult;
+      behaviorsDeferred = true;
+    }
+  } else {
+    behaviorsResult = await loadBehaviors(
+      call,
+      storage,
+      deviceKey,
+      snapshot,
+      bundleTrusted,
+      includeAliases,
+      includeDisplayNames,
+    );
+  }
+  // Hand the freshly-resolved behaviors to a waiting consumer NOW, before the
+  // (slower) layer fetch below -- but not an empty deferred set.
+  if (!behaviorsDeferred && behaviorsResult.behaviors.length > 0) {
+    options.onBehaviorsLoaded?.(behaviorsResult.behaviors);
+  }
+
   const layersResult = await loadLayers(
     call,
     storage,
@@ -277,6 +332,7 @@ export async function loadFastKeymap(
     availableLayers: snapshot.availableLayers,
     maxLayerNameLength: snapshot.maxLayerNameLength,
     pendingLayerIds: layersResult.pendingLayerIds,
+    behaviorsDeferred,
     stats: {
       behaviorsFromCache: behaviorsResult.fromCache,
       behaviorsBundled: behaviorsResult.bundledCount,
@@ -417,6 +473,38 @@ function resolveInline(
   };
 }
 
+/**
+ * The whole-set behaviors fast path (DESIGN.md SS5): when `behaviors_fp` still
+ * matches the last load's, every behavior is exactly as served, so the cached
+ * set can be returned WITHOUT a `list_behaviors` (or any `get_behaviors`)
+ * round-trip. Returns `null` on any miss -- a changed fp, a missing/old-shaped
+ * cache, or a length mismatch -- so the caller falls back to a full load.
+ * Shared by `loadBehaviors` (its fast path) and the `deferBehaviors` path,
+ * which uses it to serve a warm cache for free rather than deferring.
+ */
+function readWholeSetBehaviorCache(
+  storage: Storage | undefined,
+  deviceKey: string,
+  snapshot: Snapshot,
+): FastKeymapBehavior[] | null {
+  const cached = readCache<{
+    fp: number;
+    defFpBits?: number;
+    behaviors: unknown[];
+  }>(storage, FastKeymapCacheKeys.behaviors(deviceKey));
+  if (!cached) return null;
+  const cachedBehaviors = (cached.behaviors ?? []).filter(isSerializedBehavior);
+  // An old-shaped cache (no entries survive the filter, even though `cached`
+  // itself is truthy) is treated as absent, not a match.
+  if (
+    cached.fp !== snapshot.behaviorsFp ||
+    cachedBehaviors.length !== cached.behaviors.length
+  ) {
+    return null;
+  }
+  return cachedBehaviors.map((b) => ({ ...b, resolvedFrom: "cache" as const }));
+}
+
 async function loadBehaviors(
   call: FastKeymapCall,
   storage: Storage | undefined,
@@ -449,19 +537,11 @@ async function loadBehaviors(
 
   // Whole-set fast path: behaviors_fp matches the last load's -> every
   // behavior is still exactly as served, skip list_behaviors entirely (and
-  // so every get_behaviors round-trip with it). An old-shaped cache (no
-  // entries survive the isSerializedBehavior filter, even though `cached`
-  // itself is truthy) is treated as absent, not a match.
-  if (
-    cached &&
-    cached.fp === snapshot.behaviorsFp &&
-    cachedBehaviors.length === cached.behaviors.length
-  ) {
+  // so every get_behaviors round-trip with it).
+  const wholeSet = readWholeSetBehaviorCache(storage, deviceKey, snapshot);
+  if (wholeSet) {
     return {
-      behaviors: cachedBehaviors.map((b) => ({
-        ...b,
-        resolvedFrom: "cache" as const,
-      })),
+      behaviors: wholeSet,
       fromCache: true,
       bundledCount: 0,
       cachedCount: 0,

--- a/src/pages/KeymapPage.tsx
+++ b/src/pages/KeymapPage.tsx
@@ -48,7 +48,10 @@ export function KeymapPage() {
   const keymap = useKeymap();
   const physicalLayoutModules = usePhysicalLayoutModules();
   const sensorRotate = useRuntimeSensorRotate();
-  const runtimeMacro = useRuntimeMacro();
+  // Defer macro loading (see the effect below): the macro list is only needed
+  // to label macro keys, not to paint the preview, so we don't let its RPCs
+  // compete with the keymap load. autoLoad:false suppresses the on-mount fetch.
+  const runtimeMacro = useRuntimeMacro({ autoLoad: false });
   const inputStream = useInputStream();
   // Proactive lock state: the fast-keymap subsystem is unsecured, so the keymap
   // is viewable while Studio is locked. We use this to (a) show a lock badge in
@@ -69,6 +72,9 @@ export function KeymapPage() {
   const [renameValue, setRenameValue] = useState("");
   const [isRenaming, setIsRenaming] = useState(false);
   const renameInputRef = useRef<HTMLInputElement>(null);
+  // Guards the deferred macro load so it fires once per keymap load; reset when
+  // a new load starts (see the effect below).
+  const macrosRequestedRef = useRef(false);
 
   // Get current layer
   const currentLayer = useMemo(() => {
@@ -278,6 +284,32 @@ export function KeymapPage() {
 
     setSelectedLayerIndex(inputStream.activeLayerIndex);
   }, [inputStream.activeLayerIndex, keymap.keymap?.layers]);
+
+  // Load the runtime-macro list as the FINAL step of the keymap tab load: only
+  // after the keymap has fully loaded (preview + background behaviors/layers) so
+  // the macro RPCs (list_macros / get_macro_global_settings) run last instead of
+  // competing with the preview. Fires once per load; reset when a load restarts.
+  const { isAvailable: isMacroAvailable, loadMacros: loadRuntimeMacros } =
+    runtimeMacro;
+  useEffect(() => {
+    if (keymap.isLoading) {
+      macrosRequestedRef.current = false;
+      return;
+    }
+    if (
+      keymap.isFullyLoaded &&
+      isMacroAvailable &&
+      !macrosRequestedRef.current
+    ) {
+      macrosRequestedRef.current = true;
+      void loadRuntimeMacros();
+    }
+  }, [
+    keymap.isLoading,
+    keymap.isFullyLoaded,
+    isMacroAvailable,
+    loadRuntimeMacros,
+  ]);
 
   return (
     <div className="p-6 h-full overflow-auto">


### PR DESCRIPTION
## Description

Makes the fast-keymap load prioritize the **layout + keymap** so the preview paints as fast as possible, then resolves behaviors and the remaining layers in the background.

### What changed
- **Phase 1 (foreground → preview paints):** snapshot + first layer + active layout. Behaviors are now *deferred* unless the whole set can be served from a warm cache for free (fingerprint match, 0 RPCs). Previously `list_behaviors`/`get_behaviors` ran before the layers/layout and blocked the preview.
- **Phase 2 (background):** behaviors + remaining layers. Behaviors are handed to the UI *before* the remaining-layers fetch, via a new `onBehaviorsLoaded` callback, so labels fill in first.
- While behaviors are deferred, unresolved bindings render the existing `—` placeholder — the render path (`formatBehaviorBinding`) already tolerated a missing behavior, so nothing can crash.

### Why
The behavior round-trips were the slowest part of a cold load and were gating the whole preview. Splitting them out lets the keyboard appear immediately. Warm reconnects are unaffected: the whole-set cache still serves behaviors synchronously (no `—` flash).

### Files
- `src/lib/fastKeymap/fastKeymap.ts` — new `deferBehaviors` + `onBehaviorsLoaded` options and a `behaviorsDeferred` model field; extracted `readWholeSetBehaviorCache` (shared by `loadBehaviors`' fast path and the defer path).
- `src/hooks/useKeymapSource.ts` — phase 1 passes `deferBehaviors: true`; background phase delivers behaviors via `onBehaviorsLoaded` and remaining layers via the existing `onLayersLoaded`.
- `src/hooks/useKeymap.ts` — wires `onBehaviorsLoaded` → `setBehaviors`, guarded by the existing load-id so a superseded load can't apply a late update.

### Testing
- New `src/lib/fastKeymap/__tests__/deferBehaviors.test.ts`: asserts no `list_behaviors` RPC when deferred (cold), warm-cache serves behaviors with no RPC and no defer, and `onBehaviorsLoaded` fires before layers on a full load.
- New `useKeymapSource` case: behaviors deferred so the preview returns empty, then filled via `onBehaviorsLoaded`.
- Full suite green (429 passed), typecheck + lint clean.
- Manual (demo mode): keymap + layout render with fully-resolved labels; switching to a background-loaded layer shows its real bindings; no new console errors.

## CLA (Contributor License Agreement)

By submitting this pull request, I agree that my contributions
are licensed under the project's current license.

I also grant the maintainer(s) of this project the right to relicense
my contributions under any license, for use in future versions of the project.
This does not affect the license of any previously released versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)