### PR TITLE
feat(logging): log device notifications like custom RPC traffic

### DIFF
--- a/src/components/DeviceConnection.tsx
+++ b/src/components/DeviceConnection.tsx
@@ -1,5 +1,12 @@
 import type { ReactNode } from "react";
-import { createContext, useCallback, useEffect, useRef, useState } from "react";
+import {
+  createContext,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import type { RpcTransport } from "@zmkfirmware/zmk-studio-ts-client/transport/index";
 import {
   useZMKApp,
@@ -11,6 +18,10 @@ import type { UseZMKAppOptions } from "@cormoran/zmk-studio-react-hook";
 import { connect as connectBLE } from "@zmkfirmware/zmk-studio-ts-client/transport/gatt";
 import { connect as connectUSB } from "../lib/transport/usb";
 import { connect as connectDemo } from "../lib/transport/demo";
+import {
+  describeCustomNotification,
+  withLoggedNotifications,
+} from "../lib/rpcLogging";
 
 export type ConnectionMethod = "serial" | "ble" | "demo";
 
@@ -77,6 +88,23 @@ export function DeviceConnectionProvider({
 }: DeviceConnectionProviderProps) {
   const zmkApp = useZMKApp({ connectTimeoutMs });
   const [isReconnecting, setIsReconnecting] = useState(false);
+
+  // Dev-only: log every notification pushed from the device, mirroring the RPC
+  // logging that wraps outbound calls. Wrap the shared `zmkApp` once here so all
+  // consumers (which read it from `ZMKAppContext`) are covered without touching
+  // each `onNotification` call site. A no-op passthrough in the production build.
+  const loggedZmkApp = useMemo(
+    () => ({
+      ...zmkApp,
+      onNotification: withLoggedNotifications(zmkApp.onNotification, (index) =>
+        describeCustomNotification(
+          index,
+          zmkApp.state.customSubsystems?.subsystems,
+        ),
+      ),
+    }),
+    [zmkApp],
+  );
 
   // Guards against React StrictMode's double-invoke of effects triggering
   // the auto-reconnect attempt twice.
@@ -190,7 +218,7 @@ export function DeviceConnectionProvider({
   };
 
   return (
-    <ZMKAppContext.Provider value={zmkApp}>
+    <ZMKAppContext.Provider value={loggedZmkApp}>
       <ConnectionContext.Provider value={connectionValue}>
         {children}
       </ConnectionContext.Provider>

--- a/src/lib/__tests__/rpcLogging.test.ts
+++ b/src/lib/__tests__/rpcLogging.test.ts
@@ -1,5 +1,10 @@
 import { Request } from "@zmkfirmware/zmk-studio-ts-client";
-import { describeOfficialRequest, protoByteLength } from "../rpcLogging";
+import type { CustomSubsystemInfo } from "@zmkfirmware/zmk-studio-ts-client/custom";
+import {
+  describeCustomNotification,
+  describeOfficialRequest,
+  protoByteLength,
+} from "../rpcLogging";
 
 describe("describeOfficialRequest", () => {
   it("derives subsystem.method from an official request", () => {
@@ -19,6 +24,24 @@ describe("describeOfficialRequest", () => {
     expect(describeOfficialRequest(null)).toBe("unknown");
     expect(describeOfficialRequest({})).toBe("unknown");
     expect(describeOfficialRequest("nope")).toBe("unknown");
+  });
+});
+
+describe("describeCustomNotification", () => {
+  const subsystems: CustomSubsystemInfo[] = [
+    { index: 3, identifier: "cormoran__watchdog", uiUrl: [] },
+    { index: 7, identifier: "cormoran__pmw3610", uiUrl: [] },
+  ];
+
+  it("resolves a subsystem index to its identifier by matching index (not array position)", () => {
+    expect(describeCustomNotification(7, subsystems)).toBe(
+      "custom:cormoran__pmw3610",
+    );
+  });
+
+  it("falls back to the raw index when the subsystem list is missing or unmatched", () => {
+    expect(describeCustomNotification(3, undefined)).toBe("custom:#3");
+    expect(describeCustomNotification(99, subsystems)).toBe("custom:#99");
   });
 });
 

--- a/src/lib/rpcLogging.ts
+++ b/src/lib/rpcLogging.ts
@@ -20,6 +20,11 @@ import {
   Request,
   RequestResponse,
 } from "@zmkfirmware/zmk-studio-ts-client";
+import type {
+  CustomNotification,
+  CustomSubsystemInfo,
+} from "@zmkfirmware/zmk-studio-ts-client/custom";
+import type { NotificationSubscription } from "@cormoran/zmk-studio-react-hook";
 import { RPC_LOG_ENABLED } from "./viteEnv";
 
 /** Monotonic id so a request line and its response line can be matched even
@@ -111,6 +116,109 @@ export function protoByteLength<M>(
   } catch {
     return undefined;
   }
+}
+
+/**
+ * Notifications already logged, so a single device push isn't logged once per
+ * subscriber. The library fan-outs the *same* notification object to every
+ * registered callback for a given type/subsystem (see `dispatchNotification` /
+ * `dispatchCustomNotification` in `useZMKApp`), and several hooks subscribe to
+ * the same stream (e.g. `core` from both {@link useKeymap} and {@link usePmw3610}).
+ * Keying on object identity lets us log each notification exactly once. Weak so
+ * entries are collected with the notification itself.
+ */
+const loggedNotifications = new WeakSet<object>();
+
+/**
+ * Log a single inbound notification pushed from the device, mirroring
+ * {@link logRpc} for the unsolicited direction. Unlike an RPC there is no
+ * request/response/duration — just the notification payload and, for custom
+ * subsystems, its encoded byte size.
+ *
+ * A no-op in the production release (gated on {@link RPC_LOG_ENABLED}), and
+ * deduped by object identity so overlapping subscribers don't double-log.
+ *
+ * @param label - `core`, `keymap`, or `custom:<identifier>` (see {@link describeCustomNotification})
+ * @param notification - The decoded (core/keymap) or raw (custom) notification
+ * @param bytes - Optional lazy reporter for the payload byte size
+ */
+export function logNotification(
+  label: string,
+  notification: unknown,
+  bytes?: () => number | undefined,
+): void {
+  if (!RPC_LOG_ENABLED) return;
+
+  if (notification && typeof notification === "object") {
+    if (loggedNotifications.has(notification)) return;
+    loggedNotifications.add(notification);
+  }
+
+  console.debug(`[rpc ⇐] ${label}${bytesLabel(bytes?.())}`, notification);
+}
+
+/**
+ * Derive a notification label from a custom subsystem index, resolving it to
+ * `custom:<identifier>` (matching the `custom:<identifier>` label {@link logRpc}
+ * uses for outbound calls). Falls back to `custom:#<index>` when the subsystem
+ * list is unavailable or the index isn't found — `index` is the device-assigned
+ * `CustomSubsystemInfo.index`, not the array position.
+ */
+export function describeCustomNotification(
+  subsystemIndex: number,
+  subsystems: readonly CustomSubsystemInfo[] | undefined,
+): string {
+  const identifier = subsystems?.find(
+    (s) => s.index === subsystemIndex,
+  )?.identifier;
+  return identifier ? `custom:${identifier}` : `custom:#${subsystemIndex}`;
+}
+
+/**
+ * Wrap an `onNotification` subscriber so every notification it receives is
+ * logged via {@link logNotification}. Returns the original function untouched in
+ * the production release so there's zero overhead and Vite tree-shakes the
+ * logging away.
+ *
+ * Applied once to the shared `zmkApp` (see {@link DeviceConnectionProvider}) so
+ * all current and future subscribers are covered without wrapping each call
+ * site; per-notification dedup keeps overlapping subscribers to one line each.
+ *
+ * @param onNotification - The app's `zmkApp.onNotification`
+ * @param describeCustom - Resolves a custom `subsystemIndex` to a label, given
+ *   the connected device's subsystem list
+ */
+export function withLoggedNotifications(
+  onNotification: (subscription: NotificationSubscription) => () => void,
+  describeCustom: (subsystemIndex: number) => string,
+): (subscription: NotificationSubscription) => () => void {
+  if (!RPC_LOG_ENABLED) return onNotification;
+
+  return (subscription) => {
+    const label =
+      subscription.type === "custom"
+        ? describeCustom(subscription.subsystemIndex)
+        : subscription.type;
+
+    // Rebuild the union member with a wrapped callback. TS can't narrow the
+    // callback parameter across the union after the spread, so the cast keeps
+    // the discriminant intact while re-typing only the callback.
+    const logged = {
+      ...subscription,
+      callback: (notification: never) => {
+        logNotification(
+          label,
+          notification,
+          subscription.type === "custom"
+            ? () => (notification as CustomNotification).payload?.byteLength
+            : undefined,
+        );
+        subscription.callback(notification);
+      },
+    } as NotificationSubscription;
+
+    return onNotification(logged);
+  };
 }
 
 /** The subsystem oneof fields on an official `Request`, in wire order. */


### PR DESCRIPTION
## Description

The dev-only RPC logging in `rpcLogging.ts` wraps **outbound** calls (`loggedCallRpc` for official RPC and `logRpc` for custom subsystems) but never logged the **inbound** direction — the notifications the device pushes via `zmkApp.onNotification`. This adds matching logging for those, so BLE-triggered device notifications show up alongside the request/response lines when debugging.

### What changed

**`src/lib/rpcLogging.ts`** — three new exports:
- `logNotification(label, notification, bytes?)` — logs a `[rpc ⇐] <label> · <N>B` line mirroring the outbound `[rpc #n →/←]` format. Deduped by a `WeakSet` on the notification object, because the library fans the *same* notification object out to every subscriber and several hooks subscribe to the same stream (e.g. `core` from both `useKeymap` and `usePmw3610`) — so each device push logs exactly once.
- `describeCustomNotification(index, subsystems)` — resolves a custom subsystem index to a `custom:<identifier>` label (matching the outbound label format), matching on `CustomSubsystemInfo.index` (device-assigned, not array position), with a `custom:#<index>` fallback.
- `withLoggedNotifications(onNotification, describeCustom)` — wraps an `onNotification` so every subscriber's callback logs first. Returns the original untouched in production.

**`src/components/DeviceConnection.tsx`** — wraps the shared `zmkApp` once in the provider (`useMemo`) before putting it on `ZMKAppContext`. Since all notification subscribers read `zmkApp` from that context, this covers every current and future `onNotification` call site without touching any of them.

All of this is gated behind `RPC_LOG_ENABLED`, so the production release gets neither the log noise nor the overhead (Vite tree-shakes the branch away).

### Verification
- Typecheck, lint, full test suite (433 passing, incl. new `describeCustomNotification` cases), and production build all green.
- Exercised the real logger in the running dev app: emitted `[rpc ⇐] custom:cormoran__watchdog · 4B` and `[rpc ⇐] keymap`, resolved the identifier correctly, and deduped a repeat call on the same notification object.

## CLA (Contributor License Agreement)

By submitting this pull request, I agree that my contributions
are licensed under the project's current license.

I also grant the maintainer(s) of this project the right to relicense
my contributions under any license, for use in future versions of the project.
This does not affect the license of any previously released versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)