### PR TITLE
fix(device-info): keep "empty" device visible but out of not-ready count

### DIFF
--- a/src/components/troubleshooting/DeviceInfoSection.tsx
+++ b/src/components/troubleshooting/DeviceInfoSection.tsx
@@ -47,11 +47,15 @@ export function DeviceInfoSection({
   const { isAvailable, info, isLoading, error, refresh } = deviceInfo;
 
   // Devices with an empty name are internal/hidden Zephyr devices that are
-  // normally left uninitialized — exclude them from the "not ready" count
-  // and the list so they don't inflate it with noise.
+  // normally left uninitialized — exclude them from the list entirely.
   const namedDevices =
     info?.zephyrDevices.filter((d) => d.name.trim() !== "") ?? [];
-  const notReadyCount = namedDevices.filter((d) => !d.ready).length;
+  // Devices literally named "empty" always report as not ready, so keep them
+  // visible in the list but exclude them from the "not ready" count and badge
+  // so they don't inflate it with noise.
+  const notReadyCount = namedDevices.filter(
+    (d) => !d.ready && d.name.trim().toLowerCase() !== "empty",
+  ).length;
 
   return (
     <SectionCard


### PR DESCRIPTION
## Description

Firmware reports an internal Zephyr device literally named `empty` that always
reports as **not ready**. This was inflating the Device Info section's "devices
not ready" count and summary badge with noise.

This change excludes `empty`-named devices from the not-ready count and badge,
while still showing them as-is (with their `✗` marker) in the Zephyr Devices
list, so nothing is hidden from view. Devices with an actual empty-string name
remain fully excluded from the list, as before.

Only the counting logic changed in `DeviceInfoSection.tsx`; the list rendering
is untouched. Typecheck and the existing test suite pass.

## CLA (Contributor License Agreement)

By submitting this pull request, I agree that my contributions
are licensed under the project's current license.

I also grant the maintainer(s) of this project the right to relicense
my contributions under any license, for use in future versions of the project.
This does not affect the license of any previously released versions.
