### PR TITLE
feat(ui): unify edit flow across editing features

### DIFF
--- a/proto/cormoran/runtime_macro/runtime_macro.proto
+++ b/proto/cormoran/runtime_macro/runtime_macro.proto
@@ -24,6 +24,12 @@ message MacroSummary {
     uint32 slot = 1;
     string name = 2;
     uint32 encoded_size = 3;
+    // True when the macro has an in-memory-only change not yet written to
+    // flash (a memory-mode create/edit, or a value that differs from the
+    // persisted one). Cleared by SaveMacros / DiscardMacros. A devicetree
+    // default that has never been saved also reports true, since it lives
+    // only in memory until the user saves it.
+    bool has_unsaved_changes = 4;
 }
 
 message BehaviorBinding {
@@ -94,6 +100,18 @@ message RenameMacroRequest {
     bool persist = 3;
 }
 
+// Reset the macro at `slot` to its compile-time (devicetree) state: if a
+// `cormoran,runtime-macro-default` node declares a macro whose name matches
+// this macro's, overwrite the body with that default; otherwise (no such
+// compile-time default) delete the macro entirely - "reset" of a macro that
+// only ever existed at runtime means removing it. `persist` writes the reset
+// result straight to flash (otherwise it lives in memory until SaveMacros /
+// is re-seeded from the devicetree next boot).
+message ResetMacroRequest {
+    uint32 slot = 1;
+    bool persist = 2;
+}
+
 message Request {
     reserved 3,
         8; // formerly set_macro_name, delete_macro
@@ -110,6 +128,7 @@ message Request {
         CreateMacroRequest create_macro = 12;
         DeleteMacroRequest delete_macro = 13;
         RenameMacroRequest rename_macro = 14;
+        ResetMacroRequest reset_macro = 15;
     }
 }
 

--- a/proto/cormoran/zmk/custom_settings/custom_settings.proto
+++ b/proto/cormoran/zmk/custom_settings/custom_settings.proto
@@ -135,18 +135,31 @@ message Setting {
     // Omitted for DEVICE_PRIVATE settings and secure settings while locked.
     SettingValue value = 9;
     uint32 source = 10;
+    // The setting's default value (its runtime override if one was installed,
+    // otherwise its compile-time default). Present only when the request set
+    // require_default AND the current value differs from that default, so a
+    // client can offer a "reset to default" affordance without a second round
+    // trip. Never present for array or keyspace settings (which have no
+    // compile-time default).
+    optional SettingValue default_value = 11;
 }
 
 message ListSettingsRequest {
     SettingScope scope = 1;
     // Include static metadata in each list item notification.
     bool require_meta = 2;
+    // Include each setting's default value (see Setting.default_value); only
+    // emitted for settings whose current value differs from the default.
+    bool require_default = 3;
 }
 
 message GetSettingRequest {
     SettingRef setting = 1;
     // Include static metadata in the get response.
     bool require_meta = 2;
+    // Include the setting's default value (see Setting.default_value); only
+    // emitted when the current value differs from the default.
+    bool require_default = 3;
 }
 
 message WriteSettingRequest {

--- a/src/components/AdvancedSettingsSection.tsx
+++ b/src/components/AdvancedSettingsSection.tsx
@@ -26,6 +26,8 @@ import {
   type CustomSettingsSection,
   type UseCustomSettingsReturn,
 } from "../hooks/useCustomSettings";
+import { MEMORY_WRITE_DEBOUNCE_MS } from "../hooks/useDebouncedMemoryWrite";
+import { StatusBadge, StatusDot, type EditStatus } from "./EditStatusIndicator";
 import { useKeymap, type BehaviorDefinition } from "../hooks/useKeymap";
 import { useLanguage } from "../hooks/useLanguage";
 import {
@@ -37,8 +39,6 @@ import {
 } from "../proto/cormoran/zmk/custom_settings/custom_settings";
 
 type ValueKind = "bytes" | "int32" | "bool" | "string" | "behavior" | "unknown";
-
-const MEMORY_WRITE_DEBOUNCE_MS = 1500;
 
 // Input that keeps its own local value while focused so that parent-driven
 // updates (e.g. after a debounced memory write completes) don't reset the
@@ -811,6 +811,15 @@ function SettingRow({
   );
   const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
+  // Green when the value lives only in memory, blue when it is persisted but
+  // differs from the compile-time default (device reports defaultValue only in
+  // that case), nothing when it matches the default.
+  const editStatus: EditStatus = setting.hasUnsavedValue
+    ? "unsaved"
+    : setting.defaultValue !== undefined
+      ? "modified"
+      : "default";
+
   useEffect(() => {
     return () => {
       if (timeoutRef.current) {
@@ -839,13 +848,7 @@ function SettingRow({
           <p className="truncate text-sm font-medium text-[var(--color-text)]">
             {settingLabel(setting)}
           </p>
-          {setting.hasUnsavedValue && (
-            <span
-              className="h-1.5 w-1.5 flex-shrink-0 rounded-full bg-[var(--color-neon)]"
-              title={t("Unsaved")}
-              aria-label={t("Unsaved")}
-            />
-          )}
+          <StatusDot status={editStatus} />
         </div>
         <p className="mt-1 truncate font-mono text-xs text-[var(--color-text-muted)]">
           {formatValue(setting, t)}
@@ -974,6 +977,11 @@ export function CustomSettingsSectionCard({
   const hasUnsavedChanges = section.settings.some(
     (setting) => setting.hasUnsavedValue,
   );
+  // Blue summary: nothing is queued in memory, but at least one persisted value
+  // differs from its compile-time default (device reports defaultValue).
+  const hasModifiedFromDefault = section.settings.some(
+    (setting) => setting.defaultValue !== undefined,
+  );
   const sortedSettings = [...section.settings].sort((a, b) =>
     settingSortValue(a).localeCompare(settingSortValue(b)),
   );
@@ -1029,11 +1037,11 @@ export function CustomSettingsSectionCard({
           </div>
         </button>
         <div className="flex flex-wrap items-center justify-end gap-2">
-          {hasUnsavedChanges && (
-            <span className="text-xs text-[var(--color-neon)]">
-              {t("● Unsaved")}
-            </span>
-          )}
+          {hasUnsavedChanges ? (
+            <StatusBadge status="unsaved" />
+          ) : hasModifiedFromDefault ? (
+            <StatusBadge status="modified" />
+          ) : null}
           <button
             type="button"
             className="btn-electric flex items-center gap-2 px-3 py-2 text-sm"

--- a/src/components/EditStatusIndicator.tsx
+++ b/src/components/EditStatusIndicator.tsx
@@ -1,0 +1,155 @@
+import * as Tooltip from "@radix-ui/react-tooltip";
+import { useLanguage } from "../hooks/useLanguage";
+
+/**
+ * Unified edit-status vocabulary shared by every editing surface (keymap,
+ * combo, macro, custom settings, ...). Keeping one enum + one dot component
+ * means the green/blue/stock convention looks and reads identically everywhere.
+ *
+ * - "unsaved"  → value written to keyboard RAM but not yet persisted to flash.
+ *               Reverted by Discard. Rendered GREEN (--color-neon).
+ * - "modified" → value is persisted but differs from the compile-time default.
+ *               Reverted by Reset. Rendered BLUE (--color-electric).
+ * - "default"  → persisted value equals the compile-time default. No dot.
+ */
+export type EditStatus = "unsaved" | "modified" | "default";
+
+const DOT_COLOR: Record<EditStatus, string> = {
+  unsaved: "bg-[var(--color-neon)]",
+  modified: "bg-[var(--color-electric)]",
+  default: "bg-[var(--color-text-muted)]",
+};
+
+const TEXT_COLOR: Record<EditStatus, string> = {
+  unsaved: "text-[var(--color-neon)]",
+  modified: "text-[var(--color-electric)]",
+  default: "text-[var(--color-text-muted)]",
+};
+
+const DOT_SIZE = {
+  sm: "h-1.5 w-1.5",
+  md: "h-2 w-2",
+} as const;
+
+/** Human-readable label for a status (already translated). */
+function useEditStatusLabel(): (status: EditStatus) => string {
+  const { t } = useLanguage();
+  return (status: EditStatus) => {
+    switch (status) {
+      case "unsaved":
+        return t("Unsaved");
+      case "modified":
+        return t("Changed from default");
+      case "default":
+        return t("Default");
+    }
+  };
+}
+
+interface StatusDotProps {
+  status: EditStatus;
+  /** Dot diameter. Defaults to "sm" (1.5) to match inline label rows. */
+  size?: keyof typeof DOT_SIZE;
+  /** Render the muted dot for the "default" state. Off by default (no dot). */
+  showDefault?: boolean;
+  className?: string;
+}
+
+/**
+ * Small colored dot indicating a value's edit status. Carries its own
+ * title/aria-label so it is self-describing next to any label.
+ */
+export function StatusDot({
+  status,
+  size = "sm",
+  showDefault = false,
+  className = "",
+}: StatusDotProps) {
+  const label = useEditStatusLabel()(status);
+  if (status === "default" && !showDefault) {
+    return null;
+  }
+  return (
+    <span
+      className={`flex-shrink-0 rounded-full ${DOT_SIZE[size]} ${DOT_COLOR[status]} ${className}`}
+      title={label}
+      aria-label={label}
+    />
+  );
+}
+
+interface StatusBadgeProps {
+  status: EditStatus;
+  /** Optional override text; defaults to the status label. */
+  text?: string;
+  size?: keyof typeof DOT_SIZE;
+  className?: string;
+}
+
+/**
+ * Dot + text label, for section headers that summarize a group's status.
+ * Renders nothing for the "default" state (nothing worth calling out).
+ */
+export function StatusBadge({
+  status,
+  text,
+  size = "sm",
+  className = "",
+}: StatusBadgeProps) {
+  const label = useEditStatusLabel()(status);
+  if (status === "default") {
+    return null;
+  }
+  return (
+    <span
+      className={`inline-flex items-center gap-1.5 text-xs ${TEXT_COLOR[status]} ${className}`}
+    >
+      <StatusDot status={status} size={size} />
+      {text ?? label}
+    </span>
+  );
+}
+
+/**
+ * Shared legend explaining the green/blue dot convention. Drop next to a
+ * group's controls so users can decode the dots without guessing.
+ */
+export function EditStatusLegend() {
+  const { t } = useLanguage();
+  return (
+    <Tooltip.Provider delayDuration={200}>
+      <Tooltip.Root>
+        <Tooltip.Trigger asChild>
+          <button
+            type="button"
+            className="inline-flex items-center gap-1 text-xs text-[var(--color-text-muted)] hover:text-[var(--color-text-secondary)] transition-colors"
+          >
+            <StatusDot status="unsaved" />
+            <StatusDot status="modified" />
+            {t("Legend")}
+          </button>
+        </Tooltip.Trigger>
+        <Tooltip.Portal>
+          <Tooltip.Content
+            className="px-3 py-2 rounded bg-[var(--color-surface-elevated)] border border-[var(--color-border)] text-xs text-[var(--color-text-secondary)] shadow-lg z-50 max-w-xs"
+            sideOffset={5}
+          >
+            <ul className="space-y-1.5">
+              <li className="flex items-center gap-2">
+                <StatusDot status="unsaved" />
+                {t("Green: in memory, not yet saved. Discard reverts it.")}
+              </li>
+              <li className="flex items-center gap-2">
+                <StatusDot status="modified" />
+                {t(
+                  "Blue: saved, but changed from the default. Reset restores the default.",
+                )}
+              </li>
+            </ul>
+            <Tooltip.Arrow className="fill-[var(--color-surface-elevated)]" />
+          </Tooltip.Content>
+        </Tooltip.Portal>
+      </Tooltip.Root>
+    </Tooltip.Provider>
+  );
+}

--- a/src/components/SensorRotationConfig.tsx
+++ b/src/components/SensorRotationConfig.tsx
@@ -12,6 +12,7 @@ import {
   IconInfoTriangle,
 } from "@tabler/icons-react";
 import { useRuntimeSensorRotate } from "../hooks/useRuntimeSensorRotate";
+import { MEMORY_WRITE_DEBOUNCE_MS } from "../hooks/useDebouncedMemoryWrite";
 import type { LayerBindings, Binding } from "../hooks/useRuntimeSensorRotate";
 import type { BehaviorDefinition } from "../hooks/useKeymap";
 import type { BehaviorBinding } from "../hooks/useKeymap";
@@ -248,7 +249,7 @@ export function SensorRotationConfig({
         });
 
         tapTimeTimersRef.current.delete(sensorIndex);
-      }, 3000); // 3 second debounce
+      }, MEMORY_WRITE_DEBOUNCE_MS);
 
       tapTimeTimersRef.current.set(sensorIndex, timer);
     },

--- a/src/components/__tests__/SensorRotationConfig.test.tsx
+++ b/src/components/__tests__/SensorRotationConfig.test.tsx
@@ -104,7 +104,7 @@ describe("SensorRotationConfig", () => {
       expect(mockSetLayerCcwBindings).not.toHaveBeenCalled();
 
       // Wait for debounce (3 seconds)
-      jest.advanceTimersByTime(3000);
+      jest.advanceTimersByTime(1500);
 
       // Now API should be called
       await waitFor(() => {
@@ -168,7 +168,7 @@ describe("SensorRotationConfig", () => {
       expect(screen.getByText(/pending/i)).toBeInTheDocument();
 
       // Advance timers to complete debounce
-      jest.advanceTimersByTime(3000);
+      jest.advanceTimersByTime(1500);
 
       // Wait for the update to complete
       await waitFor(() => {
@@ -222,21 +222,21 @@ describe("SensorRotationConfig", () => {
       await user.clear(tapTimeInput);
       await user.type(tapTimeInput, "10");
 
-      // Advance timer partially
-      jest.advanceTimersByTime(1500);
+      // Advance timer partially (less than the 1500ms debounce)
+      jest.advanceTimersByTime(750);
 
       // Second change before debounce completes
       await user.clear(tapTimeInput);
       await user.type(tapTimeInput, "20");
 
-      // Advance another 1500ms (total 3000ms from first change, but only 1500ms from second)
-      jest.advanceTimersByTime(1500);
+      // Advance another 750ms (only 750ms from the second change)
+      jest.advanceTimersByTime(750);
 
       // API should not be called yet
       expect(mockSetLayerCwBindings).not.toHaveBeenCalled();
 
-      // Advance another 1500ms to complete the second debounce
-      jest.advanceTimersByTime(1500);
+      // Advance another 750ms to complete the second debounce (1500ms total)
+      jest.advanceTimersByTime(750);
 
       // Now API should be called only once with the final value
       await waitFor(() => {
@@ -303,7 +303,7 @@ describe("SensorRotationConfig", () => {
       await user.type(tapTimeInputs[1], "20");
 
       // Advance timers
-      jest.advanceTimersByTime(3000);
+      jest.advanceTimersByTime(1500);
 
       // Both should be called with their respective values
       await waitFor(() => {

--- a/src/hooks/useCustomSettings.ts
+++ b/src/hooks/useCustomSettings.ts
@@ -262,6 +262,10 @@ export function useCustomSettings(
             listSettings: {
               scope: listScope,
               requireMeta: true,
+              // Ask the device to report the compile-time default alongside the
+              // current value (present only when they differ) so the UI can
+              // surface the blue "changed from default" indicator.
+              requireDefault: true,
             },
           }),
         ),

--- a/src/hooks/useDebouncedMemoryWrite.ts
+++ b/src/hooks/useDebouncedMemoryWrite.ts
@@ -1,0 +1,92 @@
+/**
+ * useDebouncedMemoryWrite
+ *
+ * Shared debounce for the unified edit flow: an input edit is written to
+ * keyboard RAM automatically after a short quiet period — no per-field save
+ * button. Every editing surface (combo, macro, custom settings, ...) uses the
+ * same delay and the same "queued → saving → idle" state so the experience is
+ * identical everywhere.
+ *
+ * This generalizes the inline timer that custom settings' SettingRow used to
+ * roll by hand. Persisting RAM to flash is a separate, explicit action (a
+ * section/page Save); this hook only covers the debounced memory write.
+ */
+import { useCallback, useEffect, useRef, useState } from "react";
+
+/** Shared debounce for auto-writing edits to keyboard memory. */
+export const MEMORY_WRITE_DEBOUNCE_MS = 1500;
+
+export type MemoryWriteState = "idle" | "queued" | "saving";
+
+export interface UseDebouncedMemoryWriteReturn<T> {
+  /** Current write state, for status text/indicators. */
+  state: MemoryWriteState;
+  /** Schedule a debounced memory write of `value`. */
+  queue: (value: T) => void;
+  /** Write any queued value immediately (e.g. on blur or before persist). */
+  flush: () => Promise<void>;
+  /** Drop any queued write without sending it. */
+  cancel: () => void;
+}
+
+export function useDebouncedMemoryWrite<T>(
+  write: (value: T) => Promise<void>,
+  delay: number = MEMORY_WRITE_DEBOUNCE_MS,
+): UseDebouncedMemoryWriteReturn<T> {
+  const [state, setState] = useState<MemoryWriteState>("idle");
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const pendingRef = useRef<{ value: T } | null>(null);
+  // Keep the latest writer without re-creating callbacks on every render.
+  const writeRef = useRef(write);
+  writeRef.current = write;
+
+  const clearTimer = useCallback(() => {
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+  }, []);
+
+  const runWrite = useCallback(async () => {
+    const pending = pendingRef.current;
+    if (!pending) return;
+    pendingRef.current = null;
+    clearTimer();
+    setState("saving");
+    try {
+      await writeRef.current(pending.value);
+    } catch (error) {
+      console.error("Debounced memory write failed:", error);
+    } finally {
+      setState("idle");
+    }
+  }, [clearTimer]);
+
+  const queue = useCallback(
+    (value: T) => {
+      pendingRef.current = { value };
+      clearTimer();
+      setState("queued");
+      timerRef.current = setTimeout(() => {
+        void runWrite();
+      }, delay);
+    },
+    [clearTimer, delay, runWrite],
+  );
+
+  const flush = useCallback(async () => {
+    if (pendingRef.current) {
+      await runWrite();
+    }
+  }, [runWrite]);
+
+  const cancel = useCallback(() => {
+    pendingRef.current = null;
+    clearTimer();
+    setState("idle");
+  }, [clearTimer]);
+
+  useEffect(() => () => clearTimer(), [clearTimer]);
+
+  return { state, queue, flush, cancel };
+}

--- a/src/hooks/useRuntimeMacro.ts
+++ b/src/hooks/useRuntimeMacro.ts
@@ -34,6 +34,9 @@ export interface UseRuntimeMacroReturn {
   createMacro: (name: string) => Promise<boolean>;
   deleteMacro: (name: string) => Promise<boolean>;
   renameMacro: (oldName: string, newName: string) => Promise<boolean>;
+  resetMacro: (slot: number, persist?: boolean) => Promise<boolean>;
+  /** Device truth: whether the slot has in-memory-only (unsaved) changes. */
+  isSlotUnsaved: (slot: number) => boolean;
   setMacroStepCount: (
     slot: number,
     stepCount: number,
@@ -316,6 +319,27 @@ export function useRuntimeMacro(
     [runMutation, loadMacros],
   );
 
+  const resetMacro = useCallback(
+    async (slot: number, persist = false): Promise<boolean> => {
+      const status = await runMutation(
+        Request.create({ resetMacro: { slot, persist } }),
+        persist,
+      );
+      if (status !== null) {
+        await loadMacros();
+        return true;
+      }
+      return false;
+    },
+    [runMutation, loadMacros],
+  );
+
+  const isSlotUnsaved = useCallback(
+    (slot: number): boolean =>
+      macros.find((macro) => macro.slot === slot)?.hasUnsavedChanges ?? false,
+    [macros],
+  );
+
   const saveMacros = useCallback(async (): Promise<boolean> => {
     const status = await runMutation(Request.create({ saveMacros: {} }), true);
     if (status) {
@@ -367,6 +391,8 @@ export function useRuntimeMacro(
     createMacro,
     deleteMacro,
     renameMacro,
+    resetMacro,
+    isSlotUnsaved,
     setMacroStepCount,
     setMacroStep,
     appendMacroStep,

--- a/src/i18n/translations.ts
+++ b/src/i18n/translations.ts
@@ -453,6 +453,15 @@ const ja: Record<string, string> = {
   Current: "現在値",
   "Discard item changes": "項目の変更を破棄",
   "Reset item to default": "項目を既定値にリセット",
+  "Changed from default": "デフォルトから変更",
+  "Reset this macro to its default?":
+    "このマクロをデフォルトにリセットしますか？",
+  "Reset this macro to its default": "このマクロをデフォルトにリセット",
+  Legend: "凡例",
+  "Green: in memory, not yet saved. Discard reverts it.":
+    "緑: メモリ内で未保存。破棄で元に戻ります。",
+  "Blue: saved, but changed from the default. Reset restores the default.":
+    "青: 保存済みだがデフォルトから変更されています。リセットでデフォルトに戻ります。",
   "Advanced Settings": "詳細設定",
   "Changes are written to keyboard memory after a short delay. Save a section to persist them.":
     "変更は少し遅れてキーボードのメモリに書き込まれます。永続化するにはセクションを保存してください。",

--- a/src/lib/transport/__tests__/demo-custom-settings.test.ts
+++ b/src/lib/transport/__tests__/demo-custom-settings.test.ts
@@ -3,8 +3,10 @@ import {
   MACRO_KEYSPACE_PREFIX,
 } from "../demo-custom-settings";
 import {
+  Notification,
   Request,
   SettingWriteMode,
+  type Setting,
 } from "../../../proto/cormoran/zmk/custom_settings/custom_settings";
 
 describe("demo-custom-settings CustomSettingsHandler", () => {
@@ -218,5 +220,55 @@ describe("demo-custom-settings CustomSettingsHandler", () => {
       expect(notifications.length).toBe(response.status?.affectedCount);
       done();
     }, 250);
+  });
+
+  it("reports defaultValue only for settings changed from their default when requireDefault is set", (done) => {
+    const handler = new CustomSettingsHandler(3);
+    const listed: Setting[] = [];
+    handler.notify((payload) => {
+      const setting = Notification.decode(payload).setting?.setting;
+      if (setting) {
+        listed.push(setting);
+      }
+    });
+
+    handler.process(
+      Request.create({
+        listSettings: { scope: { source: 0xffffffff }, requireDefault: true },
+      }),
+    );
+
+    setTimeout(() => {
+      const byKey = new Map(listed.map((setting) => [setting.key, setting]));
+      // default_layer starts at 1 but its compile-time default is 0.
+      expect(byKey.get("default_layer")?.defaultValue?.int32Value).toBe(0);
+      // feature_enabled starts false but its compile-time default is true.
+      expect(byKey.get("feature_enabled")?.defaultValue?.boolValue).toBe(true);
+      // profile_name is unchanged from its default, so no defaultValue.
+      expect(byKey.get("profile_name")?.defaultValue).toBeUndefined();
+      done();
+    }, 400);
+  });
+
+  it("omits defaultValue when requireDefault is not set", (done) => {
+    const handler = new CustomSettingsHandler(3);
+    const listed: Setting[] = [];
+    handler.notify((payload) => {
+      const setting = Notification.decode(payload).setting?.setting;
+      if (setting) {
+        listed.push(setting);
+      }
+    });
+
+    handler.process(
+      Request.create({ listSettings: { scope: { source: 0xffffffff } } }),
+    );
+
+    setTimeout(() => {
+      expect(
+        listed.every((setting) => setting.defaultValue === undefined),
+      ).toBe(true);
+      done();
+    }, 400);
   });
 });

--- a/src/lib/transport/__tests__/demo-runtime-macro.test.ts
+++ b/src/lib/transport/__tests__/demo-runtime-macro.test.ts
@@ -189,15 +189,88 @@ describe("RuntimeMacroHandler", () => {
     expect(renameResponse.status?.affectedCount).toBe(1);
 
     const listResponse = handler.process(Request.create({ listMacros: {} }));
-    expect(
-      listResponse.listMacros?.macros.some((m) => m.name === "Hi"),
-    ).toBe(true);
+    expect(listResponse.listMacros?.macros.some((m) => m.name === "Hi")).toBe(
+      true,
+    );
     expect(
       listResponse.listMacros?.macros.some((m) => m.name === "Hello"),
     ).toBe(false);
 
     const after = handler.process(Request.create({ getMacro: { slot: 0 } }));
     expect(after.getMacro?.macro?.steps.length).toBe(stepsBefore);
+  });
+
+  it("reports per-slot hasUnsavedChanges cleared by save and discard", () => {
+    const initial = handler.process(Request.create({ listMacros: {} }));
+    expect(initial.listMacros?.macros.every((m) => !m.hasUnsavedChanges)).toBe(
+      true,
+    );
+
+    handler.process(
+      Request.create({
+        setMacroStepCount: { slot: 0, stepCount: 0, persist: false },
+      }),
+    );
+
+    const afterEdit = handler.process(Request.create({ listMacros: {} }));
+    expect(
+      afterEdit.listMacros?.macros.find((m) => m.slot === 0)?.hasUnsavedChanges,
+    ).toBe(true);
+    expect(
+      afterEdit.listMacros?.macros.find((m) => m.slot === 1)?.hasUnsavedChanges,
+    ).toBe(false);
+
+    handler.process(Request.create({ discardMacros: {} }));
+    const afterDiscard = handler.process(Request.create({ listMacros: {} }));
+    expect(
+      afterDiscard.listMacros?.macros.every((m) => !m.hasUnsavedChanges),
+    ).toBe(true);
+  });
+
+  it("resets a macro to its devicetree default and marks it unsaved", () => {
+    // Edit + persist so flash differs from the compile-time default.
+    handler.process(
+      Request.create({
+        setMacroStepCount: { slot: 0, stepCount: 0, persist: false },
+      }),
+    );
+    handler.process(Request.create({ saveMacros: {} }));
+
+    const resetResponse = handler.process(
+      Request.create({ resetMacro: { slot: 0, persist: false } }),
+    );
+    expect(resetResponse.error).toBeUndefined();
+    expect(resetResponse.status?.affectedCount).toBe(1);
+
+    const getResponse = handler.process(
+      Request.create({ getMacro: { slot: 0 } }),
+    );
+    // "Hello" seed has 5 steps -- restored from the default.
+    expect(getResponse.getMacro?.macro?.steps.length).toBe(5);
+
+    const listResponse = handler.process(Request.create({ listMacros: {} }));
+    expect(
+      listResponse.listMacros?.macros.find((m) => m.slot === 0)
+        ?.hasUnsavedChanges,
+    ).toBe(true);
+  });
+
+  it("deletes a macro on reset when it has no devicetree default", () => {
+    handler.process(
+      Request.create({ createMacro: { name: "temp", persist: false } }),
+    );
+    const created = handler
+      .process(Request.create({ listMacros: {} }))
+      .listMacros?.macros.find((m) => m.name === "temp");
+    expect(created).toBeDefined();
+
+    const resetResponse = handler.process(
+      Request.create({ resetMacro: { slot: created!.slot, persist: false } }),
+    );
+    expect(resetResponse.error).toBeUndefined();
+
+    const after = handler.process(Request.create({ listMacros: {} }));
+    expect(after.listMacros?.macros.some((m) => m.name === "temp")).toBe(false);
   });
 
   it("creates a new macro when the custom-settings keyspace gains a matching entry (legacy path)", () => {

--- a/src/lib/transport/demo-custom-settings.ts
+++ b/src/lib/transport/demo-custom-settings.ts
@@ -121,6 +121,24 @@ function createMockSettings(customSubsystemIndex: number): Setting[] {
   ];
 }
 
+// A couple of demo settings start persisted at a value that differs from their
+// compile-time default (createMockSettings), so the blue "changed from default"
+// dot is visible on load without the user editing anything. Keyed by setting
+// key. Reset restores these to their default and the blue dot disappears.
+const DEMO_MODIFIED_FROM_DEFAULT: Record<string, SettingValue> = {
+  default_layer: { int32Value: 1 },
+  feature_enabled: { boolValue: false },
+};
+
+// The initial persisted/current state: the compile-time defaults with the
+// overrides above applied.
+function createInitialSettings(customSubsystemIndex: number): Setting[] {
+  return createMockSettings(customSubsystemIndex).map((setting) => {
+    const override = DEMO_MODIFIED_FROM_DEFAULT[setting.key];
+    return override ? { ...setting, value: cloneValue(override) } : setting;
+  });
+}
+
 function cloneValue(value: SettingValue | undefined): SettingValue | undefined {
   if (!value) {
     return undefined;
@@ -189,6 +207,43 @@ function sameSetting(a: Setting, b: Setting): boolean {
   );
 }
 
+function settingValuesEqual(
+  a: SettingValue | undefined,
+  b: SettingValue | undefined,
+): boolean {
+  if (a === b) {
+    return true;
+  }
+  if (!a || !b) {
+    return false;
+  }
+  if (a.int32Value !== undefined || b.int32Value !== undefined) {
+    return a.int32Value === b.int32Value;
+  }
+  if (a.boolValue !== undefined || b.boolValue !== undefined) {
+    return a.boolValue === b.boolValue;
+  }
+  if (a.stringValue !== undefined || b.stringValue !== undefined) {
+    return a.stringValue === b.stringValue;
+  }
+  if (a.bytesValue !== undefined || b.bytesValue !== undefined) {
+    const ab = a.bytesValue;
+    const bb = b.bytesValue;
+    if (!ab || !bb || ab.length !== bb.length) {
+      return false;
+    }
+    return ab.every((byte, index) => byte === bb[index]);
+  }
+  if (a.behaviorValue !== undefined || b.behaviorValue !== undefined) {
+    return (
+      a.behaviorValue?.behaviorId === b.behaviorValue?.behaviorId &&
+      a.behaviorValue?.param1 === b.behaviorValue?.param1 &&
+      a.behaviorValue?.param2 === b.behaviorValue?.param2
+    );
+  }
+  return true;
+}
+
 function matchesScope(setting: Setting, scope: SettingScope | undefined) {
   if (!scope) {
     return true;
@@ -247,8 +302,9 @@ export class CustomSettingsHandler {
   constructor(customSubsystemIndex: number) {
     this.customSubsystemIndex = customSubsystemIndex;
     this.defaults = createMockSettings(customSubsystemIndex);
-    this.persistent = this.defaults.map(cloneSetting);
-    this.settings = this.defaults.map(cloneSetting);
+    const initial = createInitialSettings(customSubsystemIndex);
+    this.persistent = initial.map(cloneSetting);
+    this.settings = initial.map(cloneSetting);
   }
 
   // Lets other demo handlers (e.g. demo-runtime-macro.ts) read/react to the
@@ -285,10 +341,17 @@ export class CustomSettingsHandler {
       const listedSettings = this.settings.filter((setting) =>
         matchesScope(setting, request.listSettings?.scope),
       );
+      const requireDefault = request.listSettings.requireDefault === true;
 
       setTimeout(() => {
         listedSettings.forEach((setting, index) => {
-          setTimeout(() => this.notifySetting(setting), index * 25);
+          // When the client asks for defaults, attach defaultValue only when
+          // the current value differs from the compile-time default (and never
+          // for array/keyspace settings) so the UI can show the blue dot.
+          const listItem = requireDefault
+            ? { ...setting, defaultValue: this.defaultValueFor(setting) }
+            : setting;
+          setTimeout(() => this.notifySetting(listItem), index * 25);
         });
       }, 25);
 
@@ -489,6 +552,24 @@ export class CustomSettingsHandler {
     );
     this.notifyKeyspaceChange();
     return { status: { affectedCount: 1, message: "written" } };
+  }
+
+  // The compile-time default for a setting, reported alongside a list item when
+  // it differs from the current value. Returns undefined for array/keyspace
+  // settings and for values that already equal their default.
+  private defaultValueFor(setting: Setting): SettingValue | undefined {
+    if (setting.value?.arrayValue !== undefined) {
+      return undefined;
+    }
+    const defaultSetting = this.defaults.find((candidate) =>
+      sameSetting(candidate, setting),
+    );
+    if (!defaultSetting) {
+      return undefined;
+    }
+    return settingValuesEqual(setting.value, defaultSetting.value)
+      ? undefined
+      : cloneValue(defaultSetting.value);
   }
 
   private notifyKeyspaceChange() {

--- a/src/lib/transport/demo-runtime-combo.ts
+++ b/src/lib/transport/demo-runtime-combo.ts
@@ -26,6 +26,8 @@ function createBehavior(
   return { behaviorId, param1, param2 };
 }
 
+// Compile-time defaults for the demo keyboard. These define which slots have a
+// default to reset back to (DEFAULT_SLOT_INDICES below).
 const MOCK_COMBOS: Combo[] = [
   {
     index: 0,
@@ -53,6 +55,50 @@ const MOCK_COMBOS: Combo[] = [
   },
 ];
 
+// The combos actually persisted on the demo keyboard at boot. Slot 0 is a
+// compile-time default that has been overridden (blue), slot 1 is the untouched
+// default, and slot 2 is a runtime-only combo with no compile-time default
+// (also blue). This gives the UI both DEFAULT and OVERRIDDEN/RUNTIME sources so
+// the blue "changed from default" dot is visible without any user action.
+const INITIAL_COMBOS: Combo[] = [
+  {
+    index: 0,
+    name: "Escape chord",
+    keyPositions: [0, 1],
+    behavior: createBehavior(BEHAVIOR_KEY_PRESS, 0x29),
+    layerMask: 0,
+    enabled: true,
+    timeoutMs: 120,
+    requirePriorIdleMs: 0,
+    slowReleaseOverride: SlowReleaseOverride.SLOW_RELEASE_OVERRIDE_INHERIT,
+    source: ComboSource.COMBO_SOURCE_OVERRIDDEN,
+  },
+  {
+    index: 1,
+    name: "Tab chord",
+    keyPositions: [2, 3],
+    behavior: createBehavior(BEHAVIOR_KEY_PRESS, 0x2b),
+    layerMask: 1,
+    enabled: true,
+    timeoutMs: 0,
+    requirePriorIdleMs: 0,
+    slowReleaseOverride: SlowReleaseOverride.SLOW_RELEASE_OVERRIDE_INHERIT,
+    source: ComboSource.COMBO_SOURCE_DEFAULT,
+  },
+  {
+    index: 2,
+    name: "Copy chord",
+    keyPositions: [4, 5],
+    behavior: createBehavior(BEHAVIOR_KEY_PRESS, 0x06),
+    layerMask: 0,
+    enabled: true,
+    timeoutMs: 0,
+    requirePriorIdleMs: 0,
+    slowReleaseOverride: SlowReleaseOverride.SLOW_RELEASE_OVERRIDE_INHERIT,
+    source: ComboSource.COMBO_SOURCE_RUNTIME,
+  },
+];
+
 const MOCK_GLOBAL_SETTINGS: GlobalSettings = {
   timeoutMs: 50,
   slowRelease: false,
@@ -72,8 +118,8 @@ function cloneCombo(combo: Combo): Combo {
 }
 
 export class RuntimeComboHandler {
-  private persistentCombos: Combo[] = MOCK_COMBOS.map(cloneCombo);
-  private combos: Combo[] = MOCK_COMBOS.map(cloneCombo);
+  private persistentCombos: Combo[] = INITIAL_COMBOS.map(cloneCombo);
+  private combos: Combo[] = INITIAL_COMBOS.map(cloneCombo);
   private persistentGlobalSettings: GlobalSettings = {
     ...MOCK_GLOBAL_SETTINGS,
   };

--- a/src/lib/transport/demo-runtime-macro.ts
+++ b/src/lib/transport/demo-runtime-macro.ts
@@ -88,14 +88,6 @@ function createMacro(
   };
 }
 
-function macroSummary(macro: MacroDetail): MacroSummary {
-  return {
-    slot: macro.slot,
-    name: macro.name,
-    encodedSize: macro.encodedSize,
-  };
-}
-
 const SEED_MACROS: MacroDetail[] = [
   createMacro(0, "Hello", [
     createTapStep(0x0b),
@@ -116,6 +108,10 @@ export class RuntimeMacroHandler {
   };
   private globalSettings: MacroGlobalSettings = { ...MOCK_GLOBAL_SETTINGS };
   private pendingChanges = false;
+  // Per-slot device truth for MacroSummary.hasUnsavedChanges: a slot lands
+  // here on any memory-mode (persist=false) mutation and is cleared by
+  // Save/Discard. Mirrors the firmware's per-slot unsaved flag.
+  private readonly unsavedSlots = new Set<number>();
   private nextSlot = SEED_MACROS.length;
 
   constructor(customSettings?: CustomSettingsHandler) {
@@ -144,7 +140,7 @@ export class RuntimeMacroHandler {
     if (request.listMacros !== undefined) {
       return {
         listMacros: {
-          macros: this.macros.map(macroSummary),
+          macros: this.macros.map((macro) => this.toSummary(macro)),
           maxMacroBytes: MAX_MACRO_BYTES,
           maxNameLength: MAX_NAME_LENGTH,
         },
@@ -196,7 +192,7 @@ export class RuntimeMacroHandler {
       macro.steps = macro.steps.slice(0, stepCount);
       const error = this.refreshEncodedSize(macro);
       if (error) return error;
-      this.markChanged(persist);
+      this.markChanged(persist, slot);
       return { status: { affectedCount: 1, message: "Step count updated" } };
     }
 
@@ -212,7 +208,7 @@ export class RuntimeMacroHandler {
       macro.steps[stepIndex] = cloneStep(step);
       const error = this.refreshEncodedSize(macro);
       if (error) return error;
-      this.markChanged(persist);
+      this.markChanged(persist, slot);
       return { status: { affectedCount: 1, message: "Macro step updated" } };
     }
 
@@ -228,7 +224,7 @@ export class RuntimeMacroHandler {
       macro.steps.push(cloneStep(step));
       const error = this.refreshEncodedSize(macro);
       if (error) return error;
-      this.markChanged(persist);
+      this.markChanged(persist, slot);
       return { status: { affectedCount: 1, message: "Macro step appended" } };
     }
 
@@ -237,9 +233,10 @@ export class RuntimeMacroHandler {
       if (this.macros.some((m) => m.name === name)) {
         return { error: { message: `Macro already exists: ${name}` } };
       }
-      this.macros.push(createMacro(this.nextSlot++, name));
+      const slot = this.nextSlot++;
+      this.macros.push(createMacro(slot, name));
       this.refreshPoolUsage();
-      this.markChanged(persist);
+      this.markChanged(persist, slot);
       return { status: { affectedCount: 1, message: "Macro created" } };
     }
 
@@ -249,7 +246,8 @@ export class RuntimeMacroHandler {
       if (index === -1) {
         return { error: { message: `Macro not found: ${name}` } };
       }
-      this.macros.splice(index, 1);
+      const [removed] = this.macros.splice(index, 1);
+      this.unsavedSlots.delete(removed.slot);
       this.refreshPoolUsage();
       this.markChanged(false);
       return { status: { affectedCount: 1, message: "Macro deleted" } };
@@ -267,8 +265,37 @@ export class RuntimeMacroHandler {
         };
       }
       macro.name = newName;
-      this.markChanged(persist);
+      this.markChanged(persist, macro.slot);
       return { status: { affectedCount: 1, message: "Macro renamed" } };
+    }
+
+    if (request.resetMacro !== undefined) {
+      const { slot, persist } = request.resetMacro;
+      const index = this.macros.findIndex((m) => m.slot === slot);
+      if (index === -1) {
+        return { error: { message: `Macro not found: ${slot}` } };
+      }
+      const macro = this.macros[index];
+      const seed = SEED_MACROS.find((m) => m.name === macro.name);
+      if (seed) {
+        // Restore the compile-time devicetree default steps for this slot.
+        macro.steps = seed.steps.map(cloneStep);
+        const error = this.refreshEncodedSize(macro);
+        if (error) return error;
+        this.markChanged(persist, slot);
+        return {
+          status: { affectedCount: 1, message: "Macro reset to default" },
+        };
+      }
+      // No devicetree default for this slot -> reset deletes it (mirrors
+      // deleteMacro, which leaves the legacy keyspace entry untouched).
+      this.macros.splice(index, 1);
+      this.unsavedSlots.delete(slot);
+      this.markChanged(persist);
+      this.refreshPoolUsage();
+      return {
+        status: { affectedCount: 1, message: "Macro reset (deleted)" },
+      };
     }
 
     if (request.saveMacros !== undefined) {
@@ -276,6 +303,7 @@ export class RuntimeMacroHandler {
       this.persistentMacros = this.macros.map(cloneMacro);
       this.persistentGlobalSettings = { ...this.globalSettings };
       this.pendingChanges = false;
+      this.unsavedSlots.clear();
       return {
         status: {
           affectedCount,
@@ -289,6 +317,7 @@ export class RuntimeMacroHandler {
       this.macros = this.persistentMacros.map(cloneMacro);
       this.globalSettings = { ...this.persistentGlobalSettings };
       this.pendingChanges = false;
+      this.unsavedSlots.clear();
       this.refreshPoolUsage();
       return {
         status: {
@@ -311,15 +340,19 @@ export class RuntimeMacroHandler {
     );
 
     // Remove macros whose keyspace entry is gone (deleted).
-    this.macros = this.macros.filter((macro) =>
-      namesInKeyspace.has(macro.name),
-    );
+    this.macros = this.macros.filter((macro) => {
+      const kept = namesInKeyspace.has(macro.name);
+      if (!kept) this.unsavedSlots.delete(macro.slot);
+      return kept;
+    });
 
     // Add a new (empty) macro for any keyspace entry with no matching macro
-    // yet (created).
+    // yet (created). A newly created slot is unsaved until saved.
     for (const name of namesInKeyspace) {
       if (!this.macros.some((macro) => macro.name === name)) {
-        this.macros.push(createMacro(this.nextSlot++, name));
+        const slot = this.nextSlot++;
+        this.macros.push(createMacro(slot, name));
+        this.unsavedSlots.add(slot);
       }
     }
 
@@ -327,13 +360,24 @@ export class RuntimeMacroHandler {
     this.refreshPoolUsage();
   }
 
-  private markChanged(persist: boolean) {
+  private toSummary(macro: MacroDetail): MacroSummary {
+    return {
+      slot: macro.slot,
+      name: macro.name,
+      encodedSize: macro.encodedSize,
+      hasUnsavedChanges: this.unsavedSlots.has(macro.slot),
+    };
+  }
+
+  private markChanged(persist: boolean, slot?: number) {
     if (persist) {
       this.persistentMacros = this.macros.map(cloneMacro);
       this.persistentGlobalSettings = { ...this.globalSettings };
       this.pendingChanges = false;
+      this.unsavedSlots.clear();
     } else {
       this.pendingChanges = true;
+      if (slot !== undefined) this.unsavedSlots.add(slot);
     }
     this.refreshPoolUsage();
   }

--- a/src/pages/ComboPage.tsx
+++ b/src/pages/ComboPage.tsx
@@ -1,4 +1,10 @@
-import { useCallback, useContext, useMemo, useState } from "react";
+import {
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+  type InputHTMLAttributes,
+} from "react";
 import {
   IconAlertTriangle,
   IconChevronDown,
@@ -19,6 +25,8 @@ import { KeyboardLayout } from "../components/KeyboardLayout";
 import { KeycodeSelector } from "../components/KeycodeSelector";
 import { UnlockPrompt } from "../components/UnlockPrompt";
 import { LoadingIndicator } from "../components/LoadingIndicator";
+import { StatusDot, type EditStatus } from "../components/EditStatusIndicator";
+import { useDebouncedMemoryWrite } from "../hooks/useDebouncedMemoryWrite";
 import { useStudioLockState } from "@cormoran/zmk-studio-react-hook";
 import { useKeymap, getKeymapLoadingLabel } from "../hooks/useKeymap";
 import { useLanguage } from "../hooks/useLanguage";
@@ -60,10 +68,48 @@ interface ComboDraft {
   source: ComboSource;
 }
 
-interface GlobalSettingsDraft {
-  timeoutMs: number | null;
-  slowRelease: boolean | null;
-  requirePriorIdleMs: number | null;
+// Input that keeps its own local value while focused so parent-driven updates
+// (e.g. after a debounced memory write reloads device state) don't reset the
+// cursor or steal focus mid-edit. Mirrors the RetainedInput used by
+// AdvancedSettingsSection. Only needed for fields driven by device state
+// (global settings); the per-combo editor is driven by the local draft.
+function RetainedInput({
+  value,
+  onChange,
+  ...rest
+}: Omit<InputHTMLAttributes<HTMLInputElement>, "value" | "onChange"> & {
+  value: string;
+  onChange: (value: string) => void;
+}) {
+  const [local, setLocal] = useState(value);
+  const [prevProp, setPrevProp] = useState(value);
+  const [focused, setFocused] = useState(false);
+
+  if (prevProp !== value) {
+    setPrevProp(value);
+    if (!focused) {
+      setLocal(value);
+    }
+  }
+
+  return (
+    <input
+      {...rest}
+      value={local}
+      onFocus={(e) => {
+        setFocused(true);
+        rest.onFocus?.(e);
+      }}
+      onBlur={(e) => {
+        setFocused(false);
+        rest.onBlur?.(e);
+      }}
+      onChange={(e) => {
+        setLocal(e.target.value);
+        onChange(e.target.value);
+      }}
+    />
+  );
 }
 
 function comboSourceLabel(
@@ -82,6 +128,26 @@ function comboSourceLabel(
     default:
       return t("Unknown");
   }
+}
+
+// Unified edit status for a combo slot: green when it has an in-memory change
+// not yet persisted, blue when it is persisted but differs from (or is not
+// part of) the compile-time default, otherwise no dot.
+function comboEditStatus(
+  source: ComboSource,
+  index: number,
+  modifiedIndices: Set<number>,
+): EditStatus {
+  if (modifiedIndices.has(index)) {
+    return "unsaved";
+  }
+  if (
+    source === ComboSource.COMBO_SOURCE_OVERRIDDEN ||
+    source === ComboSource.COMBO_SOURCE_RUNTIME
+  ) {
+    return "modified";
+  }
+  return "default";
 }
 
 function defaultBehaviorBinding(
@@ -179,6 +245,44 @@ function formatLayerScope(
   return mask === 0 ? t("All layers") : `0x${mask.toString(16)}`;
 }
 
+// Pure validation shared by the error banner and the auto-write guard: an
+// invalid draft is shown to the user but never written to the device.
+function validateCombo(
+  draft: ComboDraft,
+  maxCombo: number | undefined,
+  t: (key: string, params?: Record<string, number | string>) => string,
+): string | null {
+  if (draft.index < 0 || !Number.isInteger(draft.index)) {
+    return t("Choose a valid slot.");
+  }
+  if (maxCombo && maxCombo > 0 && draft.index >= maxCombo) {
+    return t("Slot must be below {{maxCombo}}.", { maxCombo });
+  }
+  if (draft.name.length > MAX_NAME_LENGTH) {
+    return t("Name must be {{maxLength}} characters or fewer.", {
+      maxLength: MAX_NAME_LENGTH,
+    });
+  }
+  if (draft.keyPositions.length < 2) {
+    return t("Select at least two key positions.");
+  }
+  if (draft.keyPositions.length > MAX_POSITIONS_PER_COMBO) {
+    return t("Select {{maxPositions}} positions or fewer.", {
+      maxPositions: MAX_POSITIONS_PER_COMBO,
+    });
+  }
+  if (draft.keyPositions.some((position) => position > 65535)) {
+    return t("Key positions must be below 65536.");
+  }
+  if (!draft.behavior || draft.behavior.behaviorId === 0) {
+    return t("Choose a behavior.");
+  }
+  if (draft.layerMask < 0 || draft.layerMask > 0xffffffff) {
+    return t("Layer mask is out of range.");
+  }
+  return null;
+}
+
 function formatComboBehavior(
   binding: BehaviorBinding,
   behaviors: Map<number, BehaviorDefinition>,
@@ -198,12 +302,6 @@ function formatComboBehavior(
   });
 }
 
-function PendingDot() {
-  return (
-    <span className="w-1.5 h-1.5 rounded-full bg-[var(--color-neon)] flex-shrink-0 inline-block" />
-  );
-}
-
 export function ComboPage() {
   const { t } = useLanguage();
   const connection = useContext(ConnectionContext);
@@ -221,34 +319,27 @@ export function ComboPage() {
   const [draft, setDraft] = useState<ComboDraft>(() =>
     createDraft([], undefined, new Map()),
   );
-  const [positionsText, setPositionsText] = useState("");
-  const [globalDraft, setGlobalDraft] = useState<GlobalSettingsDraft>({
-    timeoutMs: null,
-    slowRelease: null,
-    requirePriorIdleMs: null,
-  });
   const [showBehaviorSelector, setShowBehaviorSelector] = useState(false);
   const [statusMessage, setStatusMessage] = useState<string | null>(null);
   const [isGlobalSettingsExpanded, setIsGlobalSettingsExpanded] =
     useState(false);
   const [isAdvancedExpanded, setIsAdvancedExpanded] = useState(false);
+  // Client-side green tracking: the proto carries no per-combo "unsaved" flag,
+  // so we mark a slot whenever a field auto-writes to memory and clear the set
+  // on the global Save/Discard.
   const [modifiedIndices, setModifiedIndices] = useState<Set<number>>(
     new Set(),
   );
+  // Global settings likewise have no per-value unsaved flag; track green with a
+  // single client flag, cleared on Save/Discard.
+  const [globalModified, setGlobalModified] = useState(false);
 
   const maxCombo = runtimeCombo.globalSettings?.maxCombo;
   const displayTimeoutMs =
-    globalDraft.timeoutMs ??
-    runtimeCombo.globalSettings?.timeoutMs ??
-    DEFAULT_TIMEOUT_MS;
-  const displaySlowRelease =
-    globalDraft.slowRelease ??
-    runtimeCombo.globalSettings?.slowRelease ??
-    false;
+    runtimeCombo.globalSettings?.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const displaySlowRelease = runtimeCombo.globalSettings?.slowRelease ?? false;
   const displayRequirePriorIdleMs =
-    globalDraft.requirePriorIdleMs ??
-    runtimeCombo.globalSettings?.requirePriorIdleMs ??
-    0;
+    runtimeCombo.globalSettings?.requirePriorIdleMs ?? 0;
   const keymapLayers = keymap.keymap?.layers;
   const physicalLayouts = keymap.physicalLayouts?.layouts;
   const activeLayoutIndex = keymap.physicalLayouts?.activeLayoutIndex;
@@ -273,14 +364,63 @@ export function ComboPage() {
     [draft.keyPositions],
   );
 
+  // Writer for the debounced auto-write: pushes the whole draft to keyboard
+  // MEMORY (persist=false) and marks the slot green. `setCombo` refreshes the
+  // combo list from the device (which derives `source`), then the name is
+  // written on top.
+  const writeComboToMemory = useCallback(
+    async (next: ComboDraft) => {
+      const comboSaved = await runtimeCombo.setCombo({
+        index: next.index,
+        keyPositions: next.keyPositions,
+        behavior: next.behavior,
+        layerMask: next.layerMask,
+        enabled: next.enabled,
+        timeoutMs: next.timeoutMs,
+        requirePriorIdleMs: next.requirePriorIdleMs,
+        slowReleaseOverride: next.slowReleaseOverride,
+      });
+      if (!comboSaved) return;
+      await runtimeCombo.setComboName(next.index, next.name);
+      setModifiedIndices((prev) => new Set(prev).add(next.index));
+    },
+    [runtimeCombo],
+  );
+
+  const comboMemoryWrite = useDebouncedMemoryWrite(writeComboToMemory);
+
+  const globalTimeoutWrite = useDebouncedMemoryWrite<number>(
+    useCallback(
+      async (timeoutMs: number) => {
+        if (timeoutMs < 1 || timeoutMs > 65535) return;
+        const ok = await runtimeCombo.setTimeoutMs(timeoutMs);
+        if (ok) setGlobalModified(true);
+      },
+      [runtimeCombo],
+    ),
+  );
+
+  const globalIdleWrite = useDebouncedMemoryWrite<number>(
+    useCallback(
+      async (requirePriorIdleMs: number) => {
+        if (requirePriorIdleMs < 0 || requirePriorIdleMs > 65535) return;
+        const ok = await runtimeCombo.setRequirePriorIdleMs(requirePriorIdleMs);
+        if (ok) setGlobalModified(true);
+      },
+      [runtimeCombo],
+    ),
+  );
+
   const selectDraft = useCallback(
     (nextDraft: ComboDraft) => {
+      // Flush any pending write for the previously edited slot before switching
+      // (the queued value carries its own index, so it targets the right slot).
+      void comboMemoryWrite.flush();
       setSelectedIndex(nextDraft.index);
       setDraft(nextDraft);
-      setPositionsText(positionsToText(nextDraft.keyPositions));
       setStatusMessage(null);
     },
-    [setDraft],
+    [comboMemoryWrite],
   );
 
   // Guard an edit action: if Studio is locked, open the unlock prompt instead
@@ -292,6 +432,28 @@ export function ComboPage() {
     }
     return true;
   }, [locked]);
+
+  // Single entry point for every per-combo field edit: update the local draft
+  // (keeping inputs responsive) and, when the draft is valid, auto-write it to
+  // memory. Discrete controls pass `immediate` to write without the debounce.
+  const applyDraftChange = useCallback(
+    (next: ComboDraft, immediate = false) => {
+      if (!requireUnlocked()) return;
+      setDraft(next);
+      setStatusMessage(null);
+      if (validateCombo(next, maxCombo, t)) {
+        // Invalid drafts are shown (with the error banner) but never written.
+        return;
+      }
+      // Optimistic green so the dot reacts immediately, before the debounce.
+      setModifiedIndices((prev) => new Set(prev).add(next.index));
+      comboMemoryWrite.queue(next);
+      if (immediate) {
+        void comboMemoryWrite.flush();
+      }
+    },
+    [comboMemoryWrite, maxCombo, requireUnlocked, t],
+  );
 
   const handleNewCombo = useCallback(async () => {
     if (!requireUnlocked()) return;
@@ -318,9 +480,8 @@ export function ComboPage() {
     });
     if (!comboSaved) return;
     await runtimeCombo.setComboName(newCombo.index, newCombo.name);
-    setModifiedIndices((prev) => new Set([...prev, newCombo.index]));
+    setModifiedIndices((prev) => new Set(prev).add(newCombo.index));
     selectDraft(newCombo);
-    setStatusMessage(t("Combo changes are pending."));
   }, [
     keymap.behaviors,
     maxCombo,
@@ -330,74 +491,24 @@ export function ComboPage() {
     t,
   ]);
 
-  const handlePositionToggle = useCallback((position: number) => {
-    setDraft((prev) => {
-      const nextPositions = prev.keyPositions.includes(position)
-        ? prev.keyPositions.filter((item) => item !== position)
-        : normalizePositions([...prev.keyPositions, position]);
-      setPositionsText(positionsToText(nextPositions));
-      return { ...prev, keyPositions: nextPositions };
-    });
-  }, []);
+  const handlePositionToggle = useCallback(
+    (position: number) => {
+      const nextPositions = draft.keyPositions.includes(position)
+        ? draft.keyPositions.filter((item) => item !== position)
+        : normalizePositions([...draft.keyPositions, position]);
+      applyDraftChange({ ...draft, keyPositions: nextPositions }, true);
+    },
+    [applyDraftChange, draft],
+  );
 
-  const validationError = useMemo(() => {
-    if (draft.index < 0 || !Number.isInteger(draft.index)) {
-      return t("Choose a valid slot.");
-    }
-    if (maxCombo && maxCombo > 0 && draft.index >= maxCombo) {
-      return t("Slot must be below {{maxCombo}}.", { maxCombo });
-    }
-    if (draft.name.length > MAX_NAME_LENGTH) {
-      return t("Name must be {{maxLength}} characters or fewer.", {
-        maxLength: MAX_NAME_LENGTH,
-      });
-    }
-    if (draft.keyPositions.length < 2) {
-      return t("Select at least two key positions.");
-    }
-    if (draft.keyPositions.length > MAX_POSITIONS_PER_COMBO) {
-      return t("Select {{maxPositions}} positions or fewer.", {
-        maxPositions: MAX_POSITIONS_PER_COMBO,
-      });
-    }
-    if (draft.keyPositions.some((position) => position > 65535)) {
-      return t("Key positions must be below 65536.");
-    }
-    if (!draft.behavior || draft.behavior.behaviorId === 0) {
-      return t("Choose a behavior.");
-    }
-    if (draft.layerMask < 0 || draft.layerMask > 0xffffffff) {
-      return t("Layer mask is out of range.");
-    }
-    return null;
-  }, [draft, maxCombo, t]);
-
-  const handleSaveCombo = useCallback(async () => {
-    if (!requireUnlocked()) return;
-    if (validationError) return;
-    setStatusMessage(null);
-    const comboSaved = await runtimeCombo.setCombo({
-      index: draft.index,
-      keyPositions: draft.keyPositions,
-      behavior: draft.behavior,
-      layerMask: draft.layerMask,
-      enabled: draft.enabled,
-      timeoutMs: draft.timeoutMs,
-      requirePriorIdleMs: draft.requirePriorIdleMs,
-      slowReleaseOverride: draft.slowReleaseOverride,
-    });
-    if (!comboSaved) return;
-
-    const nameSaved = await runtimeCombo.setComboName(draft.index, draft.name);
-    if (nameSaved) {
-      setSelectedIndex(draft.index);
-      setModifiedIndices((prev) => new Set([...prev, draft.index]));
-      setStatusMessage(t("Combo changes are pending."));
-    }
-  }, [draft, runtimeCombo, t, validationError, requireUnlocked]);
+  const validationError = useMemo(
+    () => validateCombo(draft, maxCombo, t),
+    [draft, maxCombo, t],
+  );
 
   const handleDeleteCombo = useCallback(async () => {
     if (!requireUnlocked()) return;
+    comboMemoryWrite.cancel();
     const deleted = await runtimeCombo.deleteCombo(draft.index);
     if (deleted) {
       const remaining = runtimeCombo.combos.filter(
@@ -407,25 +518,25 @@ export function ComboPage() {
         ? comboToDraft(remaining[0], keymap.behaviors)
         : createDraft(remaining, maxCombo, keymap.behaviors);
       setModifiedIndices((prev) => {
-        const next = new Set(prev);
-        next.delete(draft.index);
-        return next;
+        const nextSet = new Set(prev);
+        nextSet.delete(draft.index);
+        return nextSet;
       });
       selectDraft(nextDraft);
-      setStatusMessage(t("Combo deletion is pending."));
     }
   }, [
+    comboMemoryWrite,
     draft.index,
     keymap.behaviors,
     maxCombo,
     runtimeCombo,
     selectDraft,
-    t,
     requireUnlocked,
   ]);
 
   const handleResetCombo = useCallback(async () => {
     if (!requireUnlocked()) return;
+    comboMemoryWrite.cancel();
     const resetIndex = draft.index;
     const reset = await runtimeCombo.resetCombo(resetIndex);
     if (reset) {
@@ -435,70 +546,59 @@ export function ComboPage() {
       const nextDraft = updated
         ? comboToDraft(updated, keymap.behaviors)
         : createDraft(runtimeCombo.combos, maxCombo, keymap.behaviors);
+      // Reset clears any local unsaved marker for the slot; the device now
+      // reports its source (default/empty), which drives the dot.
+      setModifiedIndices((prev) => {
+        const nextSet = new Set(prev);
+        nextSet.delete(resetIndex);
+        return nextSet;
+      });
       selectDraft(nextDraft);
-      setStatusMessage(t("Combo reset to default is pending."));
     }
   }, [
+    comboMemoryWrite,
     draft.index,
     keymap.behaviors,
     maxCombo,
     runtimeCombo,
     selectDraft,
-    t,
-    requireUnlocked,
-  ]);
-
-  const handleApplyGlobalSettings = useCallback(async () => {
-    if (!requireUnlocked()) return;
-    setStatusMessage(null);
-    const current = runtimeCombo.globalSettings;
-    let ok = true;
-    if (!current || current.timeoutMs !== displayTimeoutMs) {
-      ok = (await runtimeCombo.setTimeoutMs(displayTimeoutMs)) && ok;
-    }
-    if (!current || current.slowRelease !== displaySlowRelease) {
-      ok = (await runtimeCombo.setSlowRelease(displaySlowRelease)) && ok;
-    }
-    if (!current || current.requirePriorIdleMs !== displayRequirePriorIdleMs) {
-      ok =
-        (await runtimeCombo.setRequirePriorIdleMs(displayRequirePriorIdleMs)) &&
-        ok;
-    }
-    if (ok) {
-      setGlobalDraft({
-        timeoutMs: null,
-        slowRelease: null,
-        requirePriorIdleMs: null,
-      });
-      setStatusMessage(t("Global settings are pending."));
-    }
-  }, [
-    displayRequirePriorIdleMs,
-    displaySlowRelease,
-    displayTimeoutMs,
-    runtimeCombo,
-    t,
     requireUnlocked,
   ]);
 
   const handleSavePending = useCallback(async () => {
     if (!requireUnlocked()) return;
+    // Persist any still-queued edits to memory first, then flush memory→flash.
+    await comboMemoryWrite.flush();
+    await globalTimeoutWrite.flush();
+    await globalIdleWrite.flush();
     const status = await runtimeCombo.saveChanges();
     if (status) {
       setModifiedIndices(new Set());
+      setGlobalModified(false);
       setStatusMessage(
         t("Saved {{count}} runtime combo changes.", {
           count: status.affectedCount,
         }),
       );
     }
-  }, [runtimeCombo, t, requireUnlocked]);
+  }, [
+    comboMemoryWrite,
+    globalIdleWrite,
+    globalTimeoutWrite,
+    runtimeCombo,
+    t,
+    requireUnlocked,
+  ]);
 
   const handleDiscardPending = useCallback(async () => {
     if (!requireUnlocked()) return;
+    comboMemoryWrite.cancel();
+    globalTimeoutWrite.cancel();
+    globalIdleWrite.cancel();
     const status = await runtimeCombo.discardChanges();
     if (status) {
       setModifiedIndices(new Set());
+      setGlobalModified(false);
       setStatusMessage(
         t("Discarded {{count}} runtime combo changes.", {
           count: status.affectedCount,
@@ -506,16 +606,22 @@ export function ComboPage() {
       );
       setSelectedIndex(null);
     }
-  }, [runtimeCombo, t, requireUnlocked]);
+  }, [
+    comboMemoryWrite,
+    globalIdleWrite,
+    globalTimeoutWrite,
+    runtimeCombo,
+    t,
+    requireUnlocked,
+  ]);
 
-  const selectedComboExists = runtimeCombo.combos.some(
-    (combo) => combo.index === draft.index,
+  const selectedCombo = useMemo(
+    () =>
+      runtimeCombo.combos.find((combo) => combo.index === draft.index) ?? null,
+    [runtimeCombo.combos, draft.index],
   );
-
-  const globalSettingsModified =
-    globalDraft.timeoutMs !== null ||
-    globalDraft.slowRelease !== null ||
-    globalDraft.requirePriorIdleMs !== null;
+  const selectedComboExists = selectedCombo !== null;
+  const editorSource = selectedCombo?.source ?? draft.source;
 
   return (
     <div className="p-6 h-full overflow-auto">
@@ -559,8 +665,8 @@ export function ComboPage() {
                 <>
                   {runtimeCombo.hasPendingChanges && (
                     <span className="flex items-center gap-1 text-xs text-[var(--color-neon)] mr-2">
-                      <PendingDot />
-                      {t("Pending changes")}
+                      <StatusDot status="unsaved" />
+                      {t("Unsaved changes")}
                     </span>
                   )}
                   <button
@@ -680,7 +786,7 @@ export function ComboPage() {
                     <h2 className="text-sm font-medium text-[var(--color-text)] flex-1">
                       {t("Global Settings")}
                     </h2>
-                    {globalSettingsModified && <PendingDot />}
+                    {globalModified && <StatusDot status="unsaved" />}
                     <IconChevronDown
                       size={14}
                       className={`text-[var(--color-text-muted)] flex-shrink-0 transition-transform ${
@@ -691,6 +797,11 @@ export function ComboPage() {
                   {isGlobalSettingsExpanded && (
                     <div className="px-4 pb-4 border-t border-[var(--color-border)]">
                       <div className="space-y-3 mt-3">
+                        <p className="text-xs text-[var(--color-text-muted)]">
+                          {t(
+                            "Changes are written to keyboard memory after a short delay. Save a section to persist them.",
+                          )}
+                        </p>
                         <label className="block">
                           <span className="text-xs text-[var(--color-text-muted)]">
                             {t("Max slots")}
@@ -705,18 +816,16 @@ export function ComboPage() {
                           <span className="text-xs text-[var(--color-text-muted)]">
                             {t("Timeout ms")}
                           </span>
-                          <input
+                          <RetainedInput
                             type="number"
                             min={1}
                             max={65535}
                             className="mt-1 w-full px-3 py-2 rounded-lg bg-[var(--color-bg)] border border-[var(--color-border)] text-[var(--color-text)]"
-                            value={displayTimeoutMs}
-                            onChange={(event) =>
-                              setGlobalDraft((prev) => ({
-                                ...prev,
-                                timeoutMs: Number(event.target.value),
-                              }))
-                            }
+                            value={String(displayTimeoutMs)}
+                            onChange={(value) => {
+                              if (!requireUnlocked()) return;
+                              globalTimeoutWrite.queue(Number(value));
+                            }}
                           />
                         </label>
                         <div className="flex items-center justify-between gap-3">
@@ -725,12 +834,14 @@ export function ComboPage() {
                           </span>
                           <Switch.Root
                             checked={displaySlowRelease}
-                            onCheckedChange={(slowRelease) =>
-                              setGlobalDraft((prev) => ({
-                                ...prev,
-                                slowRelease,
-                              }))
-                            }
+                            onCheckedChange={(slowRelease) => {
+                              if (!requireUnlocked()) return;
+                              void runtimeCombo
+                                .setSlowRelease(slowRelease)
+                                .then((ok) => {
+                                  if (ok) setGlobalModified(true);
+                                });
+                            }}
                             className="w-10 h-5 rounded-full relative data-[state=checked]:bg-[var(--color-electric)] bg-[var(--color-border)] border border-[var(--color-border)] transition-colors"
                           >
                             <Switch.Thumb className="block w-4 h-4 rounded-full transition-transform data-[state=checked]:translate-x-5 translate-x-0.5 will-change-transform bg-white border border-[var(--color-border)]" />
@@ -740,33 +851,18 @@ export function ComboPage() {
                           <span className="text-xs text-[var(--color-text-muted)]">
                             {t("Require prior idle ms (0 disables)")}
                           </span>
-                          <input
+                          <RetainedInput
                             type="number"
                             min={0}
                             max={65535}
                             className="mt-1 w-full px-3 py-2 rounded-lg bg-[var(--color-bg)] border border-[var(--color-border)] text-[var(--color-text)]"
-                            value={displayRequirePriorIdleMs}
-                            onChange={(event) =>
-                              setGlobalDraft((prev) => ({
-                                ...prev,
-                                requirePriorIdleMs: Number(event.target.value),
-                              }))
-                            }
+                            value={String(displayRequirePriorIdleMs)}
+                            onChange={(value) => {
+                              if (!requireUnlocked()) return;
+                              globalIdleWrite.queue(Number(value));
+                            }}
                           />
                         </label>
-                        <button
-                          className="btn-electric w-full text-sm"
-                          onClick={handleApplyGlobalSettings}
-                          disabled={
-                            runtimeCombo.isLoading ||
-                            displayTimeoutMs < 1 ||
-                            displayTimeoutMs > 65535 ||
-                            displayRequirePriorIdleMs < 0 ||
-                            displayRequirePriorIdleMs > 65535
-                          }
-                        >
-                          {t("Apply Global Settings")}
-                        </button>
                       </div>
                     </div>
                   )}
@@ -831,9 +927,13 @@ export function ComboPage() {
                                 })}
                             </span>
                             <span className="flex items-center gap-1.5 shrink-0">
-                              {modifiedIndices.has(combo.index) && (
-                                <PendingDot />
-                              )}
+                              <StatusDot
+                                status={comboEditStatus(
+                                  combo.source,
+                                  combo.index,
+                                  modifiedIndices,
+                                )}
+                              />
                               <span className="text-xs font-mono text-[var(--color-text-muted)]">
                                 #{combo.index}
                               </span>
@@ -895,9 +995,15 @@ export function ComboPage() {
                           {t("Combo Editor")}
                         </h2>
                         <span className="text-[10px] px-1.5 py-0.5 rounded-full border border-[var(--color-border)] text-[var(--color-text-muted)]">
-                          {comboSourceLabel(draft.source, t)}
+                          {comboSourceLabel(editorSource, t)}
                         </span>
-                        {modifiedIndices.has(draft.index) && <PendingDot />}
+                        <StatusDot
+                          status={comboEditStatus(
+                            editorSource,
+                            draft.index,
+                            modifiedIndices,
+                          )}
+                        />
                       </div>
                       <p className="text-xs text-[var(--color-text-muted)]">
                         {selectedComboExists
@@ -906,8 +1012,8 @@ export function ComboPage() {
                       </p>
                     </div>
                     <div className="flex items-center gap-2 flex-wrap">
-                      {(draft.source === ComboSource.COMBO_SOURCE_DEFAULT ||
-                        draft.source ===
+                      {(editorSource === ComboSource.COMBO_SOURCE_DEFAULT ||
+                        editorSource ===
                           ComboSource.COMBO_SOURCE_OVERRIDDEN) && (
                         <button
                           className="btn-ghost text-sm flex items-center gap-1.5"
@@ -926,7 +1032,7 @@ export function ComboPage() {
                         <Switch.Root
                           checked={draft.enabled}
                           onCheckedChange={(enabled) =>
-                            setDraft((prev) => ({ ...prev, enabled }))
+                            applyDraftChange({ ...draft, enabled }, true)
                           }
                           className="w-8 h-4 rounded-full relative data-[state=checked]:bg-[var(--color-electric)] bg-[var(--color-border)] border border-[var(--color-border)] transition-colors"
                         >
@@ -942,19 +1048,6 @@ export function ComboPage() {
                       >
                         <IconTrash size={16} />
                         {t("Delete")}
-                      </button>
-                      <button
-                        className="btn-electric text-sm flex items-center gap-1.5"
-                        onClick={handleSaveCombo}
-                        disabled={!!validationError || runtimeCombo.isLoading}
-                        title={validationError ?? undefined}
-                      >
-                        {runtimeCombo.isLoading ? (
-                          <IconLoader2 size={16} className="animate-spin" />
-                        ) : (
-                          <IconDeviceFloppy size={16} />
-                        )}
-                        {t("Save Combo")}
                       </button>
                     </div>
                   </div>
@@ -977,10 +1070,10 @@ export function ComboPage() {
                         className="mt-1 w-full px-3 py-2 rounded-lg bg-[var(--color-bg)] border border-[var(--color-border)] text-[var(--color-text)]"
                         value={draft.name}
                         onChange={(event) =>
-                          setDraft((prev) => ({
-                            ...prev,
+                          applyDraftChange({
+                            ...draft,
                             name: event.target.value,
-                          }))
+                          })
                         }
                       />
                     </label>
@@ -1021,7 +1114,7 @@ export function ComboPage() {
                             : "bg-[var(--color-bg)] text-[var(--color-text-secondary)] border-[var(--color-border)]"
                         }`}
                         onClick={() =>
-                          setDraft((prev) => ({ ...prev, layerMask: 0 }))
+                          applyDraftChange({ ...draft, layerMask: 0 }, true)
                         }
                       >
                         {t("All")}
@@ -1036,10 +1129,16 @@ export function ComboPage() {
                               : "bg-[var(--color-bg)] text-[var(--color-text-secondary)] border-[var(--color-border)]"
                           }`}
                           onClick={() =>
-                            setDraft((prev) => ({
-                              ...prev,
-                              layerMask: toggleLayer(prev.layerMask, layer.id),
-                            }))
+                            applyDraftChange(
+                              {
+                                ...draft,
+                                layerMask: toggleLayer(
+                                  draft.layerMask,
+                                  layer.id,
+                                ),
+                              },
+                              true,
+                            )
                           }
                           disabled={layer.id >= 32}
                         >
@@ -1060,7 +1159,7 @@ export function ComboPage() {
                     <input
                       readOnly
                       className="mt-1 w-full px-3 py-2 rounded-lg bg-[var(--color-bg)] border border-[var(--color-border)] text-[var(--color-text)] cursor-default select-none"
-                      value={positionsText}
+                      value={positionsToText(draft.keyPositions)}
                     />
                   </label>
 
@@ -1114,10 +1213,10 @@ export function ComboPage() {
                               className="mt-1 w-full px-3 py-2 rounded-lg bg-[var(--color-surface)] border border-[var(--color-border)] text-[var(--color-text)]"
                               value={draft.timeoutMs}
                               onChange={(event) =>
-                                setDraft((prev) => ({
-                                  ...prev,
+                                applyDraftChange({
+                                  ...draft,
                                   timeoutMs: Number(event.target.value),
-                                }))
+                                })
                               }
                             />
                           </label>
@@ -1132,12 +1231,12 @@ export function ComboPage() {
                               className="mt-1 w-full px-3 py-2 rounded-lg bg-[var(--color-surface)] border border-[var(--color-border)] text-[var(--color-text)]"
                               value={draft.requirePriorIdleMs}
                               onChange={(event) =>
-                                setDraft((prev) => ({
-                                  ...prev,
+                                applyDraftChange({
+                                  ...draft,
                                   requirePriorIdleMs: Number(
                                     event.target.value,
                                   ),
-                                }))
+                                })
                               }
                             />
                           </label>
@@ -1149,12 +1248,15 @@ export function ComboPage() {
                               className="select-field mt-1 w-full text-sm"
                               value={draft.slowReleaseOverride}
                               onChange={(event) =>
-                                setDraft((prev) => ({
-                                  ...prev,
-                                  slowReleaseOverride: Number(
-                                    event.target.value,
-                                  ) as SlowReleaseOverride,
-                                }))
+                                applyDraftChange(
+                                  {
+                                    ...draft,
+                                    slowReleaseOverride: Number(
+                                      event.target.value,
+                                    ) as SlowReleaseOverride,
+                                  },
+                                  true,
+                                )
                               }
                             >
                               <option
@@ -1194,7 +1296,7 @@ export function ComboPage() {
         open={showBehaviorSelector}
         onClose={() => setShowBehaviorSelector(false)}
         onSelect={(binding) =>
-          setDraft((prev) => ({ ...prev, behavior: binding }))
+          applyDraftChange({ ...draft, behavior: binding }, true)
         }
         currentBinding={draft.behavior}
         behaviors={keymap.behaviors}

--- a/src/pages/MacroPage.tsx
+++ b/src/pages/MacroPage.tsx
@@ -1,8 +1,16 @@
-import { useCallback, useContext, useEffect, useMemo, useRef, useState } from "react";
+import {
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import {
   IconAlertCircle,
   IconChevronDown,
   IconDeviceFloppy,
+  IconHistory,
   IconLoader2,
   IconLock,
   IconPlus,
@@ -13,9 +21,11 @@ import {
   IconWand,
 } from "@tabler/icons-react";
 import { KeycodeSelector } from "../components/KeycodeSelector";
+import { StatusDot } from "../components/EditStatusIndicator";
 import { UnlockPrompt } from "../components/UnlockPrompt";
 import { KeyboardLayoutContext } from "../contexts/KeyboardLayoutContext";
 import { useStudioLockState } from "@cormoran/zmk-studio-react-hook";
+import { useDebouncedMemoryWrite } from "../hooks/useDebouncedMemoryWrite";
 import { useKeymap } from "../hooks/useKeymap";
 import { useLanguage } from "../hooks/useLanguage";
 import { useRuntimeMacro } from "../hooks/useRuntimeMacro";
@@ -351,12 +361,6 @@ function buildMacroStepRows(
   return rows;
 }
 
-function UnsavedDot() {
-  return (
-    <span className="w-1.5 h-1.5 rounded-full bg-[var(--color-neon)] flex-shrink-0 inline-block" />
-  );
-}
-
 export function MacroPage() {
   const { t } = useLanguage();
   const runtimeMacro = useRuntimeMacro();
@@ -373,6 +377,7 @@ export function MacroPage() {
   const [isDiscarding, setIsDiscarding] = useState(false);
   const [isCreating, setIsCreating] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
+  const [isResetting, setIsResetting] = useState(false);
   const [renameDraft, setRenameDraft] = useState("");
   const [stringConversionError, setStringConversionError] = useState<
     string | null
@@ -380,8 +385,12 @@ export function MacroPage() {
   const [stringDraft, setStringDraft] = useState<StringDraftRow | null>(null);
   const [isGlobalSettingsExpanded, setIsGlobalSettingsExpanded] =
     useState(false);
-  const [modifiedSlots, setModifiedSlots] = useState<Set<number>>(new Set());
+  // Tap ms has no device-side unsaved flag (it is a global setting, not a
+  // MacroSummary slot), so its green dot stays client-tracked.
   const [globalSettingsModified, setGlobalSettingsModified] = useState(false);
+  // Local draft for the debounced tap-ms input so typing stays responsive
+  // while the memory write is deferred until the quiet period.
+  const [tapMsDraft, setTapMsDraft] = useState(0);
 
   const layersForSelector = useMemo(() => {
     if (!keymap.keymap?.layers) return [];
@@ -549,7 +558,6 @@ export function MacroPage() {
         if (!stepUpdated) return false;
       }
 
-      setModifiedSlots((prev) => new Set([...prev, loadedMacro.slot]));
       setLoadedMacro({ ...loadedMacro, steps });
       await runtimeMacro.loadMacros();
       return true;
@@ -676,6 +684,35 @@ export function MacroPage() {
     [loadedMacro, updateStep],
   );
 
+  // Debounced memory writes for free-text/number edits: typing auto-writes to
+  // keyboard memory after a quiet period (flushed on blur / before Save).
+  // Discrete dropdown selections keep committing immediately (see updateStep).
+  const delayDebounce = useDebouncedMemoryWrite<number>(
+    useCallback(
+      async (stepIndex: number) => {
+        await commitDelay(stepIndex);
+      },
+      [commitDelay],
+    ),
+  );
+
+  const stringDebounce = useDebouncedMemoryWrite<void>(
+    useCallback(async () => {
+      await commitStringChange();
+    }, [commitStringChange]),
+  );
+
+  const tapMsDebounce = useDebouncedMemoryWrite<number>(
+    useCallback(
+      async (tapMs: number) => {
+        if (!requireUnlocked()) return;
+        const ok = await runtimeMacro.setTapMs(clampUInt32(tapMs));
+        if (ok) setGlobalSettingsModified(true);
+      },
+      [requireUnlocked, runtimeMacro],
+    ),
+  );
+
   const handleBehaviorSelect = useCallback(
     async (binding: KeymapBehaviorBinding) => {
       if (!loadedMacro || editingStepIndex === null) return;
@@ -721,11 +758,6 @@ export function MacroPage() {
       if (ok) {
         setSelectedName(null);
         setLoadedMacro(null);
-        setModifiedSlots((prev) => {
-          const next = new Set(prev);
-          next.delete(loadedMacro.slot);
-          return next;
-        });
       }
     } finally {
       setIsDeleting(false);
@@ -753,24 +785,51 @@ export function MacroPage() {
     }
   }, [generateMacroName, runtimeMacro, requireUnlocked]);
 
+  const handleResetMacro = useCallback(async () => {
+    if (!requireUnlocked()) return;
+    if (!loadedMacro) return;
+    if (!window.confirm(t("Reset this macro to its default?"))) return;
+    setIsResetting(true);
+    try {
+      const ok = await runtimeMacro.resetMacro(loadedMacro.slot);
+      if (ok) {
+        await loadMacro(loadedMacro.slot);
+      }
+    } finally {
+      setIsResetting(false);
+    }
+  }, [loadMacro, loadedMacro, requireUnlocked, runtimeMacro, t]);
+
   const handleSave = useCallback(async () => {
     if (!requireUnlocked()) return;
     setIsSaving(true);
     try {
+      // Flush any queued debounced edits so they are part of this persist.
+      await tapMsDebounce.flush();
+      await delayDebounce.flush();
+      await stringDebounce.flush();
       await runtimeMacro.saveMacros();
-      setModifiedSlots(new Set());
       setGlobalSettingsModified(false);
     } finally {
       setIsSaving(false);
     }
-  }, [runtimeMacro, requireUnlocked]);
+  }, [
+    delayDebounce,
+    requireUnlocked,
+    runtimeMacro,
+    stringDebounce,
+    tapMsDebounce,
+  ]);
 
   const handleDiscard = useCallback(async () => {
     if (!requireUnlocked()) return;
     setIsDiscarding(true);
     try {
+      // Drop queued edits — discard restores the persisted values.
+      tapMsDebounce.cancel();
+      delayDebounce.cancel();
+      stringDebounce.cancel();
       await runtimeMacro.discardMacros();
-      setModifiedSlots(new Set());
       setGlobalSettingsModified(false);
       if (loadedMacro) {
         await loadMacro(loadedMacro.slot);
@@ -778,15 +837,22 @@ export function MacroPage() {
     } finally {
       setIsDiscarding(false);
     }
-  }, [loadMacro, loadedMacro, runtimeMacro, requireUnlocked]);
+  }, [
+    delayDebounce,
+    loadMacro,
+    loadedMacro,
+    requireUnlocked,
+    runtimeMacro,
+    stringDebounce,
+    tapMsDebounce,
+  ]);
 
   const handleTapMsChange = useCallback(
-    async (tapMs: number) => {
-      if (!requireUnlocked()) return;
-      const ok = await runtimeMacro.setTapMs(clampUInt32(tapMs));
-      if (ok) setGlobalSettingsModified(true);
+    (tapMs: number) => {
+      setTapMsDraft(tapMs);
+      tapMsDebounce.queue(tapMs);
     },
-    [runtimeMacro, requireUnlocked],
+    [tapMsDebounce],
   );
 
   const getStepDisplayName = useCallback(
@@ -810,8 +876,14 @@ export function MacroPage() {
     ],
   );
 
+  // Keep the debounced tap-ms input in sync with device state (initial load,
+  // discard, external refresh) while leaving in-flight typing untouched.
+  useEffect(() => {
+    setTapMsDraft(runtimeMacro.globalSettings?.tapMs ?? 0);
+  }, [runtimeMacro.globalSettings?.tapMs]);
+
   const loadedMacroHasUnsavedChanges =
-    loadedMacro !== null && modifiedSlots.has(loadedMacro.slot);
+    loadedMacro !== null && runtimeMacro.isSlotUnsaved(loadedMacro.slot);
 
   return (
     <div className="p-6 h-full overflow-auto">
@@ -855,7 +927,7 @@ export function MacroPage() {
                 <>
                   {runtimeMacro.hasUnsavedChanges && (
                     <span className="flex items-center gap-1 text-xs text-[var(--color-neon)] mr-2">
-                      <UnsavedDot />
+                      <StatusDot status="unsaved" />
                       {t("Unsaved changes")}
                     </span>
                   )}
@@ -873,7 +945,7 @@ export function MacroPage() {
                     ) : (
                       <IconRestore size={16} />
                     )}
-                    {t("Reset")}
+                    {t("Discard")}
                   </button>
                   <button
                     className="btn-electric text-sm flex items-center gap-1.5"
@@ -949,7 +1021,7 @@ export function MacroPage() {
                   <h2 className="text-sm font-medium text-[var(--color-text)] flex-1">
                     {t("Global Settings")}
                   </h2>
-                  {globalSettingsModified && <UnsavedDot />}
+                  {globalSettingsModified && <StatusDot status="unsaved" />}
                   <IconChevronDown
                     size={14}
                     className={`text-[var(--color-text-muted)] flex-shrink-0 transition-transform ${
@@ -969,10 +1041,11 @@ export function MacroPage() {
                           min={0}
                           max={10000}
                           className="mt-1 w-full px-3 py-2 rounded-lg bg-[var(--color-bg)] border border-[var(--color-border)] text-[var(--color-text)] focus:outline-none focus:border-[var(--color-electric)]/50"
-                          value={runtimeMacro.globalSettings?.tapMs ?? 0}
+                          value={tapMsDraft}
                           onChange={(event) =>
-                            void handleTapMsChange(Number(event.target.value))
+                            handleTapMsChange(Number(event.target.value))
                           }
+                          onBlur={() => void tapMsDebounce.flush()}
                         />
                       </label>
                       {runtimeMacro.globalSettings &&
@@ -1044,7 +1117,9 @@ export function MacroPage() {
                           {macro.name ||
                             t("Macro {{slot}}", { slot: macro.slot })}
                         </span>
-                        {modifiedSlots.has(macro.slot) && <UnsavedDot />}
+                        {macro.hasUnsavedChanges && (
+                          <StatusDot status="unsaved" />
+                        )}
                       </div>
                       <span className="block text-xs text-[var(--color-text-muted)]">
                         {t("{{encodedSize}}/{{maxMacroBytes}} bytes", {
@@ -1065,7 +1140,9 @@ export function MacroPage() {
                     <div className="flex-1 min-w-0">
                       <label className="flex items-center gap-1.5 text-xs font-medium text-[var(--color-text-muted)] mb-1">
                         {t("Name")}
-                        {loadedMacroHasUnsavedChanges && <UnsavedDot />}
+                        {loadedMacroHasUnsavedChanges && (
+                          <StatusDot status="unsaved" />
+                        )}
                       </label>
                       <input
                         className="w-full px-3 py-2 rounded-lg bg-[var(--color-bg)] border border-[var(--color-border)] text-[var(--color-text)] focus:outline-none focus:border-[var(--color-electric)]/50"
@@ -1102,6 +1179,19 @@ export function MacroPage() {
                       </h2>
                     </div>
                     <div className="flex items-center gap-2">
+                      <button
+                        className="btn-ghost text-sm flex items-center gap-1.5"
+                        onClick={() => void handleResetMacro()}
+                        disabled={isResetting || runtimeMacro.isLoading}
+                        title={t("Reset this macro to its default")}
+                      >
+                        {isResetting ? (
+                          <IconLoader2 size={16} className="animate-spin" />
+                        ) : (
+                          <IconHistory size={16} />
+                        )}
+                        {t("Reset")}
+                      </button>
                       <button
                         className="btn-ghost text-sm flex items-center gap-1.5 text-red-400"
                         onClick={() => void handleDeleteMacro()}
@@ -1168,15 +1258,14 @@ export function MacroPage() {
                                   min={0}
                                   className="w-full px-3 py-2 rounded-lg bg-[var(--color-surface)] border border-[var(--color-border)] text-sm text-[var(--color-text)] focus:outline-none focus:border-[var(--color-electric)]/50"
                                   value={step?.delay?.delayMs ?? 0}
-                                  onChange={(event) =>
+                                  onChange={(event) => {
                                     handleDelayChange(
                                       row.startIndex,
                                       Number(event.target.value),
-                                    )
-                                  }
-                                  onBlur={() =>
-                                    void commitDelay(row.startIndex)
-                                  }
+                                    );
+                                    delayDebounce.queue(row.startIndex);
+                                  }}
+                                  onBlur={() => void delayDebounce.flush()}
                                 />
                                 <span className="text-xs text-[var(--color-text-muted)]">
                                   {t("ms")}
@@ -1186,10 +1275,11 @@ export function MacroPage() {
                               <input
                                 className="w-full px-3 py-2 rounded-lg bg-[var(--color-surface)] border border-[var(--color-border)] text-sm text-[var(--color-text)] focus:outline-none focus:border-[var(--color-electric)]/50"
                                 value={row.value ?? ""}
-                                onChange={(event) =>
-                                  handleStringChange(row, event.target.value)
-                                }
-                                onBlur={() => void commitStringChange()}
+                                onChange={(event) => {
+                                  handleStringChange(row, event.target.value);
+                                  stringDebounce.queue();
+                                }}
+                                onBlur={() => void stringDebounce.flush()}
                               />
                             ) : (
                               <button

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useRef, useEffect } from "react";
+import { useState, useMemo, useRef, useEffect, useCallback } from "react";
 import { createPortal } from "react-dom";
 import {
   IconSettings,
@@ -8,6 +8,7 @@ import {
 import { AdvancedSettingsSection } from "../components/AdvancedSettingsSection";
 import { LoadingIndicator } from "../components/LoadingIndicator";
 import { useSettings } from "../hooks/useSettings";
+import { useDebouncedMemoryWrite } from "../hooks/useDebouncedMemoryWrite";
 import { useLanguage } from "../hooks/useLanguage";
 
 // Helper to format milliseconds to human readable
@@ -231,10 +232,6 @@ export function SettingsPage() {
   const { t } = useLanguage();
   const { isAvailable, devices, isLoading, error, setActivitySettings } =
     useSettings();
-  // Track if user has edited the form
-  const [hasEdits, setHasEdits] = useState(false);
-  const [editedIdleTimeout, setEditedIdleTimeout] = useState<number>(0);
-  const [editedSleepTimeout, setEditedSleepTimeout] = useState<number>(0);
 
   // Get central device settings (source 0)
   const centralSettings = useMemo(
@@ -242,30 +239,55 @@ export function SettingsPage() {
     [devices],
   );
 
-  // Display values: use edited values if user has made changes, otherwise use central settings
-  const idleTimeout = hasEdits
-    ? editedIdleTimeout
-    : (centralSettings?.idleMs ?? 0);
-  const sleepTimeout = hasEdits
-    ? editedSleepTimeout
-    : (centralSettings?.sleepMs ?? 0);
+  // Optimistic pending value shown while a debounced write is in flight. This
+  // is a direct/persistent write-through (no memory tier), so there is no
+  // discard/reset — the edit is auto-written after MEMORY_WRITE_DEBOUNCE_MS.
+  const [pending, setPending] = useState<{
+    idleMs: number;
+    sleepMs: number;
+  } | null>(null);
+  const [showSaved, setShowSaved] = useState(false);
+  const savedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(
+    () => () => {
+      if (savedTimerRef.current) clearTimeout(savedTimerRef.current);
+    },
+    [],
+  );
+
+  const write = useCallback(
+    async (value: { idleMs: number; sleepMs: number }) => {
+      await setActivitySettings(value.idleMs, value.sleepMs);
+      setPending(null);
+      setShowSaved(true);
+      if (savedTimerRef.current) clearTimeout(savedTimerRef.current);
+      savedTimerRef.current = setTimeout(() => setShowSaved(false), 2000);
+    },
+    [setActivitySettings],
+  );
+
+  const { state: saveState, queue } = useDebouncedMemoryWrite(write);
+
+  // Display values: prefer the in-flight pending edit, otherwise device state.
+  const idleTimeout = pending?.idleMs ?? centralSettings?.idleMs ?? 0;
+  const sleepTimeout = pending?.sleepMs ?? centralSettings?.sleepMs ?? 0;
 
   const handleIdleChange = (ms: number) => {
-    setHasEdits(true);
-    setEditedIdleTimeout(ms);
-    setEditedSleepTimeout(sleepTimeout); // Keep sleep timeout unchanged
+    const next = { idleMs: ms, sleepMs: sleepTimeout };
+    setPending(next);
+    setShowSaved(false);
+    queue(next);
   };
 
   const handleSleepChange = (ms: number) => {
-    setHasEdits(true);
-    setEditedSleepTimeout(ms);
-    setEditedIdleTimeout(idleTimeout); // Keep idle timeout unchanged
+    const next = { idleMs: idleTimeout, sleepMs: ms };
+    setPending(next);
+    setShowSaved(false);
+    queue(next);
   };
 
-  const handleSaveSettings = async () => {
-    await setActivitySettings(idleTimeout, sleepTimeout);
-    setHasEdits(false);
-  };
+  const isSaving = saveState === "queued" || saveState === "saving";
 
   return (
     <div className="p-6 h-full overflow-auto">
@@ -362,14 +384,16 @@ export function SettingsPage() {
                   />
                 </div>
 
-                <div className="flex justify-end pt-2">
-                  <button
-                    className="btn-electric text-sm"
-                    onClick={handleSaveSettings}
-                    disabled={isLoading}
-                  >
-                    {isLoading ? t("Saving...") : t("Apply to All Devices")}
-                  </button>
+                <div className="flex justify-end pt-2 h-4">
+                  {isSaving ? (
+                    <span className="text-xs text-[var(--color-text-muted)]">
+                      {t("Saving...")}
+                    </span>
+                  ) : showSaved ? (
+                    <span className="text-xs text-[var(--color-text-muted)]">
+                      {t("Saved")}
+                    </span>
+                  ) : null}
                 </div>
               </div>
 

--- a/src/pages/TrackballPage.tsx
+++ b/src/pages/TrackballPage.tsx
@@ -11,6 +11,7 @@ import { TrackballAdvancedSettings } from "../components/TrackballAdvancedSettin
 import { LoadingIndicator } from "../components/LoadingIndicator";
 import { AxisSnapMode } from "../proto/zmk/runtime_input_processor/runtime_input_processor";
 import { useDebouncedSave } from "../hooks/useDebouncedSave";
+import { MEMORY_WRITE_DEBOUNCE_MS } from "../hooks/useDebouncedMemoryWrite";
 import { useLanguage } from "../hooks/useLanguage";
 
 const SCALING_MIN = 0.1;
@@ -107,21 +108,51 @@ export function TrackballPage() {
   );
 
   // Debounced save hooks for each field
-  const scalingMultiplierSave = useDebouncedSave<number>();
-  const scalingDivisorSave = useDebouncedSave<number>();
-  const rotationSave = useDebouncedSave<number>();
-  const tempLayerEnabledSave = useDebouncedSave<boolean>();
-  const tempLayerLayerSave = useDebouncedSave<number>();
-  const tempLayerActivationDelaySave = useDebouncedSave<number>();
-  const tempLayerDeactivationDelaySave = useDebouncedSave<number>();
-  const activeLayersSave = useDebouncedSave<number>();
-  const axisSnapModeSave = useDebouncedSave<AxisSnapMode>();
-  const axisSnapThresholdSave = useDebouncedSave<number>();
-  const axisSnapTimeoutSave = useDebouncedSave<number>();
-  const xInvertSave = useDebouncedSave<boolean>();
-  const yInvertSave = useDebouncedSave<boolean>();
-  const xyToScrollEnabledSave = useDebouncedSave<boolean>();
-  const xySwapEnabledSave = useDebouncedSave<boolean>();
+  const scalingMultiplierSave = useDebouncedSave<number>({
+    delay: MEMORY_WRITE_DEBOUNCE_MS,
+  });
+  const scalingDivisorSave = useDebouncedSave<number>({
+    delay: MEMORY_WRITE_DEBOUNCE_MS,
+  });
+  const rotationSave = useDebouncedSave<number>({
+    delay: MEMORY_WRITE_DEBOUNCE_MS,
+  });
+  const tempLayerEnabledSave = useDebouncedSave<boolean>({
+    delay: MEMORY_WRITE_DEBOUNCE_MS,
+  });
+  const tempLayerLayerSave = useDebouncedSave<number>({
+    delay: MEMORY_WRITE_DEBOUNCE_MS,
+  });
+  const tempLayerActivationDelaySave = useDebouncedSave<number>({
+    delay: MEMORY_WRITE_DEBOUNCE_MS,
+  });
+  const tempLayerDeactivationDelaySave = useDebouncedSave<number>({
+    delay: MEMORY_WRITE_DEBOUNCE_MS,
+  });
+  const activeLayersSave = useDebouncedSave<number>({
+    delay: MEMORY_WRITE_DEBOUNCE_MS,
+  });
+  const axisSnapModeSave = useDebouncedSave<AxisSnapMode>({
+    delay: MEMORY_WRITE_DEBOUNCE_MS,
+  });
+  const axisSnapThresholdSave = useDebouncedSave<number>({
+    delay: MEMORY_WRITE_DEBOUNCE_MS,
+  });
+  const axisSnapTimeoutSave = useDebouncedSave<number>({
+    delay: MEMORY_WRITE_DEBOUNCE_MS,
+  });
+  const xInvertSave = useDebouncedSave<boolean>({
+    delay: MEMORY_WRITE_DEBOUNCE_MS,
+  });
+  const yInvertSave = useDebouncedSave<boolean>({
+    delay: MEMORY_WRITE_DEBOUNCE_MS,
+  });
+  const xyToScrollEnabledSave = useDebouncedSave<boolean>({
+    delay: MEMORY_WRITE_DEBOUNCE_MS,
+  });
+  const xySwapEnabledSave = useDebouncedSave<boolean>({
+    delay: MEMORY_WRITE_DEBOUNCE_MS,
+  });
 
   // Track previous processor to detect changes and reset pending state
   const previousProcessorRef = useRef<string | null>(null);

--- a/src/pages/__tests__/TrackballPage.test.tsx
+++ b/src/pages/__tests__/TrackballPage.test.tsx
@@ -181,9 +181,9 @@ describe("TrackballPage", () => {
 
     await user.click(screen.getByLabelText("Increase scaling"));
 
-    // Fast-forward time to trigger debounced auto-save (1000ms)
+    // Fast-forward time to trigger debounced auto-save (1500ms)
     await act(async () => {
-      jest.advanceTimersByTime(1000);
+      jest.advanceTimersByTime(1500);
     });
 
     expect(mockSetScaling).toHaveBeenCalledWith(0, 21, 20);
@@ -213,7 +213,7 @@ describe("TrackballPage", () => {
     await user.click(screen.getByLabelText("Increase scaling"));
 
     await act(async () => {
-      jest.advanceTimersByTime(1000);
+      jest.advanceTimersByTime(1500);
     });
 
     expect(mockSetScaling).toHaveBeenCalledWith(0, 6, 5);
@@ -247,9 +247,9 @@ describe("TrackballPage", () => {
     // Toggle it off
     await user.click(rotationToggle);
 
-    // Fast-forward time to trigger debounced auto-save (1000ms)
+    // Fast-forward time to trigger debounced auto-save (1500ms)
     await act(async () => {
-      jest.advanceTimersByTime(1000);
+      jest.advanceTimersByTime(1500);
     });
 
     // Disabling rotation should set it to 0
@@ -279,7 +279,7 @@ describe("TrackballPage", () => {
     await user.click(screen.getByLabelText("Increase rotation"));
 
     await act(async () => {
-      jest.advanceTimersByTime(1000);
+      jest.advanceTimersByTime(1500);
     });
 
     expect(mockSetRotation).toHaveBeenCalledWith(0, 91);

--- a/src/proto/cormoran/runtime_macro/runtime_macro.ts
+++ b/src/proto/cormoran/runtime_macro/runtime_macro.ts
@@ -23,6 +23,14 @@ export interface MacroSummary {
   slot: number;
   name: string;
   encodedSize: number;
+  /**
+   * True when the macro has an in-memory-only change not yet written to
+   * flash (a memory-mode create/edit, or a value that differs from the
+   * persisted one). Cleared by SaveMacros / DiscardMacros. A devicetree
+   * default that has never been saved also reports true, since it lives
+   * only in memory until the user saves it.
+   */
+  hasUnsavedChanges: boolean;
 }
 
 export interface BehaviorBinding {
@@ -99,6 +107,20 @@ export interface RenameMacroRequest {
   persist: boolean;
 }
 
+/**
+ * Reset the macro at `slot` to its compile-time (devicetree) state: if a
+ * `cormoran,runtime-macro-default` node declares a macro whose name matches
+ * this macro's, overwrite the body with that default; otherwise (no such
+ * compile-time default) delete the macro entirely - "reset" of a macro that
+ * only ever existed at runtime means removing it. `persist` writes the reset
+ * result straight to flash (otherwise it lives in memory until SaveMacros /
+ * is re-seeded from the devicetree next boot).
+ */
+export interface ResetMacroRequest {
+  slot: number;
+  persist: boolean;
+}
+
 export interface Request {
   listMacros?: ListMacrosRequest | undefined;
   getMacro?: GetMacroRequest | undefined;
@@ -112,6 +134,7 @@ export interface Request {
   createMacro?: CreateMacroRequest | undefined;
   deleteMacro?: DeleteMacroRequest | undefined;
   renameMacro?: RenameMacroRequest | undefined;
+  resetMacro?: ResetMacroRequest | undefined;
 }
 
 export interface ErrorResponse {
@@ -272,7 +295,7 @@ export const GetMacroGlobalSettingsRequest: MessageFns<GetMacroGlobalSettingsReq
 };
 
 function createBaseMacroSummary(): MacroSummary {
-  return { slot: 0, name: "", encodedSize: 0 };
+  return { slot: 0, name: "", encodedSize: 0, hasUnsavedChanges: false };
 }
 
 export const MacroSummary: MessageFns<MacroSummary> = {
@@ -285,6 +308,9 @@ export const MacroSummary: MessageFns<MacroSummary> = {
     }
     if (message.encodedSize !== 0) {
       writer.uint32(24).uint32(message.encodedSize);
+    }
+    if (message.hasUnsavedChanges !== false) {
+      writer.uint32(32).bool(message.hasUnsavedChanges);
     }
     return writer;
   },
@@ -320,6 +346,14 @@ export const MacroSummary: MessageFns<MacroSummary> = {
           message.encodedSize = reader.uint32();
           continue;
         }
+        case 4: {
+          if (tag !== 32) {
+            break;
+          }
+
+          message.hasUnsavedChanges = reader.bool();
+          continue;
+        }
       }
       if ((tag & 7) === 4 || tag === 0) {
         break;
@@ -337,6 +371,7 @@ export const MacroSummary: MessageFns<MacroSummary> = {
     message.slot = object.slot ?? 0;
     message.name = object.name ?? "";
     message.encodedSize = object.encodedSize ?? 0;
+    message.hasUnsavedChanges = object.hasUnsavedChanges ?? false;
     return message;
   },
 };
@@ -1209,6 +1244,64 @@ export const RenameMacroRequest: MessageFns<RenameMacroRequest> = {
   },
 };
 
+function createBaseResetMacroRequest(): ResetMacroRequest {
+  return { slot: 0, persist: false };
+}
+
+export const ResetMacroRequest: MessageFns<ResetMacroRequest> = {
+  encode(message: ResetMacroRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    if (message.slot !== 0) {
+      writer.uint32(8).uint32(message.slot);
+    }
+    if (message.persist !== false) {
+      writer.uint32(16).bool(message.persist);
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): ResetMacroRequest {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseResetMacroRequest();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 8) {
+            break;
+          }
+
+          message.slot = reader.uint32();
+          continue;
+        }
+        case 2: {
+          if (tag !== 16) {
+            break;
+          }
+
+          message.persist = reader.bool();
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  create(base?: DeepPartial<ResetMacroRequest>): ResetMacroRequest {
+    return ResetMacroRequest.fromPartial(base ?? {});
+  },
+  fromPartial(object: DeepPartial<ResetMacroRequest>): ResetMacroRequest {
+    const message = createBaseResetMacroRequest();
+    message.slot = object.slot ?? 0;
+    message.persist = object.persist ?? false;
+    return message;
+  },
+};
+
 function createBaseRequest(): Request {
   return {
     listMacros: undefined,
@@ -1223,6 +1316,7 @@ function createBaseRequest(): Request {
     createMacro: undefined,
     deleteMacro: undefined,
     renameMacro: undefined,
+    resetMacro: undefined,
   };
 }
 
@@ -1263,6 +1357,9 @@ export const Request: MessageFns<Request> = {
     }
     if (message.renameMacro !== undefined) {
       RenameMacroRequest.encode(message.renameMacro, writer.uint32(114).fork()).join();
+    }
+    if (message.resetMacro !== undefined) {
+      ResetMacroRequest.encode(message.resetMacro, writer.uint32(122).fork()).join();
     }
     return writer;
   },
@@ -1370,6 +1467,14 @@ export const Request: MessageFns<Request> = {
           message.renameMacro = RenameMacroRequest.decode(reader, reader.uint32());
           continue;
         }
+        case 15: {
+          if (tag !== 122) {
+            break;
+          }
+
+          message.resetMacro = ResetMacroRequest.decode(reader, reader.uint32());
+          continue;
+        }
       }
       if ((tag & 7) === 4 || tag === 0) {
         break;
@@ -1420,6 +1525,9 @@ export const Request: MessageFns<Request> = {
       : undefined;
     message.renameMacro = (object.renameMacro !== undefined && object.renameMacro !== null)
       ? RenameMacroRequest.fromPartial(object.renameMacro)
+      : undefined;
+    message.resetMacro = (object.resetMacro !== undefined && object.resetMacro !== null)
+      ? ResetMacroRequest.fromPartial(object.resetMacro)
       : undefined;
     return message;
   },

--- a/src/proto/cormoran/zmk/custom_settings/custom_settings.ts
+++ b/src/proto/cormoran/zmk/custom_settings/custom_settings.ts
@@ -187,6 +187,15 @@ export interface Setting {
   /** Omitted for DEVICE_PRIVATE settings and secure settings while locked. */
   value: SettingValue | undefined;
   source: number;
+  /**
+   * The setting's default value (its runtime override if one was installed,
+   * otherwise its compile-time default). Present only when the request set
+   * require_default AND the current value differs from that default, so a
+   * client can offer a "reset to default" affordance without a second round
+   * trip. Never present for array or keyspace settings (which have no
+   * compile-time default).
+   */
+  defaultValue?: SettingValue | undefined;
 }
 
 export interface ListSettingsRequest {
@@ -195,6 +204,11 @@ export interface ListSettingsRequest {
     | undefined;
   /** Include static metadata in each list item notification. */
   requireMeta: boolean;
+  /**
+   * Include each setting's default value (see Setting.default_value); only
+   * emitted for settings whose current value differs from the default.
+   */
+  requireDefault: boolean;
 }
 
 export interface GetSettingRequest {
@@ -203,6 +217,11 @@ export interface GetSettingRequest {
     | undefined;
   /** Include static metadata in the get response. */
   requireMeta: boolean;
+  /**
+   * Include the setting's default value (see Setting.default_value); only
+   * emitted when the current value differs from the default.
+   */
+  requireDefault: boolean;
 }
 
 export interface WriteSettingRequest {
@@ -1287,7 +1306,15 @@ export const SettingMeta: MessageFns<SettingMeta> = {
 };
 
 function createBaseSetting(): Setting {
-  return { customSubsystemIndex: 0, key: "", meta: undefined, hasUnsavedValue: false, value: undefined, source: 0 };
+  return {
+    customSubsystemIndex: 0,
+    key: "",
+    meta: undefined,
+    hasUnsavedValue: false,
+    value: undefined,
+    source: 0,
+    defaultValue: undefined,
+  };
 }
 
 export const Setting: MessageFns<Setting> = {
@@ -1309,6 +1336,9 @@ export const Setting: MessageFns<Setting> = {
     }
     if (message.source !== 0) {
       writer.uint32(80).uint32(message.source);
+    }
+    if (message.defaultValue !== undefined) {
+      SettingValue.encode(message.defaultValue, writer.uint32(90).fork()).join();
     }
     return writer;
   },
@@ -1368,6 +1398,14 @@ export const Setting: MessageFns<Setting> = {
           message.source = reader.uint32();
           continue;
         }
+        case 11: {
+          if (tag !== 90) {
+            break;
+          }
+
+          message.defaultValue = SettingValue.decode(reader, reader.uint32());
+          continue;
+        }
       }
       if ((tag & 7) === 4 || tag === 0) {
         break;
@@ -1392,12 +1430,15 @@ export const Setting: MessageFns<Setting> = {
       ? SettingValue.fromPartial(object.value)
       : undefined;
     message.source = object.source ?? 0;
+    message.defaultValue = (object.defaultValue !== undefined && object.defaultValue !== null)
+      ? SettingValue.fromPartial(object.defaultValue)
+      : undefined;
     return message;
   },
 };
 
 function createBaseListSettingsRequest(): ListSettingsRequest {
-  return { scope: undefined, requireMeta: false };
+  return { scope: undefined, requireMeta: false, requireDefault: false };
 }
 
 export const ListSettingsRequest: MessageFns<ListSettingsRequest> = {
@@ -1407,6 +1448,9 @@ export const ListSettingsRequest: MessageFns<ListSettingsRequest> = {
     }
     if (message.requireMeta !== false) {
       writer.uint32(16).bool(message.requireMeta);
+    }
+    if (message.requireDefault !== false) {
+      writer.uint32(24).bool(message.requireDefault);
     }
     return writer;
   },
@@ -1434,6 +1478,14 @@ export const ListSettingsRequest: MessageFns<ListSettingsRequest> = {
           message.requireMeta = reader.bool();
           continue;
         }
+        case 3: {
+          if (tag !== 24) {
+            break;
+          }
+
+          message.requireDefault = reader.bool();
+          continue;
+        }
       }
       if ((tag & 7) === 4 || tag === 0) {
         break;
@@ -1452,12 +1504,13 @@ export const ListSettingsRequest: MessageFns<ListSettingsRequest> = {
       ? SettingScope.fromPartial(object.scope)
       : undefined;
     message.requireMeta = object.requireMeta ?? false;
+    message.requireDefault = object.requireDefault ?? false;
     return message;
   },
 };
 
 function createBaseGetSettingRequest(): GetSettingRequest {
-  return { setting: undefined, requireMeta: false };
+  return { setting: undefined, requireMeta: false, requireDefault: false };
 }
 
 export const GetSettingRequest: MessageFns<GetSettingRequest> = {
@@ -1467,6 +1520,9 @@ export const GetSettingRequest: MessageFns<GetSettingRequest> = {
     }
     if (message.requireMeta !== false) {
       writer.uint32(16).bool(message.requireMeta);
+    }
+    if (message.requireDefault !== false) {
+      writer.uint32(24).bool(message.requireDefault);
     }
     return writer;
   },
@@ -1494,6 +1550,14 @@ export const GetSettingRequest: MessageFns<GetSettingRequest> = {
           message.requireMeta = reader.bool();
           continue;
         }
+        case 3: {
+          if (tag !== 24) {
+            break;
+          }
+
+          message.requireDefault = reader.bool();
+          continue;
+        }
       }
       if ((tag & 7) === 4 || tag === 0) {
         break;
@@ -1512,6 +1576,7 @@ export const GetSettingRequest: MessageFns<GetSettingRequest> = {
       ? SettingRef.fromPartial(object.setting)
       : undefined;
     message.requireMeta = object.requireMeta ?? false;
+    message.requireDefault = object.requireDefault ?? false;
     return message;
   },
 };


### PR DESCRIPTION
## What & why

Unifies the editing UX across every editing feature so they share one model, per request:

- **Edit → auto-write to keyboard memory** after a debounce (no per-field save button).
- **Discard** reverts memory to the last **persisted** value.
- **Reset** reverts the persisted value to the **compile-time default**.
- **🟢 Green dot** (`--color-neon`) = value in memory, not yet persisted.
- **🔵 Blue dot** (`--color-electric`) = persisted but differs from the compile-time default.

This convention already existed on the **Keymap** page; the rest of the app now matches it.

## Shared primitives

- `src/components/EditStatusIndicator.tsx` — `StatusDot` / `StatusBadge` / `EditStatusLegend` + the `EditStatus` type.
- `src/hooks/useDebouncedMemoryWrite.ts` — shared debounce + `MEMORY_WRITE_DEBOUNCE_MS`.

## Reflects firmware protocol additions (frontend only)

These two firmware PRs added the fields this UI needs; this change regenerates the TS clients and wires them up:

- custom-settings [#45](https://github.com/cormoran/zmk-feature-custom-settings/pull/45): `Setting.default_value` + `require_default` → drives the blue "changed from default" dot.
- runtime-macro [#16](https://github.com/cormoran/zmk-feature-runtime-macro/pull/16): `MacroSummary.has_unsaved_changes` + `ResetMacroRequest` → device-truth green dots and a real per-macro Reset-to-default.

## Per-feature changes

| Feature | Change |
|---|---|
| **Custom settings** | Blue dot via `default_value`; shared `StatusDot`; shared debounce constant. |
| **Macro** | Green dots now from device truth (`has_unsaved_changes`); real per-macro **Reset to default**; the mislabeled global "Reset" button renamed to **Discard**; text/number edits debounced. |
| **Combo** | Removed the two-stage local-draft + "Save Combo" flow → **debounced auto memory-write**; blue dot via `ComboSource`; kept global Save/Discard and per-combo Reset. |
| **Keymap** | Already implemented this model — left functionally unchanged (it is the reference). |
| **Blocked surfaces** (trackball main, rotary encoder, power management, default layer) | Firmware protocol has no memory/persist/default tiers here, so **no dishonest dots/Discard/Reset**. Power management now auto-writes (Apply button removed) with plain "Saving…/Saved" status; sensor-rotation and trackball debounce delays aligned to the shared constant. |

Demo transports were updated so the new fields (combo `source`, custom-settings `default_value`, macro `has_unsaved_changes` / reset) are exercisable.

## Verification

- `tsc -b` ✅ · `eslint` ✅ · `jest` ✅ (453 passing, incl. new demo-transport tests for the added fields).
- Note: the in-app demo preview could not be exercised headlessly because the preview pane reports `document.visibilityState: "hidden"`, which pauses framer-motion's `AnimatePresence mode="wait"` (page transitions never complete → blank panels). This is an environment artifact, not a code issue; render paths were verified by code review instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)