### PR TITLE
perf(trackball): lazy-load PMW3610 settings until section is expanded

### DIFF
--- a/src/components/TrackballAdvancedSettings.tsx
+++ b/src/components/TrackballAdvancedSettings.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import {
   IconChevronDown,
   IconChevronRight,
@@ -19,8 +19,27 @@ import { useLanguage } from "../hooks/useLanguage";
 export function TrackballAdvancedSettings() {
   const { t } = useLanguage();
   const [isExpanded, setIsExpanded] = useState(false);
-  const customSettings = useCustomSettings();
+  // Latch true once the section is first opened and stay true (a collapsed
+  // reopen shouldn't re-fetch).
+  const [hasExpanded, setHasExpanded] = useState(false);
+  // Defer loading the PMW3610 settings until the section is first expanded so
+  // opening the Trackball tab doesn't trigger the custom-settings RPC.
+  const customSettings = useCustomSettings({ autoLoad: false });
   const { keymap, behaviors, isLoading: keymapLoading } = useKeymap();
+
+  const handleToggle = () => {
+    setIsExpanded((expanded) => !expanded);
+    setHasExpanded(true);
+  };
+
+  // Once expanded, load reactively — mirroring the hook's default auto-load —
+  // so a not-yet-ready subsystem still loads once it becomes ready.
+  const { loadSettings } = customSettings;
+  useEffect(() => {
+    if (hasExpanded) {
+      void loadSettings();
+    }
+  }, [hasExpanded, loadSettings]);
 
   const layers = useMemo(
     () =>
@@ -47,7 +66,7 @@ export function TrackballAdvancedSettings() {
       <button
         type="button"
         className="flex w-full items-center justify-between gap-3 p-6 text-left"
-        onClick={() => setIsExpanded((expanded) => !expanded)}
+        onClick={handleToggle}
         aria-expanded={isExpanded}
       >
         <div>

--- a/src/hooks/useCustomSettings.ts
+++ b/src/hooks/useCustomSettings.ts
@@ -121,7 +121,17 @@ async function withTimeout<T>(
   }
 }
 
-export function useCustomSettings(): UseCustomSettingsReturn {
+export interface UseCustomSettingsOptions {
+  // When false, settings are not fetched on mount; the caller drives the
+  // initial load by calling loadSettings() (e.g. when a collapsed section is
+  // expanded). Defaults to true.
+  autoLoad?: boolean;
+}
+
+export function useCustomSettings(
+  options?: UseCustomSettingsOptions,
+): UseCustomSettingsReturn {
+  const { autoLoad = true } = options ?? {};
   const { t } = useLanguage();
   const zmkApp = useContext(ZMKAppContext);
   const { subsystem, ready, call } = useCustomSubsystem(
@@ -433,8 +443,11 @@ export function useCustomSettings(): UseCustomSettingsReturn {
   }, [settings, subsystemIdentifierForIndex]);
 
   useEffect(() => {
+    if (!autoLoad) {
+      return;
+    }
     void loadSettings();
-  }, [loadSettings]);
+  }, [autoLoad, loadSettings]);
 
   return {
     isAvailable: subsystem !== null,


### PR DESCRIPTION
## What

Defer loading the PMW3610 sensor settings on the Trackball page until the **Advanced (PMW3610 Sensor Driver)** section is first expanded, instead of fetching them as soon as the tab opens.

## Why

`TrackballAdvancedSettings` calls `useCustomSettings()`, whose mount `useEffect` fired `loadSettings()` (the custom-settings list RPC) immediately — so simply opening the Trackball tab triggered the sensor-settings load even while the section was collapsed and the data was never shown.

## How

- **`useCustomSettings`**: added an optional `{ autoLoad?: boolean }` param, defaulting to `true`. When `false`, the mount effect skips the initial fetch and the caller drives loading. Existing callers (`AdvancedSettingsSection`) are unaffected.
- **`TrackballAdvancedSettings`**: passes `{ autoLoad: false }`, latches a `hasExpanded` flag in the section's toggle handler, and loads reactively once expanded. Loading reactively (rather than a one-shot) keeps the original behavior of loading once the subsystem becomes `ready`; latching means a collapse-then-reopen doesn't re-fetch.

## Verification

Driven in the browser (demo mode) with the demo transport instrumented to count RPC requests:

- **Trackball tab open, section collapsed:** 0 custom-settings RPCs.
- **On expanding the section:** the `custom` PMW3610 list RPC fires and the section loads.

`tsc`, ESLint, and the full Jest suite (run via the pre-commit hook) all pass.

Note: the "No pmw3610 driver settings were reported" text visible in demo mode is pre-existing behavior — the demo registers its mock settings under the `cormoran_custom_settings` subsystem, never `cormoran__pmw3610` — and is not affected by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)