### PR TITLE
feat(ui): add feature-doc tooltips to card headers

### DIFF
--- a/src/components/DocTip.tsx
+++ b/src/components/DocTip.tsx
@@ -1,0 +1,98 @@
+import * as Tooltip from "@radix-ui/react-tooltip";
+import { IconInfoCircle } from "@tabler/icons-react";
+import { useLanguage } from "../hooks/useLanguage";
+
+/** A single section of a DocTip: an optional heading plus body text and/or bullets. */
+export interface DocTipSection {
+  heading?: string;
+  body?: string;
+  bullets?: string[];
+}
+
+/** Structured, lightly formatted documentation shown inside a DocTip. */
+export interface DocTipContent {
+  title: string;
+  intro?: string;
+  sections?: DocTipSection[];
+}
+
+interface DocTipProps {
+  /** Structured content (already translated). */
+  content: DocTipContent;
+}
+
+/**
+ * Info icon that reveals a small, section-formatted document on hover/focus.
+ *
+ * Unlike {@link InfoTip}, which shows a single line of text, DocTip renders a
+ * titled mini-doc with intro copy, section headings and bullet lists — handy
+ * for explaining a whole feature next to a card header. Clicking the icon
+ * focuses it, which keeps the doc pinned open until focus moves away.
+ */
+export function DocTip({ content }: DocTipProps) {
+  const { t } = useLanguage();
+  return (
+    <Tooltip.Provider delayDuration={150}>
+      <Tooltip.Root>
+        <Tooltip.Trigger asChild>
+          <button
+            type="button"
+            className="inline-flex items-center p-px opacity-60 hover:opacity-100 transition-opacity cursor-pointer align-middle text-[var(--color-text-secondary)]"
+            aria-label={t("More info")}
+          >
+            <IconInfoCircle size={14} />
+          </button>
+        </Tooltip.Trigger>
+        <Tooltip.Portal>
+          <Tooltip.Content
+            className="rounded-lg bg-[var(--color-surface-elevated)] border border-[var(--color-border)] shadow-xl z-50 w-[min(20rem,calc(100vw-2rem))] max-h-[min(24rem,calc(100vh-4rem))] overflow-y-auto"
+            sideOffset={6}
+            collisionPadding={12}
+          >
+            <div className="p-3 space-y-2.5 text-xs leading-relaxed">
+              <p className="text-sm font-semibold text-[var(--color-text)]">
+                {content.title}
+              </p>
+              {content.intro && (
+                <p className="text-[var(--color-text-secondary)]">
+                  {content.intro}
+                </p>
+              )}
+              {content.sections?.map((section, i) => (
+                <div
+                  key={i}
+                  className="pt-2 border-t border-[var(--color-border)] space-y-1"
+                >
+                  {section.heading && (
+                    <p className="font-semibold uppercase tracking-wide text-[10px] text-[var(--color-text-muted)]">
+                      {section.heading}
+                    </p>
+                  )}
+                  {section.body && (
+                    <p className="text-[var(--color-text-secondary)]">
+                      {section.body}
+                    </p>
+                  )}
+                  {section.bullets && section.bullets.length > 0 && (
+                    <ul className="space-y-1 text-[var(--color-text-secondary)]">
+                      {section.bullets.map((bullet, j) => (
+                        <li key={j} className="flex gap-1.5">
+                          <span
+                            aria-hidden
+                            className="mt-1.5 h-1 w-1 shrink-0 rounded-full bg-[var(--color-electric)]"
+                          />
+                          <span>{bullet}</span>
+                        </li>
+                      ))}
+                    </ul>
+                  )}
+                </div>
+              ))}
+            </div>
+            <Tooltip.Arrow className="fill-[var(--color-surface-elevated)]" />
+          </Tooltip.Content>
+        </Tooltip.Portal>
+      </Tooltip.Root>
+    </Tooltip.Provider>
+  );
+}

