### PR TITLE
refactor(ui): declutter Macros & Combos cards

### DIFF
--- a/src/components/macroCombo/ComboEditorCard.tsx
+++ b/src/components/macroCombo/ComboEditorCard.tsx
@@ -26,7 +26,6 @@ import {
 } from "../../proto/cormoran/runtime_combo/runtime_combo";
 import {
   comboEditStatus,
-  comboSourceLabel,
   formatComboBehavior,
   formatLayerScope,
   hasLayer,
@@ -75,9 +74,6 @@ export function ComboEditorCard({
             <h2 className="text-sm font-medium text-[var(--color-text)]">
               {t("Combo Editor")}
             </h2>
-            <span className="text-[10px] px-1.5 py-0.5 rounded-full border border-[var(--color-border)] text-[var(--color-text-muted)]">
-              {comboSourceLabel(combo.editorSource, t)}
-            </span>
             <StatusDot
               status={comboEditStatus(
                 combo.editorSource,

--- a/src/pages/MacroComboPage.tsx
+++ b/src/pages/MacroComboPage.tsx
@@ -38,7 +38,6 @@ import {
 } from "../components/macroCombo/GlobalSettingsCards";
 import {
   comboEditStatus,
-  comboSourceLabel,
   defaultBehaviorBinding,
   formatComboBehavior,
   formatLayerScope,
@@ -494,12 +493,6 @@ export function MacroComboPage() {
                             <StatusDot status="unsaved" />
                           )}
                         </div>
-                        <span className="block text-xs text-[var(--color-text-muted)]">
-                          {t("{{encodedSize}}/{{maxMacroBytes}} bytes", {
-                            encodedSize: macro.encodedSize,
-                            maxMacroBytes: runtimeMacro.maxMacroBytes,
-                          })}
-                        </span>
                       </button>
                     ))}
                   </div>
@@ -514,13 +507,6 @@ export function MacroComboPage() {
                       <h2 className="text-sm font-medium text-[var(--color-text)]">
                         {t("Combos")}
                       </h2>
-                      <p className="text-xs text-[var(--color-text-muted)]">
-                        {runtimeCombo.combos.length}
-                        {comboEditor.maxCombo
-                          ? ` / ${comboEditor.maxCombo}`
-                          : ""}{" "}
-                        {t("configured")}
-                      </p>
                     </div>
                     <div className="flex items-center gap-1">
                       {runtimeCombo.isLoading && (
@@ -589,12 +575,6 @@ export function MacroComboPage() {
                                   comboEditor.modifiedIndices,
                                 )}
                               />
-                              <span className="text-xs font-mono text-[var(--color-text-muted)]">
-                                #{combo.index}
-                              </span>
-                              <span className="text-[10px] px-1.5 py-0.5 rounded-full border border-[var(--color-border)] text-[var(--color-text-muted)]">
-                                {comboSourceLabel(combo.source, t)}
-                              </span>
                             </span>
                           </div>
                           <div className="mt-1 text-xs text-[var(--color-text-muted)] truncate">


### PR DESCRIPTION
## What

Reduce visual noise in the **Macro & Combo** tab so the Macros and Combos list cards read more cleanly.

### Combos card
- Remove the combo source label pill (`Runtime` / `Default` / `Overridden` / `Empty`) from the list rows and from the Combo Editor header. Edit state is already conveyed by the adjacent `StatusDot`.
- Remove the `#index` badge from each row.
- Remove the `{n} / {max} configured` count under the "Combos" heading.

### Macros card
- Remove the per-macro `{size}/{max} bytes` subtitle from the list rows.
- The byte counter is **kept** in the Macro Editor, where it still warns when the encoded size exceeds the limit.

## Notes
- Dropped the now-unused `comboSourceLabel` imports; the util itself is left in place.
- `tsc -b`, `eslint`, and the Jest suite (via pre-commit hook) all pass.
- Visual verification in the browser preview wasn't possible: demo mode doesn't populate the runtime macro/combo cards (they depend on a connected device's RPC subsystem).

🤖 Generated with [Claude Code](https://claude.com/claude-code)