### PR TITLE
feat(analytics): enrich GA events for usage analysis while keeping the disclosure honest

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -36,6 +36,7 @@ import { useLanguage } from "./hooks/useLanguage";
 import { useUrlTab, pathnameFromTabId } from "./hooks/useUrlTab";
 import { useDevtool } from "./hooks/useDevtool";
 import { DevtoolWindow } from "./components/DevtoolWindow";
+import { trackPageView } from "./lib/analytics";
 
 function getTabs(t: (key: string) => string): TabItem[] {
   return [
@@ -124,24 +125,17 @@ function AppContent() {
 
   const setActiveTabWithTracking = useCallback(
     (tabId: string) => {
-      // Google Analytics pageview tracking
-      if (window.gtag) {
-        window.gtag("event", "page_view", {
-          page_title: tabs.find((tab) => tab.id === tabId)?.label || "Unknown",
-          page_path: pathnameFromTabId(tabId),
-        });
-      }
+      // Google Analytics pageview tracking. The keyboard_connected /
+      // keyboard_connect_failed events live in DeviceConnection, where the
+      // connection method is known.
+      trackPageView(
+        tabs.find((tab) => tab.id === tabId)?.label || "Unknown",
+        pathnameFromTabId(tabId),
+      );
       navigateToTab(tabId);
     },
     [navigateToTab, tabs],
   );
-  useEffect(() => {
-    if (connection.deviceName && window.gtag) {
-      window.gtag("event", "keyboard_connected", {
-        name: connection.deviceName,
-      });
-    }
-  }, [connection.deviceName]);
 
   return (
     <>

--- a/src/components/ConnectionNoticeDialog.tsx
+++ b/src/components/ConnectionNoticeDialog.tsx
@@ -87,7 +87,7 @@ export function ConnectionNoticeDialog({
               </h4>
               <p className="text-sm text-[var(--color-text-secondary)] leading-relaxed">
                 {t(
-                  "DYA Studio collects your keyboard name for usage analysis purposes. However, no other keyboard data is sent to any servers. All of your keyboard configurations, keymaps, or settings are handled locally.",
+                  "DYA Studio collects your keyboard name and anonymous usage data — such as which features you use, how you connect, and connection errors — for usage analysis. No keymaps, settings, or other keyboard configuration data is ever sent; everything is handled locally on your device.",
                 )}
               </p>
             </div>

--- a/src/components/DeviceConnection.tsx
+++ b/src/components/DeviceConnection.tsx
@@ -22,6 +22,11 @@ import {
   resolveCustomSubsystemIdentifier,
   withLoggedNotifications,
 } from "../lib/rpcLogging";
+import {
+  trackKeyboardConnected,
+  trackConnectFailed,
+  classifyConnectError,
+} from "../lib/analytics";
 
 export type ConnectionMethod = "serial" | "ble" | "demo";
 
@@ -112,6 +117,45 @@ export function DeviceConnectionProvider({
   // Bridges the cancel button (outside the effect) to the in-flight attempt.
   const cancelReconnectRef = useRef<() => void>(() => {});
 
+  // Method of the connection attempt currently in flight, used to attribute the
+  // success/failure analytics event. Cleared once its outcome is reported so a
+  // single attempt is never counted twice (whether the failure surfaces as a
+  // thrown error or via `zmkApp.state.error`).
+  const attemptedMethodRef = useRef<ConnectionMethod | null>(null);
+  // Whether the current connected session's `keyboard_connected` event already
+  // fired, so a later device-info refresh doesn't re-report it.
+  const connectedTrackedRef = useRef(false);
+
+  const reportConnectFailed = useCallback((error: unknown) => {
+    const method = attemptedMethodRef.current;
+    if (!method) return;
+    attemptedMethodRef.current = null;
+    trackConnectFailed(method, classifyConnectError(error));
+  }, []);
+
+  // Report connection outcomes exactly once per attempt. Reading them from
+  // committed state (rather than only from the connect() promise) covers the
+  // case where the library surfaces errors via `state.error` instead of
+  // throwing.
+  useEffect(() => {
+    const name = zmkApp.state.deviceInfo?.name;
+    if (zmkApp.isConnected && name && !connectedTrackedRef.current) {
+      connectedTrackedRef.current = true;
+      // Auto-reconnect is always over paired serial and leaves the ref unset.
+      trackKeyboardConnected(attemptedMethodRef.current ?? "serial", name);
+      attemptedMethodRef.current = null;
+    }
+    if (!zmkApp.isConnected) {
+      connectedTrackedRef.current = false;
+    }
+  }, [zmkApp.isConnected, zmkApp.state.deviceInfo?.name]);
+
+  useEffect(() => {
+    if (zmkApp.state.error) {
+      reportConnectFailed(zmkApp.state.error);
+    }
+  }, [zmkApp.state.error, reportConnectFailed]);
+
   useEffect(() => {
     if (autoReconnectAttemptedRef.current) return;
     autoReconnectAttemptedRef.current = true;
@@ -187,9 +231,18 @@ export function DeviceConnectionProvider({
       } else {
         connectFn = connectUSB;
       }
-      await zmkApp.connect(connectFn);
+      attemptedMethodRef.current = method;
+      try {
+        await zmkApp.connect(connectFn);
+      } catch (error) {
+        // Covers errors thrown before the library commits them to `state.error`
+        // (e.g. the user dismissing the browser device picker). `reportConnectFailed`
+        // dedupes against the `state.error` effect so the attempt counts once.
+        reportConnectFailed(error);
+        throw error;
+      }
     },
-    [zmkApp],
+    [zmkApp, reportConnectFailed],
   );
 
   const handleDisconnect = useCallback(() => {

--- a/src/i18n/translations.ts
+++ b/src/i18n/translations.ts
@@ -612,8 +612,8 @@ const ja: Record<string, string> = {
   "ZMK community": "ZMK community",
   "Connect via {{method}}": "{{method}} で接続",
   "Data Collection Notice": "データ収集に関するお知らせ",
-  "DYA Studio collects your keyboard name for usage analysis purposes. However, no other keyboard data is sent to any servers. All of your keyboard configurations, keymaps, or settings are handled locally.":
-    "DYA Studio は利用状況分析のためにキーボード名を収集します。ただし、それ以外のキーボードデータはサーバーへ送信されません。キーボード設定、キーマップ、各種設定はすべてローカルで処理されます。",
+  "DYA Studio collects your keyboard name and anonymous usage data — such as which features you use, how you connect, and connection errors — for usage analysis. No keymaps, settings, or other keyboard configuration data is ever sent; everything is handled locally on your device.":
+    "DYA Studio は利用状況分析のために、キーボード名と匿名の利用データ（使用する機能、接続方法、接続エラーなど）を収集します。キーマップや各種設定など、その他のキーボード設定データが送信されることは一切なく、すべてお使いのデバイス上でローカルに処理されます。",
   "BLE Not Supported on your Browser":
     "このブラウザーは BLE に対応していません",
   "Your browser does not support Web Bluetooth API. Please use a compatible browser like Chrome, Edge, or Bluefy (iOS). BLE device discovery on non-Linux system requires cormoran's ZMK fork + press the studio unlock key on your keyboard.":

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -1,0 +1,103 @@
+/**
+ * Centralized Google Analytics (GA4) event tracking.
+ *
+ * This is the single place where usage analytics is sent, so what leaves the
+ * device is easy to audit against the data-collection notice shown before
+ * connecting (see {@link file://../components/ConnectionNoticeDialog.tsx}).
+ *
+ * Privacy rules for anything added here:
+ * - Never send keymaps, settings, or other keyboard configuration data.
+ * - Never send device identifiers (serial numbers) or raw error strings, which
+ *   can carry device paths / OS identifiers. Bucket errors into coarse reasons
+ *   instead (see {@link classifyConnectError}).
+ * - Keep parameters to the minimum needed for aggregate usage analysis.
+ *
+ * When the *categories* of data collected here change, update the notice text
+ * and bump `NOTICE_VERSION` in `connectionNoticeStorage.ts` so users re-consent.
+ */
+import type { ConnectionMethod } from "../components/DeviceConnection";
+
+/** Coarse, non-identifying bucket for a failed connection attempt. */
+export type ConnectFailReason =
+  | "cancelled"
+  | "unsupported"
+  | "timeout"
+  | "error";
+
+/**
+ * Thin guarded wrapper around `gtag`. No-ops when GA isn't loaded (e.g. the
+ * script is blocked, or `VITE_GOOGLE_ANALYTICS_ID` is unset in dev builds).
+ */
+function trackEvent(name: string, params?: Record<string, unknown>): void {
+  if (typeof window === "undefined" || !window.gtag) return;
+  window.gtag("event", name, params);
+}
+
+/** SPA page view, fired on tab navigation. */
+export function trackPageView(pageTitle: string, pagePath: string): void {
+  trackEvent("page_view", { page_title: pageTitle, page_path: pagePath });
+}
+
+/**
+ * A keyboard finished connecting. `name` is the device name (already disclosed);
+ * `method` records how the user connected for aggregate usage analysis.
+ */
+export function trackKeyboardConnected(
+  method: ConnectionMethod,
+  name: string,
+): void {
+  trackEvent("keyboard_connected", { method, name });
+}
+
+/**
+ * A connection attempt failed. Only the method and a coarse reason bucket are
+ * sent -- never the raw error, which may contain device paths or identifiers.
+ */
+export function trackConnectFailed(
+  method: ConnectionMethod,
+  reason: ConnectFailReason,
+): void {
+  trackEvent("keyboard_connect_failed", { method, reason });
+}
+
+/**
+ * Map an arbitrary connection error to a coarse, non-identifying reason bucket.
+ * Matches on well-known Web Serial / Web Bluetooth error names and messages so
+ * the raw string (which can include device paths) is never sent to analytics.
+ */
+export function classifyConnectError(error: unknown): ConnectFailReason {
+  const name =
+    typeof error === "object" && error !== null && "name" in error
+      ? String((error as { name?: unknown }).name)
+      : "";
+  const message = (
+    error instanceof Error
+      ? error.message
+      : typeof error === "string"
+        ? error
+        : ""
+  ).toLowerCase();
+
+  // Web Serial / Web Bluetooth throw these when the user dismisses the browser
+  // device picker without choosing a device.
+  if (
+    name === "NotFoundError" ||
+    name === "AbortError" ||
+    message.includes("cancel") ||
+    message.includes("no device selected") ||
+    message.includes("user gesture")
+  ) {
+    return "cancelled";
+  }
+  if (name === "NotSupportedError" || message.includes("not supported")) {
+    return "unsupported";
+  }
+  if (
+    name === "TimeoutError" ||
+    message.includes("timeout") ||
+    message.includes("timed out")
+  ) {
+    return "timeout";
+  }
+  return "error";
+}

--- a/src/lib/connectionNoticeStorage.ts
+++ b/src/lib/connectionNoticeStorage.ts
@@ -5,7 +5,7 @@
 import type { ConnectionMethod } from "../components/DeviceConnection";
 
 // Version of the notice - increment when notice content changes
-const NOTICE_VERSION = "1.0.0";
+const NOTICE_VERSION = "1.1.0";
 const NOTICE_STORAGE_KEY = "dya-studio-connection-notice-accepted";
 
 /**


### PR DESCRIPTION
## What & why

Improves the Google Analytics events so they're more useful for usage analysis, while keeping data collection **minimal and non-identifying** and keeping the pre-connect **data-collection notice consistent** with what's actually sent.

## Changes

- **Centralized GA in [`src/lib/analytics.ts`](../blob/claude/google-analytics-events-eb8e57/src/lib/analytics.ts)** — a single, auditable place for everything sent to GA4. Guards `window.gtag` (no-ops when GA is blocked or the ID is unset in dev). Documents the privacy rules for future additions.
- **Enriched events:**
  - `keyboard_connected` now includes the connection **`method`** (`serial`/`ble`/`demo`) alongside the already-disclosed `name`.
  - New **`keyboard_connect_failed`** event: `method` + a **coarse `reason`** bucket (`cancelled`/`unsupported`/`timeout`/`error`). Raw errors are classified locally and **never sent** — they can carry device paths / OS identifiers.
  - `page_view` routed through the helper (data unchanged).
- **Connection tracking moved into `DeviceConnection`** where the method is known. Reported **once per attempt** via a ref guard that dedupes whether the failure throws or surfaces via `state.error`. Auto-reconnect successes count as `serial`; benign auto-reconnect failures are intentionally not reported.
- **Kept the disclosure honest** — the notice previously promised only the keyboard name leaves the device, but these events also send anonymous usage data. Updated the notice text (EN + JA) to say so while reaffirming **no keymaps/settings/config data ever leave the device**, and bumped `NOTICE_VERSION` (1.0.0 → 1.1.0) so users who already accepted **re-consent**.

## Privacy

**Never collected:** serial number, raw error strings, keymap/settings/config content. New parameters are aggregate, non-identifying usage attributes only.

## Reviewer notes

- Bumping `NOTICE_VERSION` re-shows the notice to everyone who previously accepted — intended, since the disclosed categories changed.
- Verified via `tsc -b`, `eslint`, and the full `jest` suite (**485 passed, 1 skipped, 56 suites**). The pre-commit hook re-ran prettier/eslint/jest on commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)