--- a/src/i18n/featureDocs.ts
+++ b/src/i18n/featureDocs.ts
@@ -1,0 +1,138 @@
+import type { DocTipContent } from "../components/DocTip";
+import type { TranslationParams } from "./translations";
+
+type TranslateFn = (key: string, params?: TranslationParams) => string;
+
+/** Explains what ZMK macros are, shown next to the Macros card header. */
+export function macroDoc(t: TranslateFn): DocTipContent {
+  return {
+    title: t("What are Macros?"),
+    intro: t(
+      "A macro plays back a saved sequence of key actions when you trigger it with a single key.",
+    ),
+    sections: [
+      {
+        heading: t("Typical uses"),
+        bullets: [
+          t("Type text, symbols, or emoji that need several keystrokes"),
+          t("Fire an app or OS shortcut with one press"),
+          t("Chain presses, holds, and waits into one action"),
+        ],
+      },
+      {
+        heading: t("In DYA Studio"),
+        bullets: [
+          t("Create and edit the action sequence of each macro"),
+          t("Bind a macro to a key from the Keymap tab"),
+          t("Tune global timing such as wait and tap time"),
+        ],
+      },
+    ],
+  };
+}
+
+/** Explains what ZMK combos are, shown next to the Combos card header. */
+export function comboDoc(t: TranslateFn): DocTipContent {
+  return {
+    title: t("What are Combos?"),
+    intro: t(
+      "A combo turns pressing several keys at once into a different key or behavior.",
+    ),
+    sections: [
+      {
+        heading: t("Typical uses"),
+        bullets: [
+          t("Add extra keys without extra physical keys (e.g. Esc from J+K)"),
+          t("Reach symbols or layer switches from your home row"),
+        ],
+      },
+      {
+        heading: t("How it works"),
+        bullets: [
+          t("Press the chosen key positions together within a time window"),
+          t("Tune the timeout, active layers, and release behavior per combo"),
+        ],
+      },
+    ],
+  };
+}
+
+/** Explains trackball input processors, shown next to the Processors header. */
+export function processorDoc(t: TranslateFn): DocTipContent {
+  return {
+    title: t("What are Processors?"),
+    intro: t(
+      "Input processors transform trackball motion before it becomes pointer or scroll output, and can be turned on per layer.",
+    ),
+    sections: [
+      {
+        heading: t("Typical uses"),
+        bullets: [
+          t("Switch the trackball between moving the cursor and scrolling"),
+          t("Adjust sensitivity, or swap and invert the axes"),
+        ],
+      },
+      {
+        heading: t("Layers"),
+        bullets: [
+          t("Choose which layers each processor is active on"),
+          t("Optionally hold a temporary layer while the trackball moves"),
+        ],
+      },
+    ],
+  };
+}
+
+/** Explains default layers, shown next to the Connections header. */
+export function defaultLayerDoc(t: TranslateFn): DocTipContent {
+  return {
+    title: t("What are Default Layers?"),
+    intro: t(
+      "A default layer is the keymap layer your keyboard activates automatically for a given connection.",
+    ),
+    sections: [
+      {
+        heading: t("Per connection"),
+        bullets: [
+          t("Pick a layer for each connection target (USB and BLE profiles)"),
+          t("It switches automatically when that connection becomes active"),
+        ],
+      },
+      {
+        heading: t("Follow OS detection"),
+        bullets: [
+          t(
+            "Choose 'Follow OS detection' to use the Per-OS Default Layers instead",
+          ),
+          t("The layer set for the detected OS (Windows, macOS, …) is applied"),
+        ],
+      },
+    ],
+  };
+}
+
+/** Explains the PMW3610 sensor driver, shown next to the PMW3610 Drivers header. */
+export function pmw3610Doc(t: TranslateFn): DocTipContent {
+  return {
+    title: t("What is the PMW3610 driver?"),
+    intro: t(
+      "PMW3610 is the optical sensor inside the trackball. Its driver exposes low-level tuning for how motion is read.",
+    ),
+    sections: [
+      {
+        heading: t("Typical settings"),
+        bullets: [
+          t("CPI / sensitivity of the sensor"),
+          t("Orientation, axis rotation, and inversion"),
+          t("Polling rate and sleep / power behavior"),
+        ],
+      },
+      {
+        heading: t("Note"),
+        body: t(
+          "These values are read from and written to your keyboard's firmware. Change them in small steps.",
+        ),
+      },
+    ],
+  };
+}

