### PR TITLE
feat(subsystems): recognize fast-keymap and setting-expose subsystems

### DIFF
--- a/src/hooks/useKeymapSource.ts
+++ b/src/hooks/useKeymapSource.ts
@@ -49,7 +49,8 @@ import {
 import type { TranslationParams } from "../i18n/translations";
 
 /** Identifier the fast-keymap module registers on the device. */
-const FAST_KEYMAP_SUBSYSTEM = "cormoran__fast_keymap";
+export const FAST_KEYMAP_SUBSYSTEM_IDENTIFIER = "cormoran__fast_keymap";
+const FAST_KEYMAP_SUBSYSTEM = FAST_KEYMAP_SUBSYSTEM_IDENTIFIER;
 
 /** ts-proto codec for the fast_keymap Request/Response wire messages. */
 const FAST_KEYMAP_CODEC = {

--- a/src/lib/transport/demo-subsystems.ts
+++ b/src/lib/transport/demo-subsystems.ts
@@ -28,6 +28,18 @@ import { DEFAULT_LAYER_IDENTIFIER } from "./demo-default-layer";
 /** Identifier the fast-keymap module registers on the device. */
 export const FAST_KEYMAP_IDENTIFIER = "cormoran__fast_keymap";
 
+/**
+ * Identifier the zephyr-setting-expose module registers on the device.
+ * DYA Studio has no dedicated UI for it; it ships its own external web UI, so
+ * the Subsystems tab surfaces it as an external-link card (see
+ * SETTING_EXPOSE_UI_URL).
+ */
+export const SETTING_EXPOSE_IDENTIFIER = "zmk__setting_expose";
+
+/** External web UI published by the zephyr-setting-expose firmware module. */
+export const SETTING_EXPOSE_UI_URL =
+  "https://cormoran.github.io/zmk-feature-zephyr-setting-expose/";
+
 /** localStorage key holding `{ [identifier]: boolean }` overrides. */
 const OVERRIDES_KEY = "dya-studio-demo-subsystem-overrides";
 
@@ -140,6 +152,12 @@ export const DEMO_SUBSYSTEMS: DemoSubsystemInfo[] = [
     identifier: FAST_KEYMAP_IDENTIFIER,
     label: "Fast Keymap",
     defaultEnabled: false,
+  },
+  {
+    index: 16,
+    identifier: SETTING_EXPOSE_IDENTIFIER,
+    label: "Setting Expose",
+    defaultEnabled: true,
   },
 ];
 

--- a/src/lib/transport/demo.ts
+++ b/src/lib/transport/demo.ts
@@ -124,6 +124,8 @@ import {
 } from "../../proto/cormoran/fast_keymap/fast_keymap";
 import {
   FAST_KEYMAP_IDENTIFIER,
+  SETTING_EXPOSE_IDENTIFIER,
+  SETTING_EXPOSE_UI_URL,
   isDemoSubsystemEnabled,
 } from "./demo-subsystems";
 import {
@@ -261,6 +263,7 @@ class Keyboard {
   private readonly OS_DETECTION_SUBSYSTEM_INDEX = 13;
   private readonly DEFAULT_LAYER_SUBSYSTEM_INDEX = 14;
   private readonly FAST_KEYMAP_SUBSYSTEM_INDEX = 15;
+  private readonly SETTING_EXPOSE_SUBSYSTEM_INDEX = 16;
 
   constructor() {
     this.customSettingsHandler = new CustomSettingsHandler(
@@ -354,6 +357,14 @@ class Keyboard {
       index: this.FAST_KEYMAP_SUBSYSTEM_INDEX,
       identifier: FAST_KEYMAP_IDENTIFIER,
       uiUrl: [],
+    },
+    {
+      // No dedicated DYA Studio UI: the firmware module ships its own external
+      // web UI, so this advertises a uiUrl and shows up as an external-link
+      // card on the Subsystems tab.
+      index: this.SETTING_EXPOSE_SUBSYSTEM_INDEX,
+      identifier: SETTING_EXPOSE_IDENTIFIER,
+      uiUrl: [SETTING_EXPOSE_UI_URL],
     },
   ];
 

--- a/src/pages/CustomSubsystemsPage.tsx
+++ b/src/pages/CustomSubsystemsPage.tsx
@@ -34,6 +34,7 @@ import { SETTINGS_SUBSYSTEM_IDENTIFIER } from "../hooks/useSettings";
 import { BLE_MANAGEMENT_SUBSYSTEM_IDENTIFIER } from "../hooks/useBLEProfiles";
 import { OS_DETECTION_SUBSYSTEM_IDENTIFIER } from "../hooks/useOsDetection";
 import { DEVTOOL_SUBSYSTEM_IDENTIFIER } from "../hooks/useDevtool";
+import { FAST_KEYMAP_SUBSYSTEM_IDENTIFIER } from "../hooks/useKeymapSource";
 
 // Identifiers of subsystems DYA Studio already has a dedicated UI for
 // (mirrors the `*_IDENTIFIER` constants exported by src/hooks/*.ts).
@@ -54,6 +55,10 @@ const SUPPORTED_SUBSYSTEM_IDENTIFIERS = new Set<string>([
   BLE_MANAGEMENT_SUBSYSTEM_IDENTIFIER,
   OS_DETECTION_SUBSYSTEM_IDENTIFIER,
   DEVTOOL_SUBSYSTEM_IDENTIFIER,
+  // Fast keymap has no dedicated tab of its own — it transparently powers the
+  // Keymap tab's fast-loading path (see useKeymapSource), so DYA Studio still
+  // fully handles it and it belongs with the already-supported subsystems.
+  FAST_KEYMAP_SUBSYSTEM_IDENTIFIER,
 ]);
 
 type Subsystem = ListCustomSubsystemResponse["subsystems"][number];

--- a/src/pages/__tests__/CustomSubsystemsPage.test.tsx
+++ b/src/pages/__tests__/CustomSubsystemsPage.test.tsx
@@ -203,6 +203,64 @@ describe("CustomSubsystemsPage", () => {
       expect(screen.getByText("zmk__settings")).toBeInTheDocument();
     });
 
+    it("should treat the fast-keymap subsystem as already supported", () => {
+      const subsystems = createMockSubsystems([
+        { index: 0, identifier: "cormoran__fast_keymap", uiUrl: [] },
+      ]);
+      renderComponent({
+        state: {
+          connection: null,
+          deviceInfo: null,
+          customSubsystems: subsystems,
+          isLoading: false,
+          error: null,
+        },
+      });
+
+      // Fast keymap powers the Keymap tab, so it is grouped under the
+      // collapsed "already supported" section rather than shown prominently.
+      expect(
+        screen.queryByText("cormoran__fast_keymap"),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.getByText(
+          "All custom subsystems reported by this device are already supported by DYA Studio.",
+        ),
+      ).toBeInTheDocument();
+    });
+
+    it("should keep the setting-expose subsystem as a prominent external card", () => {
+      const subsystems = createMockSubsystems([
+        {
+          index: 0,
+          identifier: "zmk__setting_expose",
+          uiUrl: [
+            "https://cormoran.github.io/zmk-feature-zephyr-setting-expose/",
+          ],
+        },
+      ]);
+      renderComponent({
+        state: {
+          connection: null,
+          deviceInfo: null,
+          customSubsystems: subsystems,
+          isLoading: false,
+          error: null,
+        },
+      });
+
+      // No dedicated DYA Studio UI: shown prominently with its external web UI.
+      expect(screen.getByText("zmk__setting_expose")).toBeInTheDocument();
+      expect(
+        screen.getByText(
+          "https://cormoran.github.io/zmk-feature-zephyr-setting-expose/",
+        ),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByText("Already supported by DYA Studio"),
+      ).not.toBeInTheDocument();
+    });
+
     it("should not show the collapsed section when no subsystems are already supported", () => {
       const subsystems = createMockSubsystems([
         { index: 0, identifier: "zmk__unsupported", uiUrl: [] },


### PR DESCRIPTION
## What & why

The dya keyboard firmware now bundles two more modules (confirmed in dya2's `west-dependency.yml`): `zmk-feature-fast-keymap` and `zmk-feature-zephyr-setting-expose`. This updates the **Subsystems** tab so both are recognized correctly.

### `cormoran__fast_keymap` → grouped as supported
DYA Studio already fully handles this subsystem — it transparently powers the Keymap tab's fast-loading path (`useKeymapSource`). But it was missing from `SUPPORTED_SUBSYSTEM_IDENTIFIERS`, so on a real device it would wrongly appear in the prominent "unsupported" list. It now groups under **"Already supported by DYA Studio."** The identifier is exported from `useKeymapSource` for the page to reference.

### `zmk__setting_expose` → external-link card
This module has **no dedicated UI inside DYA Studio**; it ships its own external web UI (`cormoran.github.io/zmk-feature-zephyr-setting-expose/`). It's intentionally **kept out** of the supported set so it stays a prominent card and users can click through to the firmware author's settings editor. Demo mode now advertises it (index 16, with its `uiUrl`) so the external-card path is exercisable without hardware.

## Changes
- `useKeymapSource.ts` — export `FAST_KEYMAP_SUBSYSTEM_IDENTIFIER`.
- `CustomSubsystemsPage.tsx` — add fast_keymap to `SUPPORTED_SUBSYSTEM_IDENTIFIERS`.
- `demo-subsystems.ts` / `demo.ts` — advertise `zmk__setting_expose` as an external-card demo subsystem.
- `CustomSubsystemsPage.test.tsx` — tests for both behaviors.

## Reviewer notes
- The `setting_expose` treatment (external card, not "supported") was a deliberate product decision — it has a first-party external web UI rather than an in-app page.
- Verified live in demo mode: `zmk__setting_expose` renders as a prominent card with its web-UI link; the supported ones sit in the collapsed section.
- Full suite green (50 suites / 435 tests), `tsc` + eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)