### PR TITLE
fix(rpc): force fixed-deadline timeout for custom-subsystem calls

### DIFF
--- a/src/hooks/__tests__/useCustomSubsystem.test.tsx
+++ b/src/hooks/__tests__/useCustomSubsystem.test.tsx
@@ -39,8 +39,12 @@ describe("useCustomSubsystem timeout wrapper", () => {
 
     const decoded = await result.current.call?.({ foo: 1 });
     expect(encode).toHaveBeenCalledWith({ foo: 1 });
+    // lastPacketMs is pinned to undefined so the library uses a fixed-deadline
+    // timeout, not a traffic-resettable inactivity window that could hang the
+    // call (and its loading indicator) forever.
     expect(baseCallRPC).toHaveBeenCalledWith(new Uint8Array([9]), {
       timeout: DEFAULT_CUSTOM_SUBSYSTEM_TIMEOUT_MS,
+      lastPacketMs: undefined,
     });
     expect(decode).toHaveBeenCalledWith(responsePayload);
     expect(decoded).toEqual({ decoded: true });
@@ -50,6 +54,7 @@ describe("useCustomSubsystem timeout wrapper", () => {
     await result.current.callRPC(payload);
     expect(baseCallRPC).toHaveBeenCalledWith(payload, {
       timeout: DEFAULT_CUSTOM_SUBSYSTEM_TIMEOUT_MS,
+      lastPacketMs: undefined,
     });
   });
 
@@ -72,6 +77,7 @@ describe("useCustomSubsystem timeout wrapper", () => {
     await result.current.call?.({ foo: 1 }, { timeout: 1234 });
     expect(baseCallRPC).toHaveBeenCalledWith(new Uint8Array([9]), {
       timeout: 1234,
+      lastPacketMs: undefined,
     });
   });
 

--- a/src/hooks/useCustomSubsystem.ts
+++ b/src/hooks/useCustomSubsystem.ts
@@ -1,18 +1,29 @@
 /**
  * App-wide wrapper around `@cormoran/zmk-studio-react-hook`'s
- * `useCustomSubsystem` that raises the per-RPC timeout for every custom
- * subsystem.
+ * `useCustomSubsystem` that gives every custom subsystem a generous *fixed*
+ * per-RPC timeout.
  *
- * Custom-subsystem calls are wrapped in a `withTimeout` (the official
- * `call_rpc` is not), defaulting to 5s. Over slow BLE a single call can exceed
- * that; when it does, the timed-out call abandons the shared RPC mutex
- * mid-read, desyncing the response stream and cascading into "No response"
- * errors across the app. 5s is simply too tight for BLE, so every custom
- * subsystem gets a generous default here. Callers may still pass an explicit
- * `timeout` to override it.
+ * Custom-subsystem calls are wrapped in a timeout (the official `call_rpc` is
+ * not), defaulting to 5s. Over slow BLE a single call can exceed that; when it
+ * does, the timed-out call abandons the shared RPC mutex mid-read, desyncing
+ * the response stream and cascading into "No response" errors across the app.
+ * 5s is simply too tight for BLE, so every custom subsystem gets a generous
+ * default here. Callers may still pass an explicit `timeout` to override it.
+ *
+ * We also pin `lastPacketMs: undefined` on every call. The library otherwise
+ * injects the connection's global last-packet timestamp, which turns the
+ * timeout into a *sliding inactivity window* that resets on **any** transport
+ * byte — not just this call's response. With unrelated traffic flowing (RPC
+ * debug/log streaming, input-event notifications, other subsystems), a request
+ * the device never actually answers keeps having its window pushed out and so
+ * *never times out*: the awaiting hook's `finally` never runs and its loading
+ * indicator spins forever. Forcing `lastPacketMs: undefined` selects the
+ * library's fixed-deadline `withTimeout`, so the call is guaranteed to settle
+ * (resolve or reject) within `timeout` ms and the timeout is reflected to the
+ * UI regardless of background chatter.
  *
  * All app hooks should import `useCustomSubsystem` from here rather than from
- * the library directly, so the raised timeout applies uniformly.
+ * the library directly, so this uniform timeout behavior applies everywhere.
  */
 import { useCallback } from "react";
 import {
@@ -25,6 +36,34 @@ import { logRpc } from "../lib/rpcLogging";
 
 /** Default per-RPC timeout (ms) applied to every custom-subsystem call. */
 export const DEFAULT_CUSTOM_SUBSYSTEM_TIMEOUT_MS = 30_000;
+
+/**
+ * Options accepted by the library's `callRPC`. Its public type only exposes
+ * `timeout`, but the runtime also honors `lastPacketMs` (it injects the
+ * connection's global last-packet clock by default). We set it explicitly to
+ * `undefined` — see the file header for why — which requires naming the field
+ * the public type omits.
+ */
+type BaseCallRpcOptions = {
+  timeout?: number;
+  lastPacketMs?: (() => number) | undefined;
+};
+
+/**
+ * Build the options passed to the library's `callRPC` for every app call:
+ * a generous fixed timeout, `lastPacketMs` pinned to `undefined` so the timeout
+ * is a fixed deadline rather than a traffic-resettable inactivity window, and
+ * any caller overrides applied last. Typed as a variable (not an inline
+ * literal) so it stays assignable to the library's narrower public param type
+ * despite naming `lastPacketMs`.
+ */
+function baseCallOptions(options?: { timeout?: number }): BaseCallRpcOptions {
+  return {
+    timeout: DEFAULT_CUSTOM_SUBSYSTEM_TIMEOUT_MS,
+    lastPacketMs: undefined,
+    ...options,
+  };
+}
 
 export function useCustomSubsystem(
   identifier: string,
@@ -53,11 +92,7 @@ export function useCustomSubsystem<TReq, TRes>(
       logRpc(
         `custom:${identifier}`,
         payload,
-        () =>
-          baseCallRPC(payload, {
-            timeout: DEFAULT_CUSTOM_SUBSYSTEM_TIMEOUT_MS,
-            ...options,
-          }),
+        () => baseCallRPC(payload, baseCallOptions(options)),
         {
           request: () => payload.byteLength,
           response: (res) => res?.byteLength,
@@ -78,10 +113,10 @@ export function useCustomSubsystem<TReq, TRes>(
         `custom:${identifier}`,
         request,
         async () => {
-          const responsePayload = await baseCallRPC(payload, {
-            timeout: DEFAULT_CUSTOM_SUBSYSTEM_TIMEOUT_MS,
-            ...options,
-          });
+          const responsePayload = await baseCallRPC(
+            payload,
+            baseCallOptions(options),
+          );
           responseBytes = responsePayload?.byteLength;
           return responsePayload === null
             ? null


### PR DESCRIPTION
## Problem

A timed-out device request was not reflected in the UI — the loading indicator kept spinning forever.

## Root cause

Every custom-subsystem RPC goes through the app wrapper in `src/hooks/useCustomSubsystem.ts`, which sets a 30s timeout and whose docs describe it as a fixed `withTimeout`. But the underlying library's `useCustomSubsystem` silently injects the connection's **global** `lastPacketMs` into every `callRPC`. When `lastPacketMs` is present, `ZMKCustomSubsystem.callRPC` switches from a fixed deadline (`withTimeout`) to a **sliding inactivity window** (`withActivityTimeout`) that resets on *any* transport byte — not just this call's response.

So if the device never answers a particular request while **any** background traffic flows — RPC debug/log streaming (recently enabled in dev/preview), input-event notifications, other subsystems — the window keeps getting pushed out and the timeout **never fires**. The awaiting hook's `await call(...)` never settles, its `finally { setIsLoading(false) }` never runs, and the loading indicator spins indefinitely.

## Fix

Pin `lastPacketMs: undefined` on every custom-subsystem call so the library uses its fixed-deadline `withTimeout` path. The call is now guaranteed to reject within the 30s timeout regardless of background chatter, so the hook's `catch`/`finally` runs and the timeout surfaces as an error with the spinner cleared.

Because the library's *public* `callRPC` type only exposes `{ timeout }` (it omits `lastPacketMs`, though the runtime honors it), the options are built in a small typed `baseCallOptions()` helper — a typed variable, unlike a fresh literal, stays assignable to the narrower public param type despite naming the field.

This covers all custom-subsystem paths: BLE profiles, custom settings, combos, macros, input processor, sensor rotate, pmw3610, kscan, and fast keymap.

## Testing

- `tsc` clean, eslint clean
- Updated `useCustomSubsystem.test.tsx` to assert `lastPacketMs: undefined` is passed
- All hook tests pass (56/56); full suite green via pre-commit hook

## Note / out of scope

The official `call_rpc` path (legacy keymap protocol) has **no** per-call timeout at all — a separate, pre-existing gap not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)