### PR TITLE
fix(home): update outdated FAQ answers on top page

### DIFF
--- a/src/i18n/translations.ts
+++ b/src/i18n/translations.ts
@@ -88,12 +88,10 @@ const ja: Record<string, string> = {
     "警告: cormoran の ZMK fork は非常に実験的で、DYA キーボード向けに最適化されています。不安定な変更や破壊的変更を含む可能性があります。自己責任で使用してください。まれにキーボードハードウェアの誤動作や損傷につながる場合があります。",
   "Q: Can I get source code of DYA Studio?":
     "Q: DYA Studio のソースコードを入手できますか？",
-  "A: No, for now. DYA Studio is currently closed source to avoid people relying on my heavily customized zmk-fork. If you have feedback or feature request, please complaint on X with #dya_studio hashtag.":
-    "A: 現時点ではできません。DYA Studio は、強くカスタマイズされた zmk-fork への依存を避けるため、現在クローズドソースです。フィードバックや機能要望がある場合は、X で #dya_studio ハッシュタグを付けて投稿してください。",
   "Q: Are there plan to migrate the ZMK fork to ZMK v0.4.0?":
     "Q: ZMK fork を ZMK v0.4.0 へ移行する予定はありますか？",
-  "A: Yes, I'm willing but not soon...":
-    "A: はい、やる気はありますが、すぐではありません...",
+  "A: Yes, it's already done. The ZMK fork now tracks recent ZMK (Zephyr 4.x).":
+    "A: はい、すでに移行済みです。ZMK fork は最新の ZMK（Zephyr 4.x）に追従しています。",
 
   "Configure key bindings and layers": "キー割り当てとレイヤーを設定します",
   "Unsaved changes": "未保存の変更",

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -316,10 +316,17 @@ export function HomePage() {
               <p className="text-sm text-[var(--color-text-muted)]">
                 {language === "ja" ? (
                   <>
-                    A: 現時点ではできません。DYA Studio
-                    は、強くカスタマイズされた zmk-fork
-                    への依存を避けるため、現在クローズドソースです。フィードバックや機能要望がある場合は、X
-                    で{" "}
+                    A: はい、DYA Studio
+                    はオープンソースになりました。ソースコードは{" "}
+                    <a
+                      href="https://github.com/cormoran/dya-studio"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="underline text-[var(--color-electric)] hover:text-[var(--color-neon)] transition-colors mx-1"
+                    >
+                      GitHub
+                    </a>{" "}
+                    で公開しています。フィードバックや機能要望がある場合は、X で{" "}
                     <a
                       href="https://x.com/intent/tweet?hashtags=dya_studio"
                       target="_blank"
@@ -332,10 +339,18 @@ export function HomePage() {
                   </>
                 ) : (
                   <>
-                    A: No, for now. DYA Studio is currently closed source to
-                    avoid people relying on my heavily customized zmk-fork. If
-                    you have feedback or feature request, please complaint on X
-                    with{" "}
+                    A: Yes, DYA Studio is now open source. You can find the
+                    source code on{" "}
+                    <a
+                      href="https://github.com/cormoran/dya-studio"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="underline text-[var(--color-electric)] hover:text-[var(--color-neon)] transition-colors mx-1"
+                    >
+                      GitHub
+                    </a>
+                    . If you have feedback or feature request, please complaint
+                    on X with{" "}
                     <a
                       href="https://x.com/intent/tweet?hashtags=dya_studio"
                       target="_blank"
@@ -354,7 +369,9 @@ export function HomePage() {
                 {t("Q: Are there plan to migrate the ZMK fork to ZMK v0.4.0?")}
               </p>
               <p className="text-sm text-[var(--color-text-muted)]">
-                {t("A: Yes, I'm willing but not soon...")}
+                {t(
+                  "A: Yes, it's already done. The ZMK fork now tracks recent ZMK (Zephyr 4.x).",
+                )}
               </p>
             </div>
           </div>


### PR DESCRIPTION
## What changed

Updated two stale Q&A entries in the Home page (top page) Q&A section:

1. **"Can I get source code of DYA Studio?"** — previously answered that the project is closed source. `cormoran/dya-studio` is now a public repository, so the answer now says DYA Studio is open source and links to [GitHub](https://github.com/cormoran/dya-studio) (keeping the `#dya_studio` feedback line).
2. **"Are there plan to migrate the ZMK fork to ZMK v0.4.0?"** — previously answered "willing but not soon". The fork now tracks recent ZMK (Zephyr 4.x), so the answer now states the migration is already done.

Also removed the now-unused closed-source translation key from `src/i18n/translations.ts`.

## Why

Both answers no longer reflect reality and were misleading to visitors.

## Notes for reviewers

- Both EN and JA renderings were verified in the dev server via demo mode (Home tab → Q&A): new answers appear, stale text is gone.
- There is a pre-existing React hydration console warning in the *first* Q&A answer (a `<div>` warning-box nested inside a `<p>`), unrelated to this change and left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)