--- a/src/i18n/translations.ts
+++ b/src/i18n/translations.ts
@@ -1013,6 +1013,79 @@ const ja: Record<string, string> = {
   "{{count}} thread(s) · sorted by usage": "{{count}} スレッド · 使用率順",
   "No stack data yet — press Refresh or enable Auto-refresh.":
     "まだデータがありません。「更新」ボタンを押すか「自動更新」を有効にしてください。",
+
+  // Feature docs (DocTip) — Macros
+  "What are Macros?": "マクロとは？",
+  "A macro plays back a saved sequence of key actions when you trigger it with a single key.":
+    "マクロは、1 つのキーで発動すると、保存したキー操作の連続動作を再生します。",
+  "Typical uses": "主な用途",
+  "Type text, symbols, or emoji that need several keystrokes":
+    "複数の打鍵が必要な文字・記号・絵文字を入力する",
+  "Fire an app or OS shortcut with one press":
+    "アプリや OS のショートカットを 1 押しで実行する",
+  "Chain presses, holds, and waits into one action":
+    "押下・長押し・待機を 1 つの動作にまとめる",
+  "In DYA Studio": "DYA Studio では",
+  "Create and edit the action sequence of each macro":
+    "各マクロの動作シーケンスを作成・編集できます",
+  "Bind a macro to a key from the Keymap tab":
+    "キーマップタブからマクロをキーに割り当てられます",
+  "Tune global timing such as wait and tap time":
+    "待機時間やタップ時間などの全体タイミングを調整できます",
+
+  // Feature docs (DocTip) — Combos
+  "What are Combos?": "コンボとは？",
+  "A combo turns pressing several keys at once into a different key or behavior.":
+    "コンボは、複数のキーの同時押しを別のキーや動作に変換します。",
+  "Add extra keys without extra physical keys (e.g. Esc from J+K)":
+    "物理キーを増やさずにキーを追加する（例：J+K で Esc）",
+  "Reach symbols or layer switches from your home row":
+    "ホームポジションから記号やレイヤー切り替えに届く",
+  "How it works": "仕組み",
+  "Press the chosen key positions together within a time window":
+    "指定したキー位置を制限時間内に同時に押す",
+  "Tune the timeout, active layers, and release behavior per combo":
+    "コンボごとにタイムアウト・有効レイヤー・離し時の挙動を調整できます",
+
+  // Feature docs (DocTip) — Processors
+  "What are Processors?": "プロセッサとは？",
+  "Input processors transform trackball motion before it becomes pointer or scroll output, and can be turned on per layer.":
+    "入力プロセッサは、トラックボールの動きをポインタやスクロール出力になる前に変換し、レイヤーごとに有効化できます。",
+  "Switch the trackball between moving the cursor and scrolling":
+    "トラックボールをカーソル移動とスクロールで切り替える",
+  "Adjust sensitivity, or swap and invert the axes":
+    "感度を調整したり、軸を入れ替え・反転したりする",
+  "Choose which layers each processor is active on":
+    "各プロセッサを有効にするレイヤーを選ぶ",
+  "Optionally hold a temporary layer while the trackball moves":
+    "トラックボールの動作中に一時レイヤーを保持する（任意）",
+
+  // Feature docs (DocTip) — Default layers
+  "What are Default Layers?": "デフォルトレイヤーとは？",
+  "A default layer is the keymap layer your keyboard activates automatically for a given connection.":
+    "デフォルトレイヤーは、特定の接続に対してキーボードが自動的に有効化するキーマップレイヤーです。",
+  "Per connection": "接続ごと",
+  "Pick a layer for each connection target (USB and BLE profiles)":
+    "接続先（USB や BLE プロファイル）ごとにレイヤーを選ぶ",
+  "It switches automatically when that connection becomes active":
+    "その接続がアクティブになると自動的に切り替わる",
+  "Choose 'Follow OS detection' to use the Per-OS Default Layers instead":
+    "「OS 検出に従う」を選ぶと、代わりに OS 別デフォルトレイヤーが使われる",
+  "The layer set for the detected OS (Windows, macOS, …) is applied":
+    "検出された OS（Windows、macOS など）に設定したレイヤーが適用される",
+
+  // Feature docs (DocTip) — PMW3610 driver
+  "What is the PMW3610 driver?": "PMW3610 ドライバとは？",
+  "PMW3610 is the optical sensor inside the trackball. Its driver exposes low-level tuning for how motion is read.":
+    "PMW3610 はトラックボール内部の光学センサです。ドライバは動きの読み取り方を低レベルで調整する項目を提供します。",
+  "Typical settings": "主な設定",
+  "CPI / sensitivity of the sensor": "センサの CPI／感度",
+  "Orientation, axis rotation, and inversion": "向き・軸の回転・反転",
+  "Polling rate and sleep / power behavior":
+    "ポーリングレートやスリープ／電力の挙動",
+  Note: "補足",
+  "These values are read from and written to your keyboard's firmware. Change them in small steps.":
+    "これらの値はキーボードのファームウェアから読み書きされます。少しずつ変更してください。",
 };
 
 const dictionaries: Record<Language, Record<string, string>> = {

--- a/src/pages/ConnectionPage.tsx
+++ b/src/pages/ConnectionPage.tsx
@@ -23,6 +23,8 @@ import { useLanguage } from "../hooks/useLanguage";
 import { OsBadge } from "../components/OsBadge";
 import { LayerSelect } from "../components/LayerSelect";
 import { InfoTip } from "../components/InfoTip";
+import { DocTip } from "../components/DocTip";
+import { defaultLayerDoc } from "../i18n/featureDocs";
 import { LoadingIndicator } from "../components/LoadingIndicator";
 import {
   mergeConnectionCards,
@@ -363,9 +365,14 @@ export function ConnectionPage() {
 
             {cards.length > 0 && (
               <div className="mb-3">
-                <h3 className="text-sm font-medium text-[var(--color-text)] mb-1">
-                  {t("Connections")}
-                </h3>
+                <div className="flex items-center gap-1.5 mb-1">
+                  <h3 className="text-sm font-medium text-[var(--color-text)]">
+                    {t("Connections")}
+                  </h3>
+                  {defaultLayer.isAvailable && (
+                    <DocTip content={defaultLayerDoc(t)} />
+                  )}
+                </div>
                 {defaultLayer.isAvailable && (
                   <p className="text-xs text-[var(--color-text-muted)]">
                     {t(

--- a/src/pages/MacroComboPage.tsx
+++ b/src/pages/MacroComboPage.tsx
@@ -44,6 +44,8 @@ import {
 } from "../components/macroCombo/comboUtils";
 import { useComboEditor } from "../components/macroCombo/useComboEditor";
 import { useMacroEditor } from "../components/macroCombo/useMacroEditor";
+import { DocTip } from "../components/DocTip";
+import { macroDoc, comboDoc } from "../i18n/featureDocs";
 import type { Combo } from "../hooks/useRuntimeCombo";
 import type { MacroSummary } from "../proto/cormoran/runtime_macro/runtime_macro";
 
@@ -427,9 +429,12 @@ export function MacroComboPage() {
               {macroAvailable && (
                 <section className="glass-card p-3">
                   <div className="flex items-center justify-between mb-3">
-                    <h2 className="text-sm font-medium text-[var(--color-text)]">
-                      {t("Macros")}
-                    </h2>
+                    <div className="flex items-center gap-1.5">
+                      <h2 className="text-sm font-medium text-[var(--color-text)]">
+                        {t("Macros")}
+                      </h2>
+                      <DocTip content={macroDoc(t)} />
+                    </div>
                     <div className="flex items-center gap-1">
                       {runtimeMacro.isLoading && (
                         <IconLoader2
@@ -503,10 +508,11 @@ export function MacroComboPage() {
               {comboAvailable && keymap.keymap && (
                 <section className="glass-card p-3">
                   <div className="flex items-center justify-between mb-3">
-                    <div>
+                    <div className="flex items-center gap-1.5">
                       <h2 className="text-sm font-medium text-[var(--color-text)]">
                         {t("Combos")}
                       </h2>
+                      <DocTip content={comboDoc(t)} />
                     </div>
                     <div className="flex items-center gap-1">
                       {runtimeCombo.isLoading && (

--- a/src/pages/TrackballPage.tsx
+++ b/src/pages/TrackballPage.tsx
@@ -17,6 +17,8 @@ import {
 } from "../components/AdvancedSettingsSection";
 import { StatusDot } from "../components/EditStatusIndicator";
 import { LoadingIndicator } from "../components/LoadingIndicator";
+import { DocTip } from "../components/DocTip";
+import { processorDoc, pmw3610Doc } from "../i18n/featureDocs";
 import { AxisSnapMode } from "../proto/zmk/runtime_input_processor/runtime_input_processor";
 import { useCustomSettings } from "../hooks/useCustomSettings";
 import { useDebouncedSave } from "../hooks/useDebouncedSave";
@@ -526,6 +528,7 @@ export function TrackballPage() {
                   <h2 className="text-sm font-medium text-[var(--color-text)]">
                     {t("Processors")}
                   </h2>
+                  <DocTip content={processorDoc(t)} />
                 </div>
                 {isLoading && (
                   <IconLoader2
@@ -605,6 +608,7 @@ export function TrackballPage() {
                   <h2 className="text-sm font-medium text-[var(--color-text)]">
                     {t("PMW3610 Drivers")}
                   </h2>
+                  <DocTip content={pmw3610Doc(t)} />
                 </div>
                 <div className="flex items-center gap-1">
                   {customSettings.isLoading && (


### PR DESCRIPTION
## Description

Adds an info icon with a section-formatted mini-doc tooltip next to feature card headers, so users can learn what each feature does without leaving the page. Requested for Macros/Combos, the Trackball tab's Processor/driver sections, and the Connection tab's default-layer part.

**Where the tooltips appear**
- **Macros & Combos page** — next to the `Macros` and `Combos` headers
- **Trackball tab** — next to `Processors` and `PMW3610 Drivers`
- **Connection tab** — next to `Connections` (default-layer config), shown only when the default-layer subsystem is available

**What's new**
- `src/components/DocTip.tsx` — a reusable tooltip (built on the already-installed `@radix-ui/react-tooltip`) that renders a titled mini-doc: bold title, intro paragraph, and section blocks with uppercase headings and bullet lists. Opens on hover and stays pinned on click/focus; scrollable and collision-aware for longer content. Complements the existing single-line `InfoTip` rather than replacing it.
- `src/i18n/featureDocs.ts` — translated content builders (`macroDoc`, `comboDoc`, `processorDoc`, `pmw3610Doc`, `defaultLayerDoc`) so the doc text stays out of the JSX and is fully i18n'd.
- Japanese translations for all new strings in `src/i18n/translations.ts`.

**Reviewer notes**
- English text comes from the translation keys (the `en` dictionary is empty by design); `ja` strings were added for each new key.
- The DocTip content is conceptual, high-level guidance. The PMW3610 bullets describe typical driver settings rather than reading the exact settings your firmware exposes — happy to tighten if you'd prefer it be data-driven.
- These sections only render with a connected keyboard, so I verified via `tsc -b` (clean), ESLint (clean), and a clean dev-server compile rather than driving the live tooltip in a browser.
- The pre-commit hook's `jest` step can't run in this worktree (`@zmkfirmware/zmk-studio-ts-client` isn't installed here, so the suites fail to load) — this is unrelated to the change, which touches only UI components and translations.

## CLA (Contributor License Agreement)

By submitting this pull request, I agree that my contributions
are licensed under the project's current license.

I also grant the maintainer(s) of this project the right to relicense
my contributions under any license, for use in future versions of the project.
This does not affect the license of any previously released versions.
