### PR TITLE
feat(i18n): auto-detect language when no saved preference

### DIFF
--- a/src/contexts/LanguageContext.tsx
+++ b/src/contexts/LanguageContext.tsx
@@ -14,6 +14,21 @@ import { LanguageContext } from "./language";
 
 const STORAGE_KEY = "dya-studio-language";
 
+function detectBrowserLanguage(): Language {
+  const candidates =
+    navigator.languages && navigator.languages.length > 0
+      ? navigator.languages
+      : [navigator.language];
+
+  for (const candidate of candidates) {
+    if (candidate.toLowerCase().startsWith("ja")) {
+      return "ja";
+    }
+  }
+
+  return "en";
+}
+
 function getInitialLanguage(): Language {
   if (typeof window === "undefined") {
     return "en";
@@ -24,23 +39,27 @@ function getInitialLanguage(): Language {
     return stored;
   }
 
-  return "en";
+  return detectBrowserLanguage();
 }
 
 export function LanguageProvider({ children }: { children: ReactNode }) {
   const [language, setLanguageState] = useState<Language>(getInitialLanguage);
 
   useEffect(() => {
-    localStorage.setItem(STORAGE_KEY, language);
     document.documentElement.lang = language;
   }, [language]);
 
   const setLanguage = useCallback((newLanguage: Language) => {
+    localStorage.setItem(STORAGE_KEY, newLanguage);
     setLanguageState(newLanguage);
   }, []);
 
   const toggleLanguage = useCallback(() => {
-    setLanguageState((current) => (current === "en" ? "ja" : "en"));
+    setLanguageState((current) => {
+      const next = current === "en" ? "ja" : "en";
+      localStorage.setItem(STORAGE_KEY, next);
+      return next;
+    });
   }, []);
 
   const t = useCallback(


### PR DESCRIPTION
## What

Make the UI language auto-detect from the browser locale when the user has no saved preference, while continuing to respect a saved preference when one exists.

- **No saved preference in localStorage** → detect from `navigator.languages` / `navigator.language` (`ja*` → Japanese, otherwise English).
- **Saved preference present** → use it (takes priority over the browser locale).

## Why

Previously the language always defaulted to English (`en`) regardless of the browser locale, so Japanese users had to switch manually on every fresh browser.

## Notes for reviewers

- Persistence to localStorage previously happened in a mount `useEffect`, which immediately saved the initial value. That meant an auto-detected value was persisted right away and would no longer follow the browser locale. This PR moves persistence into `setLanguage` / `toggleLanguage` so it only writes when the user explicitly picks a language; the auto-detected value stays reactive until then.
- Supported languages are unchanged: `en` and `ja`.

## Verification

Tested in the browser (locale `ja-JP`):

| State | Result |
|---|---|
| No saved value → reload | `<html lang>` becomes `ja` (auto-detected); localStorage stays empty (not persisted) |
| Saved value `en` → reload | Stays `en` despite `ja-JP` locale (saved value wins) |

`tsc --noEmit` passes; pre-commit hooks (prettier, eslint, jest) passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)