### PR TITLE
fix(trackball): scope PMW3610 custom settings list to the module

### DIFF
--- a/src/components/TrackballAdvancedSettings.tsx
+++ b/src/components/TrackballAdvancedSettings.tsx
@@ -23,8 +23,13 @@ export function TrackballAdvancedSettings() {
   // reopen shouldn't re-fetch).
   const [hasExpanded, setHasExpanded] = useState(false);
   // Defer loading the PMW3610 settings until the section is first expanded so
-  // opening the Trackball tab doesn't trigger the custom-settings RPC.
-  const customSettings = useCustomSettings({ autoLoad: false });
+  // opening the Trackball tab doesn't trigger the custom-settings RPC. Scope
+  // the list to the pmw3610 subsystem so unrelated custom subsystems aren't
+  // fetched or listed here.
+  const customSettings = useCustomSettings({
+    autoLoad: false,
+    subsystemIdentifier: PMW3610_CUSTOM_SETTINGS_IDENTIFIER,
+  });
   const { keymap, behaviors, isLoading: keymapLoading } = useKeymap();
 
   const handleToggle = () => {

--- a/src/hooks/useCustomSettings.ts
+++ b/src/hooks/useCustomSettings.ts
@@ -126,12 +126,17 @@ export interface UseCustomSettingsOptions {
   // initial load by calling loadSettings() (e.g. when a collapsed section is
   // expanded). Defaults to true.
   autoLoad?: boolean;
+  // When set, the list request is scoped to the custom subsystem that
+  // registered this identifier (e.g. the pmw3610 driver) instead of fetching
+  // every subsystem's settings. Callers that only care about one module should
+  // set this so unrelated subsystems are never transferred or listed.
+  subsystemIdentifier?: string;
 }
 
 export function useCustomSettings(
   options?: UseCustomSettingsOptions,
 ): UseCustomSettingsReturn {
-  const { autoLoad = true } = options ?? {};
+  const { autoLoad = true, subsystemIdentifier } = options ?? {};
   const { t } = useLanguage();
   const zmkApp = useContext(ZMKAppContext);
   const { subsystem, ready, call } = useCustomSubsystem(
@@ -150,6 +155,19 @@ export function useCustomSettings(
       t("Subsystem {{index}}", { index }),
     [t, zmkApp?.state.customSubsystems?.subsystems],
   );
+
+  // Resolve the caller-requested subsystem identifier to the numeric index the
+  // list scope expects. Undefined identifier => no scoping. A set-but-unknown
+  // identifier resolves to undefined, which is treated as "subsystem absent".
+  const targetSubsystemIndex = useMemo(() => {
+    if (subsystemIdentifier === undefined) {
+      return undefined;
+    }
+    const index = zmkApp?.state.customSubsystems?.subsystems?.findIndex(
+      (candidate) => candidate?.identifier === subsystemIdentifier,
+    );
+    return index !== undefined && index >= 0 ? index : undefined;
+  }, [subsystemIdentifier, zmkApp?.state.customSubsystems?.subsystems]);
 
   const callCustomRequest = useCallback(
     async (request: Request): Promise<Response> => {
@@ -173,6 +191,20 @@ export function useCustomSettings(
   const collectListSettings = useCallback(async (): Promise<Setting[]> => {
     if (!ready || !zmkApp || subsystemIndex === undefined) {
       return [];
+    }
+
+    // A scoped caller whose subsystem isn't present has nothing to list; skip
+    // the request rather than falling back to an all-subsystems list.
+    if (
+      subsystemIdentifier !== undefined &&
+      targetSubsystemIndex === undefined
+    ) {
+      return [];
+    }
+
+    const listScope: SettingScope = { source: CUSTOM_SETTINGS_SOURCE_ALL };
+    if (targetSubsystemIndex !== undefined) {
+      listScope.customSubsystemIndex = targetSubsystemIndex;
     }
 
     const collected: Setting[] = [];
@@ -228,7 +260,7 @@ export function useCustomSettings(
         callCustomRequest(
           Request.create({
             listSettings: {
-              scope: { source: CUSTOM_SETTINGS_SOURCE_ALL },
+              scope: listScope,
               requireMeta: true,
             },
           }),
@@ -250,7 +282,15 @@ export function useCustomSettings(
         clearTimeout(quietTimeout);
       }
     }
-  }, [callCustomRequest, ready, subsystemIndex, t, zmkApp]);
+  }, [
+    callCustomRequest,
+    ready,
+    subsystemIdentifier,
+    subsystemIndex,
+    t,
+    targetSubsystemIndex,
+    zmkApp,
+  ]);
 
   const loadSettings = useCallback(async () => {
     if (!ready) {


### PR DESCRIPTION
## Description

The Trackball tab's **Advanced (PMW3610 Sensor Driver)** section was fetching **every** custom subsystem's settings over the custom-settings RPC and then filtering down to PMW3610 client-side. This transfers and lists settings from unrelated subsystems just to show one module's settings.

The custom-settings protocol already supports narrowing a list via `SettingScope.customSubsystemIndex` (the same field the save/discard/reset paths use via `scopeForSection`). This change wires that into the list path.

### What changed

- **`useCustomSettings`** now accepts an optional `subsystemIdentifier` option. When set, it resolves the identifier to its numeric subsystem index (via `zmkApp.state.customSubsystems.subsystems`, consistent with the existing `subsystemIdentifierForIndex` convention) and passes `customSubsystemIndex` in the `listSettings` scope, so only that module's settings are requested. If the identifier isn't present on the device, it skips the request and returns empty rather than falling back to an all-subsystems list.
- **`TrackballAdvancedSettings`** passes `subsystemIdentifier: PMW3610_CUSTOM_SETTINGS_IDENTIFIER`. The existing client-side identifier filter stays as a cheap defensive guard.

Other consumers (the general "Advanced Settings" viewer) call `useCustomSettings()` with no identifier and keep listing all subsystems — untouched.

### Verification

- `tsc -b` and `eslint` clean; pre-commit hook (prettier + eslint + full `jest` suite) passed.
- Ran the app in demo mode → Trackball → expanded the PMW3610 section. The scoped list RPC (`custom:cormoran_custom_settings`) fires and completes with no errors. Because the hook now skips the request entirely when the identifier can't resolve, the request firing confirms PMW3610 resolved to its subsystem index and the scoped request went out. Demo mode seeds its custom settings under a different subsystem index, so it correctly reports no PMW3610-owned settings (matching prior behavior). On real firmware with the pmw3610 driver, the request now transfers only that module's settings.

## CLA (Contributor License Agreement)

By submitting this pull request, I agree that my contributions
are licensed under the project's current license.

I also grant the maintainer(s) of this project the right to relicense
my contributions under any license, for use in future versions of the project.
This does not affect the license of any previously released versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)