### PR TITLE
fix(unlock): resume the attempted keymap edit after unlocking

### DIFF
--- a/src/contexts/StudioUnlockContext.tsx
+++ b/src/contexts/StudioUnlockContext.tsx
@@ -11,7 +11,11 @@
  *
  * `requireUnlock` is the proactive counterpart used by editor pages: it opens
  * the same modal *before* sending a doomed request when Studio is already known
- * to be locked.
+ * to be locked. Callers may hand it an `onUnlocked` callback — the action the
+ * user was trying to take (open the keycode selector, apply the edit, …) — and
+ * it is *parked* just like a failed request: once the user unlocks, the action
+ * runs, so a locked click resumes into what it was going to do instead of being
+ * silently dropped.
  *
  * Cancel cooldown: after the user dismisses the modal, further unlock errors
  * are auto-cancelled (no modal) until every unlock-gated request has finished
@@ -56,8 +60,13 @@ export interface StudioUnlockContextValue {
   /**
    * Proactive gate for editor actions: if Studio is currently locked, open the
    * unlock modal and return `false` (caller should bail); otherwise `true`.
+   *
+   * Pass `onUnlocked` to have the action the user attempted resume after they
+   * unlock — it is parked while locked and invoked once unlocked (or discarded
+   * if the modal is cancelled). When already unlocked the callback is ignored:
+   * `requireUnlock` returns `true` and the caller proceeds inline.
    */
-  requireUnlock: () => boolean;
+  requireUnlock: (onUnlocked?: () => void | Promise<void>) => boolean;
 }
 
 /**
@@ -96,6 +105,9 @@ export function StudioUnlockProvider({
   const parkedRef = useRef<ParkedOp[]>([]);
   // True when the proactive gate opened the modal without a parked op.
   const proactiveOpenRef = useRef(false);
+  // Actions handed to `requireUnlock(onUnlocked)` while locked: the operation
+  // the user was attempting, replayed once the device is actually unlocked.
+  const pendingActionsRef = useRef<Array<() => void | Promise<void>>>([]);
   // Cancel cooldown state: `suppressing` is true from a Cancel until things go
   // quiet; `inFlight` counts executing unlock-gated requests; `quietTimer` fires
   // once no request has been in flight for `quietMs`.
@@ -150,7 +162,15 @@ export function StudioUnlockProvider({
     // Snapshot and clear: any op that is still locked re-parks itself below.
     const ops = parkedRef.current;
     parkedRef.current = [];
-    proactiveOpenRef.current = false;
+    // Proactive resume actions only fire once the device is actually unlocked.
+    // If the user hit Retry while still locked, keep them parked (and the modal
+    // open) so the pending edit isn't dropped.
+    const unlocked = !lockedRef.current;
+    const pendingActions = unlocked ? pendingActionsRef.current : [];
+    if (unlocked) {
+      pendingActionsRef.current = [];
+      proactiveOpenRef.current = false;
+    }
     syncOpen();
 
     await Promise.all(
@@ -168,6 +188,17 @@ export function StudioUnlockProvider({
         }
       }),
     );
+
+    // Replay the operations the user originally attempted (open the selector,
+    // apply the edit, …) now that we're unlocked. Best-effort: a throwing
+    // resume must not take down the others.
+    for (const action of pendingActions) {
+      try {
+        await action();
+      } catch {
+        // Swallow — resume is best-effort; the action owns its error handling.
+      }
+    }
   }, [syncOpen]);
 
   const cancel = useCallback(() => {
@@ -178,6 +209,9 @@ export function StudioUnlockProvider({
     const ops = parkedRef.current;
     parkedRef.current = [];
     proactiveOpenRef.current = false;
+    // Dismissing the modal drops the pending edits too — the user chose not to
+    // unlock, so nothing should resume.
+    pendingActionsRef.current = [];
     syncOpen();
     for (const op of ops) {
       op.reject(new StudioUnlockCancelledError());
@@ -246,14 +280,21 @@ export function StudioUnlockProvider({
     [beginActivity, endActivity, syncOpen],
   );
 
-  const requireUnlock = useCallback((): boolean => {
-    if (lockedRef.current) {
-      proactiveOpenRef.current = true;
-      syncOpen();
-      return false;
-    }
-    return true;
-  }, [syncOpen]);
+  const requireUnlock = useCallback(
+    (onUnlocked?: () => void | Promise<void>): boolean => {
+      if (lockedRef.current) {
+        // Park the attempted action so it resumes after unlock (see retryAll).
+        if (onUnlocked) {
+          pendingActionsRef.current.push(onUnlocked);
+        }
+        proactiveOpenRef.current = true;
+        syncOpen();
+        return false;
+      }
+      return true;
+    },
+    [syncOpen],
+  );
 
   // Stable context value: `runWithUnlock`/`requireUnlock` never change identity,
   // so consumers don't re-render (and their `call`/auto-load effects don't

--- a/src/contexts/__tests__/StudioUnlockContext.test.tsx
+++ b/src/contexts/__tests__/StudioUnlockContext.test.tsx
@@ -51,6 +51,9 @@ function setLockState(next: StudioLockState) {
   mockLockState = next;
 }
 
+const sleepMs = (ms: number) =>
+  act(() => new Promise<void>((r) => setTimeout(r, ms)));
+
 describe("StudioUnlockProvider", () => {
   beforeEach(() => {
     mockLockState = "locked";
@@ -101,6 +104,124 @@ describe("StudioUnlockProvider", () => {
     );
 
     await screen.findByText("Keyboard Unlock Required");
+  });
+
+  it("resumes the parked action after unlock (requireUnlock onUnlocked)", async () => {
+    // Mirrors KeymapPage's key click while locked: the gate returns false and
+    // opens the modal, and the attempted action must replay once unlocked.
+    const resumed = jest.fn();
+    function Gate() {
+      const { requireUnlock } = useStudioUnlock();
+      return (
+        <button
+          onClick={() => {
+            if (!requireUnlock(resumed)) return;
+            resumed();
+          }}
+        >
+          edit
+        </button>
+      );
+    }
+
+    const { rerender } = render(
+      <StudioUnlockProvider>
+        <Gate />
+      </StudioUnlockProvider>,
+    );
+
+    // Locked: click parks the action and opens the modal without running it.
+    await userEvent.click(screen.getByText("edit"));
+    await screen.findByText("Keyboard Unlock Required");
+    expect(resumed).not.toHaveBeenCalled();
+
+    // Device unlocks -> the parked action runs exactly once, modal closes.
+    act(() => setLockState("unlocked"));
+    rerender(
+      <StudioUnlockProvider>
+        <Gate />
+      </StudioUnlockProvider>,
+    );
+
+    await waitFor(() => expect(resumed).toHaveBeenCalledTimes(1));
+    await waitFor(() =>
+      expect(
+        screen.queryByText("Keyboard Unlock Required"),
+      ).not.toBeInTheDocument(),
+    );
+  });
+
+  it("runs the action inline (not parked) when already unlocked", async () => {
+    mockLockState = "unlocked";
+    const resumed = jest.fn();
+    function Gate() {
+      const { requireUnlock } = useStudioUnlock();
+      return (
+        <button
+          onClick={() => {
+            if (!requireUnlock(resumed)) return;
+            resumed();
+          }}
+        >
+          edit
+        </button>
+      );
+    }
+
+    render(
+      <StudioUnlockProvider>
+        <Gate />
+      </StudioUnlockProvider>,
+    );
+
+    await userEvent.click(screen.getByText("edit"));
+    // Runs once, inline — the onUnlocked callback is ignored when unlocked.
+    expect(resumed).toHaveBeenCalledTimes(1);
+    expect(
+      screen.queryByText("Keyboard Unlock Required"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("discards the parked action when the modal is cancelled", async () => {
+    const resumed = jest.fn();
+    function Gate() {
+      const { requireUnlock } = useStudioUnlock();
+      return (
+        <button
+          onClick={() => {
+            if (!requireUnlock(resumed)) return;
+            resumed();
+          }}
+        >
+          edit
+        </button>
+      );
+    }
+
+    const { rerender } = render(
+      <StudioUnlockProvider>
+        <Gate />
+      </StudioUnlockProvider>,
+    );
+
+    await userEvent.click(screen.getByText("edit"));
+    await screen.findByText("Keyboard Unlock Required");
+    await userEvent.click(screen.getByRole("button", { name: /Cancel/i }));
+    await waitFor(() =>
+      expect(
+        screen.queryByText("Keyboard Unlock Required"),
+      ).not.toBeInTheDocument(),
+    );
+
+    // A later unlock must not replay the dismissed action.
+    act(() => setLockState("unlocked"));
+    rerender(
+      <StudioUnlockProvider>
+        <Gate />
+      </StudioUnlockProvider>,
+    );
+    await sleepMs(20);
+    expect(resumed).not.toHaveBeenCalled();
   });
 
   it("requireUnlock does not open the modal when unlocked", async () => {

--- a/src/pages/KeymapPage.tsx
+++ b/src/pages/KeymapPage.tsx
@@ -111,47 +111,59 @@ export function KeymapPage() {
   // bails out. `unknown` lock state is treated as unlocked (optimistic) — a
   // rare edit during that brief window still surfaces the modal reactively when
   // the request fails (see useKeymap's runWithUnlock).
-
-  // Handle key click
-  const handleKeyClick = useCallback(
-    (keyPosition: number) => {
-      if (!requireUnlocked()) return;
-      setSelectedKeyPosition(keyPosition);
-      setShowKeycodeSelector(true);
+  //
+  // `withUnlock` wraps an edit behind that gate *and* resumes it after unlock:
+  // run the action now if unlocked, otherwise hand it to the modal so it
+  // replays the exact operation the user attempted once they unlock — instead
+  // of silently dropping the click.
+  const withUnlock = useCallback(
+    (action: () => void | Promise<void>) => {
+      if (!requireUnlocked(action)) return;
+      void action();
     },
     [requireUnlocked],
   );
 
+  // Handle key click
+  const handleKeyClick = useCallback(
+    (keyPosition: number) =>
+      withUnlock(() => {
+        setSelectedKeyPosition(keyPosition);
+        setShowKeycodeSelector(true);
+      }),
+    [withUnlock],
+  );
+
   // Handle key reset
   const handleKeyReset = useCallback(
-    async (keyPosition: number) => {
-      if (!requireUnlocked()) return;
-      if (!currentLayer) return;
-      await keymap.resetBinding(currentLayer.id, keyPosition);
-    },
-    [currentLayer, keymap, requireUnlocked],
+    (keyPosition: number) =>
+      withUnlock(async () => {
+        if (!currentLayer) return;
+        await keymap.resetBinding(currentLayer.id, keyPosition);
+      }),
+    [currentLayer, keymap, withUnlock],
   );
 
   // Handle key reset-to-default (in-memory edit; becomes an unsaved change)
   const handleKeyResetToDefault = useCallback(
-    async (keyPosition: number) => {
-      if (!requireUnlocked()) return;
-      if (!currentLayer) return;
-      await keymap.resetBindingToDefault(currentLayer.id, keyPosition);
-    },
-    [currentLayer, keymap, requireUnlocked],
+    (keyPosition: number) =>
+      withUnlock(async () => {
+        if (!currentLayer) return;
+        await keymap.resetBindingToDefault(currentLayer.id, keyPosition);
+      }),
+    [currentLayer, keymap, withUnlock],
   );
 
   // Handle binding selection
   const handleBindingSelect = useCallback(
-    async (binding: BehaviorBinding) => {
-      if (!requireUnlocked()) return;
-      if (!currentLayer || selectedKeyPosition === null) return;
-      await keymap.setBinding(currentLayer.id, selectedKeyPosition, binding);
-      setShowKeycodeSelector(false);
-      setSelectedKeyPosition(null);
-    },
-    [currentLayer, selectedKeyPosition, keymap, requireUnlocked],
+    (binding: BehaviorBinding) =>
+      withUnlock(async () => {
+        if (!currentLayer || selectedKeyPosition === null) return;
+        await keymap.setBinding(currentLayer.id, selectedKeyPosition, binding);
+        setShowKeycodeSelector(false);
+        setSelectedKeyPosition(null);
+      }),
+    [currentLayer, selectedKeyPosition, keymap, withUnlock],
   );
 
   // Handle save
@@ -178,96 +190,118 @@ export function KeymapPage() {
   // Handle reset-to-default: reset the persistent keymap to the hard-coded
   // default, then close the confirmation dialog. Gated on unlock (it edits +
   // saves) like every other keymap edit.
-  const handleResetToDefault = useCallback(async () => {
-    if (!requireUnlocked()) return;
-    setIsResetting(true);
-    try {
-      const ok = await keymap.resetToDefault();
-      if (ok) {
-        setShowResetDialog(false);
-      }
-    } finally {
-      setIsResetting(false);
-    }
-  }, [keymap, requireUnlocked]);
+  const handleResetToDefault = useCallback(
+    () =>
+      withUnlock(async () => {
+        setIsResetting(true);
+        try {
+          const ok = await keymap.resetToDefault();
+          if (ok) {
+            setShowResetDialog(false);
+          }
+        } finally {
+          setIsResetting(false);
+        }
+      }),
+    [keymap, withUnlock],
+  );
 
   // Handle layer move up
-  const handleMoveLayerUp = useCallback(async () => {
-    if (!requireUnlocked()) return;
-    if (selectedLayerIndex <= 0) return;
-    const success = await keymap.moveLayer(
-      selectedLayerIndex,
-      selectedLayerIndex - 1,
-    );
-    if (success) {
-      setSelectedLayerIndex(selectedLayerIndex - 1);
-    }
-  }, [selectedLayerIndex, keymap, requireUnlocked]);
+  const handleMoveLayerUp = useCallback(
+    () =>
+      withUnlock(async () => {
+        if (selectedLayerIndex <= 0) return;
+        const success = await keymap.moveLayer(
+          selectedLayerIndex,
+          selectedLayerIndex - 1,
+        );
+        if (success) {
+          setSelectedLayerIndex(selectedLayerIndex - 1);
+        }
+      }),
+    [selectedLayerIndex, keymap, withUnlock],
+  );
 
   // Handle layer move down
-  const handleMoveLayerDown = useCallback(async () => {
-    if (!requireUnlocked()) return;
-    if (!keymap.keymap?.layers) return;
-    if (selectedLayerIndex >= keymap.keymap.layers.length - 1) return;
-    const success = await keymap.moveLayer(
-      selectedLayerIndex,
-      selectedLayerIndex + 1,
-    );
-    if (success) {
-      setSelectedLayerIndex(selectedLayerIndex + 1);
-    }
-  }, [selectedLayerIndex, keymap, requireUnlocked]);
+  const handleMoveLayerDown = useCallback(
+    () =>
+      withUnlock(async () => {
+        if (!keymap.keymap?.layers) return;
+        if (selectedLayerIndex >= keymap.keymap.layers.length - 1) return;
+        const success = await keymap.moveLayer(
+          selectedLayerIndex,
+          selectedLayerIndex + 1,
+        );
+        if (success) {
+          setSelectedLayerIndex(selectedLayerIndex + 1);
+        }
+      }),
+    [selectedLayerIndex, keymap, withUnlock],
+  );
 
   // Handle add layer
-  const handleAddLayer = useCallback(async () => {
-    if (!requireUnlocked()) return;
-    const result = await keymap.addLayer();
-    if (result) {
-      // Select the new layer
-      setSelectedLayerIndex(result.index);
-    }
-  }, [keymap, requireUnlocked]);
+  const handleAddLayer = useCallback(
+    () =>
+      withUnlock(async () => {
+        const result = await keymap.addLayer();
+        if (result) {
+          // Select the new layer
+          setSelectedLayerIndex(result.index);
+        }
+      }),
+    [keymap, withUnlock],
+  );
 
   // Handle delete layer
-  const handleDeleteLayer = useCallback(async () => {
-    if (!requireUnlocked()) return;
-    if (!keymap.keymap?.layers || keymap.keymap.layers.length <= 1) return;
-    if (!confirm(t("Are you sure you want to delete this layer?"))) return;
+  const handleDeleteLayer = useCallback(
+    () =>
+      withUnlock(async () => {
+        if (!keymap.keymap?.layers || keymap.keymap.layers.length <= 1) return;
+        if (!confirm(t("Are you sure you want to delete this layer?"))) return;
 
-    const success = await keymap.removeLayer(selectedLayerIndex);
-    if (success) {
-      // Adjust selected index if we deleted the last layer
-      if (selectedLayerIndex >= keymap.keymap.layers.length - 1) {
-        setSelectedLayerIndex(Math.max(0, selectedLayerIndex - 1));
-      }
-    }
-  }, [selectedLayerIndex, keymap, t, requireUnlocked]);
+        const success = await keymap.removeLayer(selectedLayerIndex);
+        if (success) {
+          // Adjust selected index if we deleted the last layer
+          if (selectedLayerIndex >= keymap.keymap.layers.length - 1) {
+            setSelectedLayerIndex(Math.max(0, selectedLayerIndex - 1));
+          }
+        }
+      }),
+    [selectedLayerIndex, keymap, t, withUnlock],
+  );
 
   // Handle restore layer
-  const handleRestoreLayer = useCallback(async () => {
-    if (!requireUnlocked()) return;
-    if (keymap.removedLayerIds.length === 0) return;
+  const handleRestoreLayer = useCallback(
+    () =>
+      withUnlock(async () => {
+        if (keymap.removedLayerIds.length === 0) return;
 
-    // Restore the most recently removed layer at the end
-    const layerId = keymap.removedLayerIds[keymap.removedLayerIds.length - 1];
-    const atIndex = keymap.keymap?.layers.length ?? 0;
+        // Restore the most recently removed layer at the end
+        const layerId =
+          keymap.removedLayerIds[keymap.removedLayerIds.length - 1];
+        const atIndex = keymap.keymap?.layers.length ?? 0;
 
-    const layer = await keymap.restoreLayer(layerId, atIndex);
-    if (layer) {
-      // Select the restored layer
-      setSelectedLayerIndex(atIndex);
-    }
-  }, [keymap, requireUnlocked]);
+        const layer = await keymap.restoreLayer(layerId, atIndex);
+        if (layer) {
+          // Select the restored layer
+          setSelectedLayerIndex(atIndex);
+        }
+      }),
+    [keymap, withUnlock],
+  );
 
   // Handle open rename dialog
-  const handleOpenRenameDialog = useCallback(() => {
-    if (!requireUnlocked()) return;
-    if (!keymap.keymap?.layers) return;
-    const layer = keymap.keymap.layers[selectedLayerIndex];
-    if (!layer) return;
-    setRenameValue(layer.name);
-    setShowRenameDialog(true);
-  }, [keymap.keymap?.layers, selectedLayerIndex, requireUnlocked]);
+  const handleOpenRenameDialog = useCallback(
+    () =>
+      withUnlock(() => {
+        if (!keymap.keymap?.layers) return;
+        const layer = keymap.keymap.layers[selectedLayerIndex];
+        if (!layer) return;
+        setRenameValue(layer.name);
+        setShowRenameDialog(true);
+      }),
+    [keymap.keymap?.layers, selectedLayerIndex, withUnlock],
+  );
 
   // Handle rename confirm
   const handleRenameConfirm = useCallback(async () => {


### PR DESCRIPTION
## Problem

In the Keymap tab, clicking a key to change its behavior while Studio is locked pops the unlock modal — but after unlocking, nothing happens. The keycode selector never opens and the user has to click the key again. The same applied to every keymap edit (key reset, reset-to-default, layer move/add/delete/restore, rename).

**Root cause:** the app has two unlock paths through the shared `StudioUnlockContext`:

- **Reactive** (`runWithUnlock`, used by device requests): parks the failed request and *resumes* it after unlock — "just works."
- **Proactive** (`requireUnlock`, used by click handlers): only opened the modal and returned `false`, storing **nothing**. After unlock the attempted action was silently dropped.

## Fix

Give the proactive path the same park-and-resume machinery as the reactive one:

- `StudioUnlockContext`: `requireUnlock(onUnlocked?)` now accepts the attempted action, parks it in `pendingActionsRef` while locked, replays it in `retryAll` once the device is actually unlocked, and discards it on Cancel. **Backward compatible** — callers passing no callback behave exactly as before (so the Macro&Combo tab is unaffected).
- `KeymapPage`: added a `withUnlock(action)` helper (run inline when unlocked, else resume after unlock) and routed every edit handler through it.

Now: click a key while locked → modal appears → unlock → the keycode selector opens automatically for that key, resuming the exact operation.

## Testing

- 3 new unit tests in `StudioUnlockContext.test.tsx`: resume-after-unlock, run-inline-when-unlocked, discard-on-cancel.
- Full suite: 485 passing, typecheck and lint clean.
- Note: the browser preview can't exercise this — the demo transport is hardwired "always unlocked," so the modal only appears against a real locked device. Verified via unit tests instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)