### PR TITLE
feat(logging): decode custom-subsystem notification payloads in RPC log

### DIFF
--- a/src/components/DeviceConnection.tsx
+++ b/src/components/DeviceConnection.tsx
@@ -19,7 +19,7 @@ import { connect as connectBLE } from "@zmkfirmware/zmk-studio-ts-client/transpo
 import { connect as connectUSB } from "../lib/transport/usb";
 import { connect as connectDemo } from "../lib/transport/demo";
 import {
-  describeCustomNotification,
+  resolveCustomSubsystemIdentifier,
   withLoggedNotifications,
 } from "../lib/rpcLogging";
 
@@ -97,7 +97,7 @@ export function DeviceConnectionProvider({
     () => ({
       ...zmkApp,
       onNotification: withLoggedNotifications(zmkApp.onNotification, (index) =>
-        describeCustomNotification(
+        resolveCustomSubsystemIdentifier(
           index,
           zmkApp.state.customSubsystems?.subsystems,
         ),

--- a/src/lib/__tests__/customNotificationCodecs.test.ts
+++ b/src/lib/__tests__/customNotificationCodecs.test.ts
@@ -1,0 +1,31 @@
+import { Notification as WatchdogNotification } from "../../proto/cormoran/watchdog/watchdog";
+import { decodeCustomNotification } from "../customNotificationCodecs";
+
+describe("decodeCustomNotification", () => {
+  it("decodes a payload with its subsystem's Notification proto", () => {
+    const notification = WatchdogNotification.fromPartial({
+      peripheralResponse: { sourceKeyboardIndex: 2 },
+    });
+    const payload = WatchdogNotification.encode(notification).finish();
+
+    expect(decodeCustomNotification("cormoran__watchdog", payload)).toEqual(
+      WatchdogNotification.decode(payload),
+    );
+  });
+
+  it("returns undefined for an unregistered subsystem identifier", () => {
+    const payload = new Uint8Array([1, 2, 3]);
+    expect(
+      decodeCustomNotification("cormoran__unknown", payload),
+    ).toBeUndefined();
+  });
+
+  it("returns undefined when the identifier or payload is absent", () => {
+    expect(
+      decodeCustomNotification(undefined, new Uint8Array([1])),
+    ).toBeUndefined();
+    expect(
+      decodeCustomNotification("cormoran__watchdog", undefined),
+    ).toBeUndefined();
+  });
+});

--- a/src/lib/__tests__/rpcLogging.test.ts
+++ b/src/lib/__tests__/rpcLogging.test.ts
@@ -4,6 +4,7 @@ import {
   describeCustomNotification,
   describeOfficialRequest,
   protoByteLength,
+  resolveCustomSubsystemIdentifier,
 } from "../rpcLogging";
 
 describe("describeOfficialRequest", () => {
@@ -42,6 +43,24 @@ describe("describeCustomNotification", () => {
   it("falls back to the raw index when the subsystem list is missing or unmatched", () => {
     expect(describeCustomNotification(3, undefined)).toBe("custom:#3");
     expect(describeCustomNotification(99, subsystems)).toBe("custom:#99");
+  });
+});
+
+describe("resolveCustomSubsystemIdentifier", () => {
+  const subsystems: CustomSubsystemInfo[] = [
+    { index: 3, identifier: "cormoran__watchdog", uiUrl: [] },
+    { index: 7, identifier: "cormoran__pmw3610", uiUrl: [] },
+  ];
+
+  it("resolves a subsystem index to its identifier by matching index", () => {
+    expect(resolveCustomSubsystemIdentifier(7, subsystems)).toBe(
+      "cormoran__pmw3610",
+    );
+  });
+
+  it("returns undefined when the subsystem list is missing or unmatched", () => {
+    expect(resolveCustomSubsystemIdentifier(3, undefined)).toBeUndefined();
+    expect(resolveCustomSubsystemIdentifier(99, subsystems)).toBeUndefined();
   });
 });
 

--- a/src/lib/customNotificationCodecs.ts
+++ b/src/lib/customNotificationCodecs.ts
@@ -1,0 +1,68 @@
+/**
+ * Registry of custom-subsystem notification decoders, keyed by subsystem
+ * identifier, used only by the dev RPC logging ({@link decodeCustomNotification}).
+ *
+ * A custom-subsystem notification arrives as a raw `Uint8Array` payload — the
+ * device doesn't tell the transport which proto it is; each subsystem's hook
+ * decodes it with its own `Notification` proto (e.g. {@link usePmw3610},
+ * {@link useWatchdog}). The generic logging layer sits below those hooks and has
+ * only the payload bytes, so without this map it can only log the raw bytes.
+ * This mirrors each hook's `Notification.decode` so the log shows the decoded
+ * payload instead.
+ *
+ * This whole module is referenced only from inside the `RPC_LOG_ENABLED` branch
+ * of {@link withLoggedNotifications}; when that flag folds to `false` in the
+ * production release, the reference is dead code and Vite tree-shakes this
+ * module (and its proto imports) out of the bundle.
+ */
+import { Notification as WatchdogNotification } from "../proto/cormoran/watchdog/watchdog";
+import { Notification as InputStreamNotification } from "../proto/zmk/input_stream/input_stream";
+import { Notification as RuntimeInputProcessorNotification } from "../proto/zmk/runtime_input_processor/runtime_input_processor";
+import { Notification as CustomSettingsNotification } from "../proto/cormoran/zmk/custom_settings/custom_settings";
+import { Notification as SettingsNotification } from "../proto/zmk/settings/core";
+import { Notification as Pmw3610Notification } from "../proto/cormoran/pmw3610/pmw3610";
+import { Notification as DevtoolNotification } from "../proto/cormoran/devtool/devtool";
+
+/**
+ * Notification decoders per subsystem identifier. Each identifier matches the
+ * one its hook passes to `useCustomSubsystem`, and each decoder is that hook's
+ * own `Notification` proto (see the corresponding `use*` hook). Identifiers
+ * absent here (or notifications that fail to decode) fall back to raw-byte
+ * logging.
+ */
+const CUSTOM_NOTIFICATION_DECODERS: Record<
+  string,
+  (payload: Uint8Array) => unknown
+> = {
+  cormoran__watchdog: (payload) => WatchdogNotification.decode(payload),
+  zmk__input_stream: (payload) => InputStreamNotification.decode(payload),
+  cormoran_rip: (payload) => RuntimeInputProcessorNotification.decode(payload),
+  cormoran_custom_settings: (payload) =>
+    CustomSettingsNotification.decode(payload),
+  zmk__settings: (payload) => SettingsNotification.decode(payload),
+  cormoran__pmw3610: (payload) => Pmw3610Notification.decode(payload),
+  cormoran__devtool: (payload) => DevtoolNotification.decode(payload),
+};
+
+/**
+ * Decode a custom-subsystem notification payload for logging, or `undefined`
+ * when the subsystem has no registered decoder (unknown identifier) or the
+ * payload fails to decode — in which case the caller logs the raw bytes.
+ *
+ * @param identifier - The subsystem identifier (e.g. `cormoran__watchdog`), or
+ *   `undefined` when the index couldn't be resolved to one
+ * @param payload - The raw notification payload bytes
+ */
+export function decodeCustomNotification(
+  identifier: string | undefined,
+  payload: Uint8Array | undefined,
+): unknown {
+  if (identifier === undefined || payload === undefined) return undefined;
+  const decode = CUSTOM_NOTIFICATION_DECODERS[identifier];
+  if (!decode) return undefined;
+  try {
+    return decode(payload);
+  } catch {
+    return undefined;
+  }
+}

--- a/src/lib/rpcLogging.ts
+++ b/src/lib/rpcLogging.ts
@@ -26,6 +26,7 @@ import type {
 } from "@zmkfirmware/zmk-studio-ts-client/custom";
 import type { NotificationSubscription } from "@cormoran/zmk-studio-react-hook";
 import { RPC_LOG_ENABLED } from "./viteEnv";
+import { decodeCustomNotification } from "./customNotificationCodecs";
 
 /** Monotonic id so a request line and its response line can be matched even
  * when several BLE calls are in flight at once. */
@@ -139,13 +140,20 @@ const loggedNotifications = new WeakSet<object>();
  * deduped by object identity so overlapping subscribers don't double-log.
  *
  * @param label - `core`, `keymap`, or `custom:<identifier>` (see {@link describeCustomNotification})
- * @param notification - The decoded (core/keymap) or raw (custom) notification
- * @param bytes - Optional lazy reporter for the payload byte size
+ * @param notification - The raw notification object; also the dedup key, so it
+ *   must be the same object the library fans out to every subscriber
+ * @param options.bytes - Optional lazy reporter for the payload byte size
+ * @param options.decoded - Decoded payload to display in place of the raw
+ *   notification (for custom subsystems, whose payload is otherwise raw bytes);
+ *   the raw `notification` is still used for dedup
  */
 export function logNotification(
   label: string,
   notification: unknown,
-  bytes?: () => number | undefined,
+  options?: {
+    bytes?: () => number | undefined;
+    decoded?: unknown;
+  },
 ): void {
   if (!RPC_LOG_ENABLED) return;
 
@@ -154,7 +162,32 @@ export function logNotification(
     loggedNotifications.add(notification);
   }
 
-  console.debug(`[rpc ⇐] ${label}${bytesLabel(bytes?.())}`, notification);
+  console.debug(
+    `[rpc ⇐] ${label}${bytesLabel(options?.bytes?.())}`,
+    options?.decoded ?? notification,
+  );
+}
+
+/**
+ * Resolve a custom subsystem index to its device-assigned `identifier`, or
+ * `undefined` when the subsystem list is unavailable or the index isn't found.
+ * `index` is the device-assigned `CustomSubsystemInfo.index`, not the array
+ * position.
+ */
+export function resolveCustomSubsystemIdentifier(
+  subsystemIndex: number,
+  subsystems: readonly CustomSubsystemInfo[] | undefined,
+): string | undefined {
+  return subsystems?.find((s) => s.index === subsystemIndex)?.identifier;
+}
+
+/** Build a `custom:<identifier>` label (matching the outbound label {@link logRpc}
+ * uses), falling back to `custom:#<index>` when the identifier is unknown. */
+function customNotificationLabel(
+  identifier: string | undefined,
+  subsystemIndex: number,
+): string {
+  return identifier ? `custom:${identifier}` : `custom:#${subsystemIndex}`;
 }
 
 /**
@@ -168,10 +201,10 @@ export function describeCustomNotification(
   subsystemIndex: number,
   subsystems: readonly CustomSubsystemInfo[] | undefined,
 ): string {
-  const identifier = subsystems?.find(
-    (s) => s.index === subsystemIndex,
-  )?.identifier;
-  return identifier ? `custom:${identifier}` : `custom:#${subsystemIndex}`;
+  return customNotificationLabel(
+    resolveCustomSubsystemIdentifier(subsystemIndex, subsystems),
+    subsystemIndex,
+  );
 }
 
 /**
@@ -184,20 +217,28 @@ export function describeCustomNotification(
  * all current and future subscribers are covered without wrapping each call
  * site; per-notification dedup keeps overlapping subscribers to one line each.
  *
+ * Custom-subsystem payloads arrive as raw bytes; when the subsystem has a
+ * registered decoder (see {@link decodeCustomNotification}) the log shows the
+ * decoded payload instead of the byte data.
+ *
  * @param onNotification - The app's `zmkApp.onNotification`
- * @param describeCustom - Resolves a custom `subsystemIndex` to a label, given
- *   the connected device's subsystem list
+ * @param resolveCustomIdentifier - Resolves a custom `subsystemIndex` to its
+ *   subsystem identifier, given the connected device's subsystem list
  */
 export function withLoggedNotifications(
   onNotification: (subscription: NotificationSubscription) => () => void,
-  describeCustom: (subsystemIndex: number) => string,
+  resolveCustomIdentifier: (subsystemIndex: number) => string | undefined,
 ): (subscription: NotificationSubscription) => () => void {
   if (!RPC_LOG_ENABLED) return onNotification;
 
   return (subscription) => {
+    const identifier =
+      subscription.type === "custom"
+        ? resolveCustomIdentifier(subscription.subsystemIndex)
+        : undefined;
     const label =
       subscription.type === "custom"
-        ? describeCustom(subscription.subsystemIndex)
+        ? customNotificationLabel(identifier, subscription.subsystemIndex)
         : subscription.type;
 
     // Rebuild the union member with a wrapped callback. TS can't narrow the
@@ -206,13 +247,17 @@ export function withLoggedNotifications(
     const logged = {
       ...subscription,
       callback: (notification: never) => {
-        logNotification(
-          label,
-          notification,
-          subscription.type === "custom"
-            ? () => (notification as CustomNotification).payload?.byteLength
-            : undefined,
-        );
+        if (subscription.type === "custom") {
+          const payload = (notification as CustomNotification).payload;
+          logNotification(label, notification, {
+            bytes: () => payload?.byteLength,
+            // Show the decoded payload rather than raw bytes; falls back to the
+            // raw notification when the subsystem has no decoder or decode fails.
+            decoded: decodeCustomNotification(identifier, payload),
+          });
+        } else {
+          logNotification(label, notification);
+        }
         subscription.callback(notification);
       },
     } as NotificationSubscription;


### PR DESCRIPTION
## What

The dev RPC logging (added in #125) logs inbound device notifications, but for **custom subsystems** it printed the raw `Uint8Array` payload instead of the decoded message. This decodes those payloads so the log shows the actual notification.

## Why

A custom-subsystem notification arrives at the generic logging layer as opaque bytes — the device doesn't tell the transport which proto it is; each subsystem's hook decodes it with its own `Notification` proto (e.g. `usePmw3610`, `useWatchdog`). The logging layer sits below those hooks and only had the bytes, so it could only log `Uint8Array(…)`.

## How

- **New `src/lib/customNotificationCodecs.ts`** — a registry mapping each subsystem identifier to its hook's own `Notification` proto (every subsystem in the repo that exports one: `cormoran__watchdog`, `zmk__input_stream`, `cormoran_rip`, `cormoran_custom_settings`, `zmk__settings`, `cormoran__pmw3610`, `cormoran__devtool`). `decodeCustomNotification(identifier, payload)` returns the decoded object, or `undefined` on unknown identifier / decode failure.
- **`rpcLogging.ts`** — `logNotification` now takes a `decoded` display value; it still dedups on the raw notification object (the identity the library fans out to every subscriber), but displays the decoded payload. `withLoggedNotifications` resolves the subsystem *identifier* (new exported `resolveCustomSubsystemIdentifier`), decodes the payload, and shows it; falls back to raw bytes when there's no decoder. `describeCustomNotification` is kept, now built on the resolver.
- **`DeviceConnection.tsx`** — passes the identifier resolver instead of a label builder.

## Reviewer notes

- **Tree-shaking preserved**: the decode path is referenced only inside the `RPC_LOG_ENABLED` branch, so Vite still eliminates the codecs module and its proto imports from the production release bundle.
- Subsystems without a registered decoder (or payloads that fail to decode) fall back to the previous raw-byte logging — no behavior change for them.
- Dev-console-only behavior; not driven in a browser since it requires real hardware pushing custom notifications. Covered by unit tests instead: decode round-trip + both fallbacks in `customNotificationCodecs.test.ts`, and `resolveCustomSubsystemIdentifier` in `rpcLogging.test.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)