### PR TITLE
feat(keymap): Discard/Reset buttons and changed-from-default highlight

### DIFF
--- a/src/components/KeyboardLayout.tsx
+++ b/src/components/KeyboardLayout.tsx
@@ -44,6 +44,12 @@ interface KeyboardLayoutProps {
   onKeyReset: (keyPosition: number) => void;
   /** Function to check if a binding is modified */
   isBindingModified: (layerId: number, keyPosition: number) => boolean;
+  /** Function to check if a binding's persisted value differs from the default
+   * keymap (optional; only available when the fast-keymap subsystem is present) */
+  isBindingChangedFromDefault?: (
+    layerId: number,
+    keyPosition: number,
+  ) => boolean;
   /** Function to get original binding */
   getOriginalBinding: (
     layerId: number,
@@ -103,6 +109,7 @@ export function KeyboardLayout({
   onKeyClick,
   onKeyReset,
   isBindingModified,
+  isBindingChangedFromDefault,
   getOriginalBinding,
   keyboardLayout,
   modules = [],
@@ -267,6 +274,8 @@ export function KeyboardLayout({
         {layout.keys.map((key, position) => {
           const binding = layer.bindings[position];
           const modified = isBindingModified(layer.id, position);
+          const changedFromDefault =
+            isBindingChangedFromDefault?.(layer.id, position) ?? false;
 
           // Adjust position with offset for centering
           const adjustedKey: KeyPhysicalAttrs = {
@@ -282,6 +291,7 @@ export function KeyboardLayout({
               keyPosition={position}
               binding={binding}
               isModified={modified}
+              isChangedFromDefault={changedFromDefault}
               displayName={getKeyDisplayName(position, binding)}
               longDisplayName={getKeyLongDisplayName(position, binding)}
               originalDisplayName={

--- a/src/components/KeyboardLayout.tsx
+++ b/src/components/KeyboardLayout.tsx
@@ -42,6 +42,9 @@ interface KeyboardLayoutProps {
   onKeyClick: (keyPosition: number) => void;
   /** Callback to reset a key to original */
   onKeyReset: (keyPosition: number) => void;
+  /** Callback to reset a key to its hard-coded default (optional; only wired
+   * when the fast-keymap subsystem is present) */
+  onKeyResetToDefault?: (keyPosition: number) => void;
   /** Function to check if a binding is modified */
   isBindingModified: (layerId: number, keyPosition: number) => boolean;
   /** Function to check if a binding's persisted value differs from the default
@@ -52,6 +55,12 @@ interface KeyboardLayoutProps {
   ) => boolean;
   /** Function to get original binding */
   getOriginalBinding: (
+    layerId: number,
+    keyPosition: number,
+  ) => BehaviorBinding | null;
+  /** Function to get the hard-coded default binding (optional; only available
+   * when the fast-keymap subsystem is present) */
+  getDefaultBinding?: (
     layerId: number,
     keyPosition: number,
   ) => BehaviorBinding | null;
@@ -108,9 +117,11 @@ export function KeyboardLayout({
   selectedKey,
   onKeyClick,
   onKeyReset,
+  onKeyResetToDefault,
   isBindingModified,
   isBindingChangedFromDefault,
   getOriginalBinding,
+  getDefaultBinding,
   keyboardLayout,
   modules = [],
   highlightedKeys,
@@ -250,6 +261,28 @@ export function KeyboardLayout({
     ],
   );
 
+  // Get default-binding display name for tooltip
+  const getDefaultDisplayName = useCallback(
+    (keyPosition: number): string | undefined => {
+      const def = getDefaultBinding?.(layer.id, keyPosition);
+      if (!def) return undefined;
+      const behavior = behaviors.get(def.behaviorId) || null;
+      return formatBehaviorBinding(def, behavior, {
+        layers: layers,
+        keyboardLayout,
+        runtimeMacros,
+      });
+    },
+    [
+      getDefaultBinding,
+      layer,
+      behaviors,
+      layers,
+      keyboardLayout,
+      runtimeMacros,
+    ],
+  );
+
   // Get full binding description for tooltip
   const getBindingDescription = useCallback(
     (binding: BehaviorBinding | undefined): string => {
@@ -297,11 +330,19 @@ export function KeyboardLayout({
               originalDisplayName={
                 modified ? getOriginalDisplayName(position) : undefined
               }
+              defaultDisplayName={
+                changedFromDefault ? getDefaultDisplayName(position) : undefined
+              }
               bindingDescription={getBindingDescription(binding)}
               isSelected={selectedKey === position}
               isHighlighted={highlightedKeys?.has(position)}
               onClick={() => onKeyClick(position)}
               onReset={() => onKeyReset(position)}
+              onResetToDefault={
+                onKeyResetToDefault
+                  ? () => onKeyResetToDefault(position)
+                  : undefined
+              }
               scale={scale}
             />
           );

--- a/src/components/PhysicalKey.tsx
+++ b/src/components/PhysicalKey.tsx
@@ -30,6 +30,9 @@ interface PhysicalKeyProps {
   binding?: BehaviorBinding;
   /** Whether this key has been modified from original */
   isModified: boolean;
+  /** Whether this key's persisted binding differs from the hard-coded default
+   * keymap (a modest, informational highlight, distinct from `isModified`). */
+  isChangedFromDefault?: boolean;
   /** Display name for the binding */
   displayName: string;
   /** Long display name (for tooltip) */
@@ -53,6 +56,7 @@ interface PhysicalKeyProps {
 export function PhysicalKey({
   attrs,
   isModified,
+  isChangedFromDefault = false,
   displayName,
   longDisplayName,
   originalDisplayName,
@@ -114,7 +118,9 @@ export function PhysicalKey({
               ? "bg-[var(--color-electric)]/20 border-[var(--color-electric)] shadow-[0_0_10px_rgba(0,212,255,0.3)]"
               : isModified
                 ? "bg-[var(--color-neon)]/10 border-[var(--color-neon)]/50 hover:border-[var(--color-neon)]"
-                : "bg-[var(--color-surface)] border-[var(--color-border)] hover:border-[var(--color-electric)]/50 hover:bg-[var(--color-electric)]/5"
+                : isChangedFromDefault
+                  ? "bg-[var(--color-surface)] border-[var(--color-electric)]/30 hover:border-[var(--color-electric)]/60 hover:bg-[var(--color-electric)]/5"
+                  : "bg-[var(--color-surface)] border-[var(--color-border)] hover:border-[var(--color-electric)]/50 hover:bg-[var(--color-electric)]/5"
         }
       `}
       style={style}
@@ -144,6 +150,12 @@ export function PhysicalKey({
       {/* Modified indicator */}
       {isModified && (
         <div className="absolute top-1 right-1 w-2 h-2 rounded-full bg-[var(--color-neon)]" />
+      )}
+
+      {/* Changed-from-default indicator (modest, distinct corner + color from
+          the modified dot above) */}
+      {isChangedFromDefault && !isModified && (
+        <div className="absolute top-1 left-1 w-1.5 h-1.5 rounded-full bg-[var(--color-electric)]/50" />
       )}
 
       {isHighlighted && (
@@ -204,6 +216,12 @@ export function PhysicalKey({
                     {t("Original")}:{" "}
                   </span>
                   <span>{originalDisplayName}</span>
+                </div>
+              )}
+              {/* Note when the persisted binding differs from the default */}
+              {isChangedFromDefault && !isModified && (
+                <div className="text-[var(--color-electric)]">
+                  {t("Changed from default keymap")}
                 </div>
               )}
             </div>

--- a/src/components/PhysicalKey.tsx
+++ b/src/components/PhysicalKey.tsx
@@ -11,6 +11,7 @@ import {
   IconBrandWindows,
   IconChevronUp,
   IconCommand,
+  IconHistory,
   IconOption,
   IconRotateClockwise,
   IconSpace,
@@ -33,6 +34,8 @@ interface PhysicalKeyProps {
   /** Whether this key's persisted binding differs from the hard-coded default
    * keymap (a modest, informational highlight, distinct from `isModified`). */
   isChangedFromDefault?: boolean;
+  /** Default-binding display name (for tooltip when changed from default) */
+  defaultDisplayName?: string;
   /** Display name for the binding */
   displayName: string;
   /** Long display name (for tooltip) */
@@ -49,6 +52,8 @@ interface PhysicalKeyProps {
   onClick: () => void;
   /** Callback to reset this key to original */
   onReset: () => void;
+  /** Callback to reset this key to its hard-coded default (optional) */
+  onResetToDefault?: () => void;
   /** Scale factor for responsive sizing */
   scale?: number;
 }
@@ -60,11 +65,13 @@ export function PhysicalKey({
   displayName,
   longDisplayName,
   originalDisplayName,
+  defaultDisplayName,
   bindingDescription,
   isSelected,
   isHighlighted = false,
   onClick,
   onReset,
+  onResetToDefault,
   scale = 1.0,
 }: PhysicalKeyProps) {
   const { t } = useLanguage();
@@ -178,6 +185,22 @@ export function PhysicalKey({
           />
         </button>
       )}
+
+      {/* Reset-to-default button on hover when changed from default (and not
+          currently modified — that state shows the reset-to-original button
+          above instead) */}
+      {isChangedFromDefault && !isModified && isHovered && onResetToDefault && (
+        <button
+          className="absolute bottom-1 right-1 p-0.5 rounded bg-[var(--color-surface)]/80 hover:bg-[var(--color-surface)] border border-[var(--color-border)]"
+          onClick={(e) => {
+            e.stopPropagation();
+            onResetToDefault();
+          }}
+          title={t("Reset to default")}
+        >
+          <IconHistory size={12} className="text-[var(--color-electric)]" />
+        </button>
+      )}
     </div>
   );
 
@@ -218,10 +241,15 @@ export function PhysicalKey({
                   <span>{originalDisplayName}</span>
                 </div>
               )}
-              {/* Note when the persisted binding differs from the default */}
-              {isChangedFromDefault && !isModified && (
-                <div className="text-[var(--color-electric)]">
-                  {t("Changed from default keymap")}
+              {/* Default binding when the persisted value differs from it */}
+              {isChangedFromDefault && !isModified && defaultDisplayName && (
+                <div>
+                  <span className="text-[var(--color-text-muted)]">
+                    {t("Default")}:{" "}
+                  </span>
+                  <span className="text-[var(--color-electric)]">
+                    {defaultDisplayName}
+                  </span>
                 </div>
               )}
             </div>

--- a/src/components/__tests__/PhysicalKey.test.tsx
+++ b/src/components/__tests__/PhysicalKey.test.tsx
@@ -1,0 +1,60 @@
+/**
+ * Tests for PhysicalKey — focused on the changed-from-default affordances
+ * (the hover reset-to-default button). Other states (modified, selected,
+ * highlighted) are exercised indirectly through KeymapPage.
+ */
+import { render, screen, fireEvent } from "@testing-library/react";
+import { PhysicalKey } from "../PhysicalKey";
+
+const attrs = { width: 100, height: 100, x: 0, y: 0, r: 0, rx: 0, ry: 0 };
+
+function renderKey(overrides = {}) {
+  const props = {
+    attrs,
+    keyPosition: 0,
+    isModified: false,
+    displayName: "A",
+    isSelected: false,
+    onClick: jest.fn(),
+    onReset: jest.fn(),
+    ...overrides,
+  };
+  return { props, ...render(<PhysicalKey {...props} />) };
+}
+
+describe("PhysicalKey — changed from default", () => {
+  it("reveals a reset-to-default button on hover and calls onResetToDefault", () => {
+    const onResetToDefault = jest.fn();
+    renderKey({
+      isChangedFromDefault: true,
+      defaultDisplayName: "B",
+      onResetToDefault,
+    });
+
+    // Hidden until hovered.
+    expect(screen.queryByTitle("Reset to default")).not.toBeInTheDocument();
+
+    // mouseenter doesn't bubble, so fire it on the key container itself.
+    const keyEl = screen.getByText("A").closest("div")!;
+    fireEvent.mouseEnter(keyEl);
+
+    const resetBtn = screen.getByTitle("Reset to default");
+    fireEvent.click(resetBtn);
+    expect(onResetToDefault).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not show the reset-to-default button when the key is modified", () => {
+    renderKey({
+      isModified: true,
+      isChangedFromDefault: false,
+      onResetToDefault: jest.fn(),
+    });
+
+    const keyEl = screen.getByText("A").closest("div")!;
+    fireEvent.mouseEnter(keyEl);
+
+    // The modified state shows the reset-to-original button instead.
+    expect(screen.queryByTitle("Reset to default")).not.toBeInTheDocument();
+    expect(screen.getByTitle("Reset to original")).toBeInTheDocument();
+  });
+});

--- a/src/hooks/__tests__/useKeymapSource.test.tsx
+++ b/src/hooks/__tests__/useKeymapSource.test.tsx
@@ -4,6 +4,10 @@ import { ZMKAppContext } from "@cormoran/zmk-studio-react-hook";
 import { useKeymapSource } from "../useKeymapSource";
 import { setFastKeymapAvailable } from "../../lib/officialKeymapRpcGuard";
 import type { FastKeymapModel } from "../../lib/fastKeymap";
+import {
+  Request,
+  Response,
+} from "../../proto/cormoran/fast_keymap/fast_keymap";
 
 // -- mock the transport bits --------------------------------------------------
 
@@ -108,6 +112,12 @@ describe("useKeymapSource — official fallback", () => {
     expect(data.keymap.availableLayers).toBe(4);
     expect(data.behaviors.get(7)?.displayName).toBe("kp");
     expect(mockLoadFastKeymap).not.toHaveBeenCalled();
+  });
+
+  it("loadDefaultKeymap returns an empty map (no default source on official)", async () => {
+    const { result } = renderHook(() => useKeymapSource(), { wrapper });
+    const defaults = await result.current.loadDefaultKeymap([1, 2]);
+    expect(defaults.size).toBe(0);
   });
 });
 
@@ -290,6 +300,31 @@ describe("useKeymapSource — fast path", () => {
     >;
     expect(behaviors.get(42)?.displayName).toBe("Key Press");
     expect(mockLoadFastKeymap).toHaveBeenCalledTimes(2);
+  });
+
+  it("loadDefaultKeymap fetches each layer's default via get_default_layer", async () => {
+    // call() encodes the Request and delegates to callRPC(), which returns the
+    // encoded Response bytes the codec then decodes.
+    mockCallRPC.mockImplementation(async (payload: Uint8Array) => {
+      const req = Request.decode(payload);
+      const layerId = req.getDefaultLayer?.layerId ?? 0;
+      return Response.encode({
+        getDefaultLayer: {
+          id: layerId,
+          name: "",
+          bindings: [{ behaviorId: layerId + 10, param1: 1, param2: 2 }],
+        },
+      }).finish();
+    });
+
+    const { result } = renderHook(() => useKeymapSource(), { wrapper });
+    const defaults = await result.current.loadDefaultKeymap([1, 2]);
+
+    expect(defaults.size).toBe(2);
+    expect(defaults.get(1)).toEqual([{ behaviorId: 11, param1: 1, param2: 2 }]);
+    expect(defaults.get(2)).toEqual([{ behaviorId: 12, param1: 1, param2: 2 }]);
+    // One get_default_layer round-trip per requested layer.
+    expect(mockCallRPC).toHaveBeenCalledTimes(2);
   });
 
   it("fetches one layout's geometry lazily via loadLayoutGeometry", async () => {

--- a/src/hooks/useKeymap.ts
+++ b/src/hooks/useKeymap.ts
@@ -179,6 +179,11 @@ export interface UseKeymapReturn extends KeymapState {
     layerId: number,
     keyPosition: number,
   ) => boolean;
+  /** True when the PERSISTED keymap differs from the hard-coded default in at
+   * least one position (i.e. the saved keymap has been customized). False while
+   * the default keymap is still loading or when it isn't available (no
+   * fast-keymap subsystem). */
+  isKeymapChangedFromDefault: boolean;
   /** Get behavior definition by ID */
   getBehavior: (behaviorId: number) => BehaviorDefinition | undefined;
   /** Get display name for a binding */
@@ -963,6 +968,19 @@ export function useKeymap(): UseKeymapReturn {
     [defaultBindings, originalBindings, isBindingModified],
   );
 
+  // Whether the persisted keymap differs from the hard-coded default anywhere —
+  // drives the "saved but customized" badge state. Compares the persisted
+  // (original) bindings, not the current in-memory ones, so it reflects what is
+  // actually on the device once saved.
+  const isKeymapChangedFromDefault = useMemo(() => {
+    if (defaultBindings.size === 0) return false;
+    for (const [key, def] of defaultBindings) {
+      const original = originalBindings.get(key);
+      if (original && !bindingsEqual(original, def)) return true;
+    }
+    return false;
+  }, [defaultBindings, originalBindings]);
+
   // Get behavior by ID
   const getBehavior = useCallback(
     (behaviorId: number): BehaviorDefinition | undefined => {
@@ -1138,6 +1156,7 @@ export function useKeymap(): UseKeymapReturn {
     isBindingModified,
     isFastKeymapAvailable,
     isBindingChangedFromDefault,
+    isKeymapChangedFromDefault,
     getBehavior,
     getBindingDisplayName,
     clearUnlockRequired,

--- a/src/hooks/useKeymap.ts
+++ b/src/hooks/useKeymap.ts
@@ -119,6 +119,14 @@ export interface UseKeymapReturn extends KeymapState {
   ) => Promise<boolean>;
   /** Reset a binding to its original value */
   resetBinding: (layerId: number, keyPosition: number) => Promise<boolean>;
+  /** Reset a single binding to its hard-coded default value (an in-memory edit,
+   * so the key becomes an unsaved change until saved). Only meaningful when
+   * {@link isFastKeymapAvailable} is true. Returns false when the default for
+   * this key isn't available. */
+  resetBindingToDefault: (
+    layerId: number,
+    keyPosition: number,
+  ) => Promise<boolean>;
   /** Move a layer from one position to another */
   moveLayer: (startIndex: number, destIndex: number) => Promise<boolean>;
   /** Add a new layer */
@@ -147,6 +155,12 @@ export interface UseKeymapReturn extends KeymapState {
   setActiveLayout: (layoutIndex: number) => Promise<boolean>;
   /** Get the original binding for a key (before modification) */
   getOriginalBinding: (
+    layerId: number,
+    keyPosition: number,
+  ) => BehaviorBinding | null;
+  /** Get the hard-coded default binding for a key, or null when the default
+   * keymap isn't loaded/available. */
+  getDefaultBinding: (
     layerId: number,
     keyPosition: number,
   ) => BehaviorBinding | null;
@@ -555,6 +569,20 @@ export function useKeymap(): UseKeymapReturn {
     [originalBindings, setBinding],
   );
 
+  // Reset a single binding to its hard-coded default value. Unlike
+  // resetToDefault (whole keymap + save), this is an in-memory edit: the key
+  // becomes an unsaved change the user can then save or discard.
+  const resetBindingToDefault = useCallback(
+    async (layerId: number, keyPosition: number): Promise<boolean> => {
+      const def = defaultBindings.get(bindingKey(layerId, keyPosition));
+      if (!def) {
+        return false;
+      }
+      return setBinding(layerId, keyPosition, def);
+    },
+    [defaultBindings, setBinding],
+  );
+
   // Move a layer
   const moveLayer = useCallback(
     async (startIndex: number, destIndex: number): Promise<boolean> => {
@@ -892,6 +920,14 @@ export function useKeymap(): UseKeymapReturn {
     [originalBindings],
   );
 
+  // Get hard-coded default binding
+  const getDefaultBinding = useCallback(
+    (layerId: number, keyPosition: number): BehaviorBinding | null => {
+      return defaultBindings.get(bindingKey(layerId, keyPosition)) ?? null;
+    },
+    [defaultBindings],
+  );
+
   // Check if binding is modified
   const isBindingModified = useCallback(
     (layerId: number, keyPosition: number): boolean => {
@@ -1084,6 +1120,7 @@ export function useKeymap(): UseKeymapReturn {
     loadKeymapData,
     setBinding,
     resetBinding,
+    resetBindingToDefault,
     moveLayer,
     addLayer,
     removeLayer,
@@ -1097,6 +1134,7 @@ export function useKeymap(): UseKeymapReturn {
     resetToDefault,
     setActiveLayout,
     getOriginalBinding,
+    getDefaultBinding,
     isBindingModified,
     isFastKeymapAvailable,
     isBindingChangedFromDefault,

--- a/src/hooks/useKeymap.ts
+++ b/src/hooks/useKeymap.ts
@@ -137,6 +137,12 @@ export interface UseKeymapReturn extends KeymapState {
   saveChanges: () => Promise<boolean>;
   /** Discard all unsaved changes */
   discardChanges: () => Promise<boolean>;
+  /** Reset the persistent keymap back to the hard-coded (devicetree-stock)
+   * default: applies every default binding that differs from the current one,
+   * then saves. Only meaningful when {@link isFastKeymapAvailable} is true (the
+   * default keymap is read via the fast-keymap subsystem). Returns false when
+   * unavailable or the save fails. */
+  resetToDefault: () => Promise<boolean>;
   /** Set the active physical layout */
   setActiveLayout: (layoutIndex: number) => Promise<boolean>;
   /** Get the original binding for a key (before modification) */
@@ -146,6 +152,19 @@ export interface UseKeymapReturn extends KeymapState {
   ) => BehaviorBinding | null;
   /** Check if a binding has been modified */
   isBindingModified: (layerId: number, keyPosition: number) => boolean;
+  /** True when the connected keyboard exposes the fast-keymap subsystem, which
+   * is what serves the hard-coded default keymap. Gates the "reset to default"
+   * action and the "changed from default" highlight. */
+  isFastKeymapAvailable: boolean;
+  /** Check whether a binding's PERSISTED value differs from the hard-coded
+   * default keymap (i.e. it was saved to flash and is no longer stock). Returns
+   * false while the default keymap is still loading, when it isn't available
+   * (no fast-keymap subsystem), or when the key is currently modified in memory
+   * (that state is surfaced by {@link isBindingModified} instead). */
+  isBindingChangedFromDefault: (
+    layerId: number,
+    keyPosition: number,
+  ) => boolean;
   /** Get behavior definition by ID */
   getBehavior: (behaviorId: number) => BehaviorDefinition | undefined;
   /** Get display name for a binding */
@@ -186,6 +205,12 @@ export function useKeymap(): UseKeymapReturn {
   const [originalBindings, setOriginalBindings] = useState<
     Map<string, BehaviorBinding>
   >(new Map());
+  // Hard-coded (devicetree-stock) default bindings, keyed like originalBindings
+  // (`layerId:position`). Loaded lazily as the final step of a keymap load (see
+  // the effect below) and only when the fast-keymap subsystem is present.
+  const [defaultBindings, setDefaultBindings] = useState<
+    Map<string, BehaviorBinding>
+  >(new Map());
   const [hasUnsavedChanges, setHasUnsavedChanges] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
   // True only once the foreground preview AND the background incremental load
@@ -200,6 +225,9 @@ export function useKeymap(): UseKeymapReturn {
 
   // Ref to track if data has been loaded
   const dataLoadedRef = useRef(false);
+  // Guards the final-step default-keymap load so it runs once per keymap load;
+  // reset when a new load starts (see loadKeymapData) and on disconnect.
+  const defaultKeymapRequestedRef = useRef(false);
   // Monotonic id per loadKeymapData call, so a background (incremental) layer
   // update from a superseded load is ignored.
   const loadIdRef = useRef(0);
@@ -215,8 +243,12 @@ export function useKeymap(): UseKeymapReturn {
   // Loading is delegated to useKeymapSource, which picks the fast-keymap
   // subsystem when the device exposes it and the official protocol otherwise.
   // (Editing below always uses the official protocol.)
-  const { loadKeymapData: loadFromSource, loadLayoutGeometry } =
-    useKeymapSource();
+  const {
+    loadKeymapData: loadFromSource,
+    loadLayoutGeometry,
+    loadDefaultKeymap,
+    isFastAvailable: isFastKeymapAvailable,
+  } = useKeymapSource();
 
   // Helper to set error with auto-clear timer (5 seconds)
   const setErrorWithAutoClear = useCallback((message: string) => {
@@ -329,6 +361,8 @@ export function useKeymap(): UseKeymapReturn {
     // Guard for the background (incremental) layer load: a load that has been
     // superseded (reconnect/reload) must not apply its late layer update.
     const loadId = ++loadIdRef.current;
+    // A fresh load re-arms the final-step default-keymap fetch.
+    defaultKeymapRequestedRef.current = false;
     const isFirstLoad = !dataLoadedRef.current;
     // Populated after the initial (phase-1) load returns; read by the
     // background callback, which fires later.
@@ -760,6 +794,36 @@ export function useKeymap(): UseKeymapReturn {
     return false;
   }, [callRpc, loadKeymapData, clearError, setErrorWithAutoClear]);
 
+  // Reset the persistent keymap to the hard-coded default: set every binding
+  // that differs from its default value, then save. Only works when the default
+  // keymap has been loaded (fast-keymap subsystem present).
+  const resetToDefault = useCallback(async (): Promise<boolean> => {
+    if (!keymap) return false;
+    if (defaultBindings.size === 0) {
+      setErrorWithAutoClear("Default keymap is not available");
+      return false;
+    }
+
+    // Apply only the positions whose current binding differs from the default,
+    // to keep the number of RPCs (BLE round-trips) to what actually changed.
+    for (const layer of keymap.layers) {
+      for (let position = 0; position < layer.bindings.length; position++) {
+        const def = defaultBindings.get(bindingKey(layer.id, position));
+        if (!def) continue;
+        const current = layer.bindings[position];
+        if (current && bindingsEqual(current, def)) continue;
+        const ok = await setBinding(layer.id, position, def);
+        if (!ok) {
+          // setBinding already surfaced the error (incl. unlock-required).
+          return false;
+        }
+      }
+    }
+
+    // Persist the now-default keymap to flash.
+    return saveChanges();
+  }, [keymap, defaultBindings, setBinding, saveChanges, setErrorWithAutoClear]);
+
   // Set active physical layout
   const setActiveLayout = useCallback(
     async (layoutIndex: number): Promise<boolean> => {
@@ -845,6 +909,24 @@ export function useKeymap(): UseKeymapReturn {
     [originalBindings, keymap],
   );
 
+  // Check if a binding's PERSISTED value differs from the hard-coded default.
+  // Uses the original (persistent) binding, not the current in-memory one, so a
+  // key the user is actively editing surfaces as "modified" (green) rather than
+  // here — the two highlights are mutually exclusive by design.
+  const isBindingChangedFromDefault = useCallback(
+    (layerId: number, keyPosition: number): boolean => {
+      const key = bindingKey(layerId, keyPosition);
+      const def = defaultBindings.get(key);
+      if (!def) return false;
+      const original = originalBindings.get(key);
+      if (!original) return false;
+      // Suppress while the key is modified in memory — that takes precedence.
+      if (isBindingModified(layerId, keyPosition)) return false;
+      return !bindingsEqual(original, def);
+    },
+    [defaultBindings, originalBindings, isBindingModified],
+  );
+
   // Get behavior by ID
   const getBehavior = useCallback(
     (behaviorId: number): BehaviorDefinition | undefined => {
@@ -923,6 +1005,39 @@ export function useKeymap(): UseKeymapReturn {
     }
   }, [connection, loadKeymapData]);
 
+  // Load the hard-coded default keymap as the FINAL step of the keymap tab
+  // load — only once the preview + background behaviors/layers have all settled
+  // (isFullyLoaded), so its one-round-trip-per-layer fetch never competes with
+  // the preview. Fast-keymap only; skipped entirely on the official path. Fires
+  // once per load (guarded by defaultKeymapRequestedRef, re-armed on reload).
+  useEffect(() => {
+    if (!isFullyLoaded || !isFastKeymapAvailable) return;
+    if (defaultKeymapRequestedRef.current) return;
+    const layers = keymap?.layers;
+    if (!layers || layers.length === 0) return;
+
+    defaultKeymapRequestedRef.current = true;
+    const loadId = loadIdRef.current;
+    const layerIds = layers.map((layer) => layer.id);
+    void loadDefaultKeymap(layerIds)
+      .then((defaultsByLayer) => {
+        // Ignore a late result from a superseded load (reconnect/reload).
+        if (loadIdRef.current !== loadId) return;
+        const next = new Map<string, BehaviorBinding>();
+        for (const [layerId, bindings] of defaultsByLayer) {
+          bindings.forEach((binding, position) => {
+            next.set(bindingKey(layerId, position), { ...binding });
+          });
+        }
+        setDefaultBindings(next);
+      })
+      .catch((err) => {
+        // Best-effort: the default keymap only drives an optional highlight and
+        // the reset action, so a failure just leaves both unavailable.
+        console.error("Failed to load default keymap:", err);
+      });
+  }, [isFullyLoaded, isFastKeymapAvailable, keymap?.layers, loadDefaultKeymap]);
+
   // Reset state when disconnected
   useEffect(() => {
     if (!connection) {
@@ -930,12 +1045,14 @@ export function useKeymap(): UseKeymapReturn {
       setKeymap(null);
       setBehaviors(new Map());
       setOriginalBindings(new Map());
+      setDefaultBindings(new Map());
       setHasUnsavedChanges(false);
       setError(null);
       setUnlockRequired(false);
       setRemovedLayerIds([]);
       setLoadingProgress(null);
       dataLoadedRef.current = false;
+      defaultKeymapRequestedRef.current = false;
       // Clear error timer
       if (errorTimerRef.current) {
         clearTimeout(errorTimerRef.current);
@@ -977,9 +1094,12 @@ export function useKeymap(): UseKeymapReturn {
     removedLayerIds,
     saveChanges,
     discardChanges,
+    resetToDefault,
     setActiveLayout,
     getOriginalBinding,
     isBindingModified,
+    isFastKeymapAvailable,
+    isBindingChangedFromDefault,
     getBehavior,
     getBindingDisplayName,
     clearUnlockRequired,

--- a/src/hooks/useKeymapSource.ts
+++ b/src/hooks/useKeymapSource.ts
@@ -29,6 +29,7 @@ import type {
   PhysicalLayouts,
   PhysicalLayout,
   KeyPhysicalAttrs,
+  BehaviorBinding,
 } from "@zmkfirmware/zmk-studio-ts-client/keymap";
 import type { BehaviorBindingParametersSet } from "@zmkfirmware/zmk-studio-ts-client/behaviors";
 import { ErrorConditions } from "@zmkfirmware/zmk-studio-ts-client/meta";
@@ -194,6 +195,21 @@ export interface UseKeymapSourceReturn {
    * non-active layout geometry is loaded lazily (not at initial load) — call
    * this when switching to a layout whose `keys` are still empty. */
   loadLayoutGeometry: (index: number) => Promise<KeyPhysicalAttrs[]>;
+  /** Load the keyboard's hard-coded (devicetree-stock) DEFAULT keymap — the
+   * bindings before any Studio edit was ever saved — as a map from layer id to
+   * that layer's default bindings.
+   *
+   * Only the fast-keymap subsystem exposes this (`get_default_layer`); on the
+   * official path there is no way to read the stock keymap, so this returns an
+   * empty map. Callers gate any "reset to default" / "changed from default"
+   * feature on {@link isFastAvailable} and treat an empty map as "unavailable".
+   *
+   * This costs one round-trip per layer, so it is meant to run as the FINAL
+   * step of a keymap load (after the preview is already painted), never on the
+   * critical path. */
+  loadDefaultKeymap: (
+    layerIds: number[],
+  ) => Promise<Map<number, BehaviorBinding[]>>;
 }
 
 // -- fast-path helpers ------------------------------------------------------
@@ -499,6 +515,38 @@ export function useKeymapSource(): UseKeymapSourceReturn {
     [isFastAvailable, call, deviceKey, officialRpc],
   );
 
+  const loadDefaultKeymap = useCallback(
+    async (layerIds: number[]): Promise<Map<number, BehaviorBinding[]>> => {
+      const defaults = new Map<number, BehaviorBinding[]>();
+      // Only the fast subsystem can serve the devicetree-stock keymap; the
+      // official protocol has no such request. Return empty so callers fall
+      // back to "unavailable" (highlight skipped, reset disabled).
+      if (!isFastAvailable) {
+        return defaults;
+      }
+      // One get_default_layer round-trip per layer — deliberately serial and
+      // meant to run last (see the interface doc), so it never competes with
+      // the preview load.
+      for (const layerId of layerIds) {
+        const response = await fastCallChecked(call, {
+          getDefaultLayer: { layerId },
+        });
+        const layer = response.getDefaultLayer;
+        if (!layer) continue;
+        defaults.set(
+          layerId,
+          layer.bindings.map((b) => ({
+            behaviorId: b.behaviorId,
+            param1: b.param1,
+            param2: b.param2,
+          })),
+        );
+      }
+      return defaults;
+    },
+    [isFastAvailable, call],
+  );
+
   return {
     isFastAvailable,
     source,
@@ -506,5 +554,6 @@ export function useKeymapSource(): UseKeymapSourceReturn {
     loadPhysicalLayouts,
     loadLayerNames,
     loadLayoutGeometry,
+    loadDefaultKeymap,
   };
 }

--- a/src/i18n/translations.ts
+++ b/src/i18n/translations.ts
@@ -109,7 +109,6 @@ const ja: Record<string, string> = {
   "This resets the saved keymap on your keyboard back to its hard-coded default and writes it to flash immediately. All saved key bindings will be lost. This cannot be undone.":
     "キーボードに保存されたキーマップをハードコードされたデフォルトに戻し、直ちにフラッシュへ書き込みます。保存済みのすべてのキー割り当ては失われます。この操作は元に戻せません。",
   "Reset to default": "デフォルトにリセット",
-  "Changed from default keymap": "デフォルトのキーマップから変更されています",
   "Default keymap is not available": "デフォルトのキーマップを利用できません",
   Locked: "ロック中",
   "Studio is locked — click to unlock":

--- a/src/i18n/translations.ts
+++ b/src/i18n/translations.ts
@@ -99,7 +99,18 @@ const ja: Record<string, string> = {
   "● Unsaved changes": "● 未保存の変更",
   Stream: "ストリーム",
   "Toggle stream mode": "ストリームモードを切り替え",
-  "Reset All": "すべてリセット",
+  "Discard unsaved changes and reload the keymap":
+    "未保存の変更を破棄してキーマップを再読み込みします",
+  "Reset the saved keymap to the default keymap":
+    "保存済みのキーマップをデフォルトのキーマップにリセットします",
+  "Resetting to the default keymap requires the fast-keymap firmware module, which this keyboard does not expose.":
+    "デフォルトのキーマップへのリセットには fast-keymap ファームウェアモジュールが必要ですが、このキーボードは対応していません。",
+  "Reset to default keymap?": "デフォルトのキーマップにリセットしますか？",
+  "This resets the saved keymap on your keyboard back to its hard-coded default and writes it to flash immediately. All saved key bindings will be lost. This cannot be undone.":
+    "キーボードに保存されたキーマップをハードコードされたデフォルトに戻し、直ちにフラッシュへ書き込みます。保存済みのすべてのキー割り当ては失われます。この操作は元に戻せません。",
+  "Reset to default": "デフォルトにリセット",
+  "Changed from default keymap": "デフォルトのキーマップから変更されています",
+  "Default keymap is not available": "デフォルトのキーマップを利用できません",
   Locked: "ロック中",
   "Studio is locked — click to unlock":
     "Studio はロックされています — クリックしてロック解除",
@@ -137,8 +148,8 @@ const ja: Record<string, string> = {
     "物理レイアウトモジュールのプレビューを読み込めませんでした: {{error}}",
   "Runtime sensor rotation subsystem is not available for your keyboard. Rotary encoder configuration will not be displayed. You can enable the feature by applying cormoran/zmk-behavior-runtime-sensor-rotate in your firmware.":
     "このキーボードではランタイムセンサー回転サブシステムを利用できません。ロータリーエンコーダー設定は表示されません。ファームウェアに cormoran/zmk-behavior-runtime-sensor-rotate を適用すると、この機能を有効にできます。",
-  "Click on a key to modify its binding. Modified keys are highlighted in green and show the original binding on hover. Use the Reset All button to discard all changes.":
-    "キーをクリックして割り当てを変更します。変更されたキーは緑で強調表示され、ホバーすると元の割り当てが表示されます。すべての変更を破棄するには「すべてリセット」を使ってください。",
+  "Click on a key to modify its binding. Modified keys are highlighted in green and show the original binding on hover. Use the Discard button to drop unsaved changes, or Reset to restore the default keymap.":
+    "キーをクリックして割り当てを変更します。変更されたキーは緑で強調表示され、ホバーすると元の割り当てが表示されます。未保存の変更を破棄するには「破棄」を、デフォルトのキーマップに戻すには「リセット」を使ってください。",
   "Connect your keyboard to edit keymaps. Click on a key to modify its binding.":
     "キーマップを編集するにはキーボードを接続してください。キーをクリックすると割り当てを変更できます。",
 

--- a/src/i18n/translations.ts
+++ b/src/i18n/translations.ts
@@ -96,7 +96,8 @@ const ja: Record<string, string> = {
     "A: はい、やる気はありますが、すぐではありません...",
 
   "Configure key bindings and layers": "キー割り当てとレイヤーを設定します",
-  "● Unsaved changes": "● 未保存の変更",
+  "Unsaved changes": "未保存の変更",
+  Saved: "保存済み",
   Stream: "ストリーム",
   "Toggle stream mode": "ストリームモードを切り替え",
   "Discard unsaved changes and reload the keymap":

--- a/src/i18n/translations.ts
+++ b/src/i18n/translations.ts
@@ -98,6 +98,8 @@ const ja: Record<string, string> = {
   "Configure key bindings and layers": "キー割り当てとレイヤーを設定します",
   "Unsaved changes": "未保存の変更",
   Saved: "保存済み",
+  "Saved — changed from the default keymap":
+    "保存済み — デフォルトのキーマップから変更されています",
   Stream: "ストリーム",
   "Toggle stream mode": "ストリームモードを切り替え",
   "Discard unsaved changes and reload the keymap":

--- a/src/pages/KeymapPage.tsx
+++ b/src/pages/KeymapPage.tsx
@@ -792,20 +792,34 @@ export function KeymapPage() {
             {/* Keyboard Layout */}
             {currentLayer && (
               <div className="glass-card p-8 relative">
-                {/* Saved / unsaved status indicator */}
-                <div className="absolute top-3 right-3 z-10 flex items-center gap-1.5 px-2 py-1 rounded-full border border-[var(--color-border)] bg-[var(--color-surface)]/70 text-xs">
+                {/* Status indicator: unsaved edits (neon), saved-but-
+                    customized-from-default (electric/blue), or saved-and-stock
+                    (muted). */}
+                <div
+                  className="absolute top-3 right-3 z-10 flex items-center gap-1.5 px-2 py-1 rounded-full border border-[var(--color-border)] bg-[var(--color-surface)]/70 text-xs"
+                  title={
+                    !keymap.hasUnsavedChanges &&
+                    keymap.isKeymapChangedFromDefault
+                      ? t("Saved — changed from the default keymap")
+                      : undefined
+                  }
+                >
                   <span
                     className={`w-2 h-2 rounded-full ${
                       keymap.hasUnsavedChanges
                         ? "bg-[var(--color-neon)]"
-                        : "bg-[var(--color-text-muted)]"
+                        : keymap.isKeymapChangedFromDefault
+                          ? "bg-[var(--color-electric)]"
+                          : "bg-[var(--color-text-muted)]"
                     }`}
                   />
                   <span
                     className={
                       keymap.hasUnsavedChanges
                         ? "text-[var(--color-neon)]"
-                        : "text-[var(--color-text-muted)]"
+                        : keymap.isKeymapChangedFromDefault
+                          ? "text-[var(--color-electric)]"
+                          : "text-[var(--color-text-muted)]"
                     }
                   >
                     {keymap.hasUnsavedChanges

--- a/src/pages/KeymapPage.tsx
+++ b/src/pages/KeymapPage.tsx
@@ -16,6 +16,7 @@ import {
   IconPlus,
   IconTrash,
   IconRestore,
+  IconHistory,
   IconAlertTriangle,
   IconInfoCircle,
   IconPencil,
@@ -68,6 +69,8 @@ export function KeymapPage() {
   const [showKeycodeSelector, setShowKeycodeSelector] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
   const [isDiscarding, setIsDiscarding] = useState(false);
+  const [showResetDialog, setShowResetDialog] = useState(false);
+  const [isResetting, setIsResetting] = useState(false);
   const [showRenameDialog, setShowRenameDialog] = useState(false);
   const [renameValue, setRenameValue] = useState("");
   const [isRenaming, setIsRenaming] = useState(false);
@@ -166,6 +169,22 @@ export function KeymapPage() {
       setIsDiscarding(false);
     }
   }, [keymap, t]);
+
+  // Handle reset-to-default: reset the persistent keymap to the hard-coded
+  // default, then close the confirmation dialog. Gated on unlock (it edits +
+  // saves) like every other keymap edit.
+  const handleResetToDefault = useCallback(async () => {
+    if (!requireUnlocked()) return;
+    setIsResetting(true);
+    try {
+      const ok = await keymap.resetToDefault();
+      if (ok) {
+        setShowResetDialog(false);
+      }
+    } finally {
+      setIsResetting(false);
+    }
+  }, [keymap, requireUnlocked]);
 
   // Handle layer move up
   const handleMoveLayerUp = useCallback(async () => {
@@ -379,14 +398,55 @@ export function KeymapPage() {
                       !keymap.hasUnsavedChanges ||
                       keymap.isLoading
                     }
+                    title={t("Discard unsaved changes and reload the keymap")}
                   >
                     {isDiscarding ? (
                       <IconLoader2 size={16} className="animate-spin" />
                     ) : (
                       <IconRestore size={16} />
                     )}
-                    {t("Reset All")}
+                    {t("Discard")}
                   </button>
+                  <Tooltip.Provider delayDuration={200}>
+                    <Tooltip.Root>
+                      <Tooltip.Trigger asChild>
+                        {/* Wrapper span so the tooltip still shows while the
+                            button is disabled (a disabled button fires no
+                            pointer events). */}
+                        <span className="flex-shrink-0">
+                          <button
+                            className="btn-ghost text-sm flex items-center gap-1.5"
+                            onClick={() => setShowResetDialog(true)}
+                            disabled={
+                              !keymap.isFastKeymapAvailable ||
+                              isResetting ||
+                              keymap.isLoading
+                            }
+                          >
+                            {isResetting ? (
+                              <IconLoader2 size={16} className="animate-spin" />
+                            ) : (
+                              <IconHistory size={16} />
+                            )}
+                            {t("Reset")}
+                          </button>
+                        </span>
+                      </Tooltip.Trigger>
+                      <Tooltip.Portal>
+                        <Tooltip.Content
+                          className="px-3 py-2 rounded bg-[var(--color-surface-elevated)] border border-[var(--color-border)] text-xs text-[var(--color-text-secondary)] shadow-lg z-50 max-w-xs"
+                          sideOffset={5}
+                        >
+                          {keymap.isFastKeymapAvailable
+                            ? t("Reset the saved keymap to the default keymap")
+                            : t(
+                                "Resetting to the default keymap requires the fast-keymap firmware module, which this keyboard does not expose.",
+                              )}
+                          <Tooltip.Arrow className="fill-[var(--color-surface-elevated)]" />
+                        </Tooltip.Content>
+                      </Tooltip.Portal>
+                    </Tooltip.Root>
+                  </Tooltip.Provider>
                   <button
                     className="btn-electric text-sm flex items-center gap-1.5"
                     onClick={handleSave}
@@ -736,6 +796,9 @@ export function KeymapPage() {
                   onKeyClick={handleKeyClick}
                   onKeyReset={handleKeyReset}
                   isBindingModified={keymap.isBindingModified}
+                  isBindingChangedFromDefault={
+                    keymap.isBindingChangedFromDefault
+                  }
                   getOriginalBinding={keymap.getOriginalBinding}
                   keyboardLayout={keyboardLayoutContext.layout}
                   runtimeMacros={runtimeMacro.macros}
@@ -803,7 +866,7 @@ export function KeymapPage() {
           <p className="text-xs text-[var(--color-text-muted)]">
             {connection.isConnected
               ? t(
-                  "Click on a key to modify its binding. Modified keys are highlighted in green and show the original binding on hover. Use the Reset All button to discard all changes.",
+                  "Click on a key to modify its binding. Modified keys are highlighted in green and show the original binding on hover. Use the Discard button to drop unsaved changes, or Reset to restore the default keymap.",
                 )
               : t(
                   "Connect your keyboard to edit keymaps. Click on a key to modify its binding.",
@@ -860,6 +923,51 @@ export function KeymapPage() {
                   <IconLoader2 size={16} className="animate-spin" />
                 )}
                 {t("Rename")}
+              </button>
+            </div>
+          </Dialog.Content>
+        </Dialog.Portal>
+      </Dialog.Root>
+
+      {/* Reset-to-Default Confirmation Dialog */}
+      <Dialog.Root
+        open={showResetDialog}
+        onOpenChange={(open) => {
+          if (!open && !isResetting) setShowResetDialog(false);
+        }}
+      >
+        <Dialog.Portal>
+          <Dialog.Overlay className="fixed inset-0 bg-black/50 backdrop-blur-sm z-50" />
+          <Dialog.Content className="fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[90vw] max-w-md bg-[var(--color-surface)] rounded-xl border border-[var(--color-border)] shadow-2xl z-50 p-6">
+            <Dialog.Title className="text-base font-medium text-[var(--color-text)] mb-2 flex items-center gap-2">
+              <IconAlertTriangle
+                size={18}
+                className="text-[var(--color-warning)]"
+              />
+              {t("Reset to default keymap?")}
+            </Dialog.Title>
+            <Dialog.Description className="text-sm text-[var(--color-text-muted)] mb-5">
+              {t(
+                "This resets the saved keymap on your keyboard back to its hard-coded default and writes it to flash immediately. All saved key bindings will be lost. This cannot be undone.",
+              )}
+            </Dialog.Description>
+            <div className="flex gap-3">
+              <button
+                className="flex-1 btn-ghost border border-[var(--color-border)]"
+                onClick={() => setShowResetDialog(false)}
+                disabled={isResetting}
+              >
+                {t("Cancel")}
+              </button>
+              <button
+                className="flex-1 btn-electric flex items-center justify-center gap-2"
+                onClick={() => void handleResetToDefault()}
+                disabled={isResetting}
+              >
+                {isResetting && (
+                  <IconLoader2 size={16} className="animate-spin" />
+                )}
+                {t("Reset to default")}
               </button>
             </div>
           </Dialog.Content>

--- a/src/pages/KeymapPage.tsx
+++ b/src/pages/KeymapPage.tsx
@@ -137,6 +137,16 @@ export function KeymapPage() {
     [currentLayer, keymap, requireUnlocked],
   );
 
+  // Handle key reset-to-default (in-memory edit; becomes an unsaved change)
+  const handleKeyResetToDefault = useCallback(
+    async (keyPosition: number) => {
+      if (!requireUnlocked()) return;
+      if (!currentLayer) return;
+      await keymap.resetBindingToDefault(currentLayer.id, keyPosition);
+    },
+    [currentLayer, keymap, requireUnlocked],
+  );
+
   // Handle binding selection
   const handleBindingSelect = useCallback(
     async (binding: BehaviorBinding) => {
@@ -795,11 +805,13 @@ export function KeymapPage() {
                   selectedKey={selectedKeyPosition}
                   onKeyClick={handleKeyClick}
                   onKeyReset={handleKeyReset}
+                  onKeyResetToDefault={handleKeyResetToDefault}
                   isBindingModified={keymap.isBindingModified}
                   isBindingChangedFromDefault={
                     keymap.isBindingChangedFromDefault
                   }
                   getOriginalBinding={keymap.getOriginalBinding}
+                  getDefaultBinding={keymap.getDefaultBinding}
                   keyboardLayout={keyboardLayoutContext.layout}
                   runtimeMacros={runtimeMacro.macros}
                   modules={

--- a/src/pages/KeymapPage.tsx
+++ b/src/pages/KeymapPage.tsx
@@ -395,11 +395,6 @@ export function KeymapPage() {
                 </button>
               ) : (
                 <>
-                  {keymap.hasUnsavedChanges && (
-                    <span className="text-xs text-[var(--color-neon)] mr-2">
-                      {t("● Unsaved changes")}
-                    </span>
-                  )}
                   <button
                     className="btn-ghost text-sm flex items-center gap-1.5 flex-shrink-0"
                     onClick={handleDiscard}
@@ -796,7 +791,28 @@ export function KeymapPage() {
 
             {/* Keyboard Layout */}
             {currentLayer && (
-              <div className="glass-card p-8">
+              <div className="glass-card p-8 relative">
+                {/* Saved / unsaved status indicator */}
+                <div className="absolute top-3 right-3 z-10 flex items-center gap-1.5 px-2 py-1 rounded-full border border-[var(--color-border)] bg-[var(--color-surface)]/70 text-xs">
+                  <span
+                    className={`w-2 h-2 rounded-full ${
+                      keymap.hasUnsavedChanges
+                        ? "bg-[var(--color-neon)]"
+                        : "bg-[var(--color-text-muted)]"
+                    }`}
+                  />
+                  <span
+                    className={
+                      keymap.hasUnsavedChanges
+                        ? "text-[var(--color-neon)]"
+                        : "text-[var(--color-text-muted)]"
+                    }
+                  >
+                    {keymap.hasUnsavedChanges
+                      ? t("Unsaved changes")
+                      : t("Saved")}
+                  </span>
+                </div>
                 <KeyboardLayout
                   layout={currentLayout}
                   layer={currentLayer}

--- a/src/pages/__tests__/KeymapPage.test.tsx
+++ b/src/pages/__tests__/KeymapPage.test.tsx
@@ -148,6 +148,7 @@ describe("KeymapPage", () => {
       isBindingModified: jest.fn().mockReturnValue(false),
       isFastKeymapAvailable: false,
       isBindingChangedFromDefault: jest.fn().mockReturnValue(false),
+      isKeymapChangedFromDefault: false,
       getBehavior: jest.fn(),
       getBindingDisplayName: jest.fn().mockReturnValue("Key"),
       clearUnlockRequired: jest.fn(),
@@ -295,6 +296,28 @@ describe("KeymapPage", () => {
 
       expect(screen.getByText("Saved")).toBeInTheDocument();
       expect(screen.queryByText("Unsaved changes")).not.toBeInTheDocument();
+    });
+
+    it("marks the saved indicator when the keymap differs from the default", () => {
+      renderComponent(
+        { isConnected: true },
+        {
+          keymap: mockKeymap,
+          physicalLayouts: mockPhysicalLayouts,
+          behaviors: mockBehaviors,
+          hasUnsavedChanges: false,
+          isKeymapChangedFromDefault: true,
+        },
+      );
+
+      // Still reads "Saved", but tinted electric and carrying the explanatory
+      // title (the blue-dot state).
+      const label = screen.getByText("Saved");
+      expect(label).toBeInTheDocument();
+      expect(label.className).toContain("--color-electric");
+      expect(
+        screen.getByTitle("Saved — changed from the default keymap"),
+      ).toBeInTheDocument();
     });
 
     it("should show save and reset buttons when connected", () => {

--- a/src/pages/__tests__/KeymapPage.test.tsx
+++ b/src/pages/__tests__/KeymapPage.test.tsx
@@ -278,7 +278,23 @@ describe("KeymapPage", () => {
         },
       );
 
-      expect(screen.getByText("● Unsaved changes")).toBeInTheDocument();
+      expect(screen.getByText("Unsaved changes")).toBeInTheDocument();
+      expect(screen.queryByText("Saved")).not.toBeInTheDocument();
+    });
+
+    it("should show the saved indicator when there are no unsaved changes", () => {
+      renderComponent(
+        { isConnected: true },
+        {
+          keymap: mockKeymap,
+          physicalLayouts: mockPhysicalLayouts,
+          behaviors: mockBehaviors,
+          hasUnsavedChanges: false,
+        },
+      );
+
+      expect(screen.getByText("Saved")).toBeInTheDocument();
+      expect(screen.queryByText("Unsaved changes")).not.toBeInTheDocument();
     });
 
     it("should show save and reset buttons when connected", () => {

--- a/src/pages/__tests__/KeymapPage.test.tsx
+++ b/src/pages/__tests__/KeymapPage.test.tsx
@@ -127,6 +127,7 @@ describe("KeymapPage", () => {
       loadKeymapData: jest.fn(),
       setBinding: jest.fn().mockResolvedValue(true),
       resetBinding: jest.fn().mockResolvedValue(true),
+      resetBindingToDefault: jest.fn().mockResolvedValue(true),
       moveLayer: jest.fn().mockResolvedValue(true),
       addLayer: jest.fn().mockResolvedValue({
         index: 0,
@@ -143,6 +144,7 @@ describe("KeymapPage", () => {
       resetToDefault: jest.fn().mockResolvedValue(true),
       setActiveLayout: jest.fn().mockResolvedValue(true),
       getOriginalBinding: jest.fn().mockReturnValue(null),
+      getDefaultBinding: jest.fn().mockReturnValue(null),
       isBindingModified: jest.fn().mockReturnValue(false),
       isFastKeymapAvailable: false,
       isBindingChangedFromDefault: jest.fn().mockReturnValue(false),

--- a/src/pages/__tests__/KeymapPage.test.tsx
+++ b/src/pages/__tests__/KeymapPage.test.tsx
@@ -140,9 +140,12 @@ describe("KeymapPage", () => {
       removedLayerIds: [],
       saveChanges: jest.fn().mockResolvedValue(true),
       discardChanges: jest.fn().mockResolvedValue(true),
+      resetToDefault: jest.fn().mockResolvedValue(true),
       setActiveLayout: jest.fn().mockResolvedValue(true),
       getOriginalBinding: jest.fn().mockReturnValue(null),
       isBindingModified: jest.fn().mockReturnValue(false),
+      isFastKeymapAvailable: false,
+      isBindingChangedFromDefault: jest.fn().mockReturnValue(false),
       getBehavior: jest.fn(),
       getBindingDisplayName: jest.fn().mockReturnValue("Key"),
       clearUnlockRequired: jest.fn(),
@@ -287,7 +290,48 @@ describe("KeymapPage", () => {
       );
 
       expect(screen.getByText("Save")).toBeInTheDocument();
-      expect(screen.getByText("Reset All")).toBeInTheDocument();
+      expect(screen.getByText("Discard")).toBeInTheDocument();
+      expect(screen.getByText("Reset")).toBeInTheDocument();
+    });
+
+    it("disables Reset when the fast-keymap subsystem is unavailable", () => {
+      renderComponent(
+        { isConnected: true },
+        {
+          keymap: mockKeymap,
+          physicalLayouts: mockPhysicalLayouts,
+          behaviors: mockBehaviors,
+          isFastKeymapAvailable: false,
+        },
+      );
+
+      expect(screen.getByText("Reset").closest("button")).toBeDisabled();
+    });
+
+    it("resets to default via the confirmation dialog when fast-keymap is available", async () => {
+      const user = userEvent.setup();
+      const resetToDefault = jest.fn().mockResolvedValue(true);
+      renderComponent(
+        { isConnected: true },
+        {
+          keymap: mockKeymap,
+          physicalLayouts: mockPhysicalLayouts,
+          behaviors: mockBehaviors,
+          isFastKeymapAvailable: true,
+          resetToDefault,
+        },
+      );
+
+      const resetButton = screen.getByText("Reset").closest("button");
+      expect(resetButton).not.toBeDisabled();
+      await user.click(resetButton!);
+
+      // Confirmation dialog appears; reset only fires after confirming.
+      expect(screen.getByText("Reset to default keymap?")).toBeInTheDocument();
+      expect(resetToDefault).not.toHaveBeenCalled();
+
+      await user.click(screen.getByText("Reset to default"));
+      expect(resetToDefault).toHaveBeenCalledTimes(1);
     });
 
     it("shows a Locked badge instead of Save/Reset when Studio is locked", () => {
@@ -306,7 +350,8 @@ describe("KeymapPage", () => {
 
       expect(screen.getByText("Locked")).toBeInTheDocument();
       expect(screen.queryByText("Save")).not.toBeInTheDocument();
-      expect(screen.queryByText("Reset All")).not.toBeInTheDocument();
+      expect(screen.queryByText("Discard")).not.toBeInTheDocument();
+      expect(screen.queryByText("Reset")).not.toBeInTheDocument();
     });
 
     it("opens the unlock prompt when the Locked badge is clicked", async () => {


### PR DESCRIPTION
## Description

Splits the single **Reset All** keymap control into two clearer actions and adds a modest highlight for keys whose *persisted* value differs from the hard-coded default keymap.

### What changed

- **Discard** — reverts in-memory edits to the persisted keymap. This is the existing `keymap.discardChanges` flow; the old "Reset All" label was renamed to "Discard" to match the semantics.
- **Reset** — resets the *persisted* keymap back to the devicetree-stock default and writes it to flash immediately, behind a confirmation modal. Disabled (with an explanatory tooltip) when the `cormoran__fast_keymap` subsystem is absent, since only it exposes the default keymap.
- **Changed-from-default highlight** — keys whose persisted binding differs from the default get a subtle electric-tinted border, a small corner dot, and a tooltip note. It is visually distinct from the existing green in-memory-modified highlight, which takes precedence. Skipped entirely when fast-keymap is unavailable.

### How it loads (BLE-friendly)

The default keymap is fetched via `get_default_layer` (one round-trip per layer) **only as the final step** of the keymap load — gated on `isFullyLoaded && isFastKeymapAvailable` — mirroring the existing runtime-macro deferral so it never blocks the preview. A best-effort failure just leaves the highlight and Reset unavailable.

### Notes for reviewers

- Both Reset and the highlight require the fast-keymap module; without it, highlighting is skipped and Reset is disabled — as intended.
- **Scope:** Reset resets *bindings* for existing layers to their defaults. It does not undo layer add/remove/rename/reorder (reverting layer structure would be a materially larger change). Happy to follow up if wanted.
- New unit tests cover `loadDefaultKeymap` (fast + official paths); new UI tests cover Reset gating on fast-keymap availability and the confirm-dialog flow. Japanese translations added for all new strings.
- Verified in the browser (demo mode): buttons render; Reset disabled with the correct tooltip when fast-keymap is absent; editing a key enables Discard/Save while Reset stays gated; no console errors from the new code. The functional Reset and the highlight require a real fast-keymap device (the demo doesn't expose it), so those paths are covered by unit tests.

## CLA (Contributor License Agreement)

By submitting this pull request, I agree that my contributions
are licensed under the project's current license.

I also grant the maintainer(s) of this project the right to relicense
my contributions under any license, for use in future versions of the project.
This does not affect the license of any previously released versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)