### PR TITLE
fix(macro-combo): clear stale unlock error after re-unlocking

### DIFF
--- a/src/pages/MacroComboPage.tsx
+++ b/src/pages/MacroComboPage.tsx
@@ -6,7 +6,7 @@
  * global settings, or an empty placeholder. A single top action bar refreshes,
  * saves and discards both domains at once.
  */
-import { useCallback, useContext, useEffect, useState } from "react";
+import { useCallback, useContext, useEffect, useRef, useState } from "react";
 import {
   IconAlertCircle,
   IconAlertTriangle,
@@ -119,6 +119,28 @@ export function MacroComboPage() {
   useEffect(() => {
     if (locked) requireUnlocked();
   }, [locked, requireUnlocked]);
+
+  // Clear stale errors and reload on the locked -> unlocked transition. A load
+  // RPC that failed while the unlock modal was open surfaces an error into
+  // `runtimeMacro.error` / `runtimeCombo.error` whenever it was *not* parked and
+  // auto-retried — e.g. the user dismissed the modal (or a request landed during
+  // the post-cancel cooldown), so `callRpc` set the "device is locked" message.
+  // Unlock's `retryAll` only replays parked ops, and the auto-load effects fire
+  // once per subsystem, so nothing else clears that error. Reacting to the
+  // transition here clears both hooks' errors and refetches so the page reflects
+  // the now-unlocked device. (`loadMacros`/`reload` are in-flight-guarded, so
+  // this no-ops when a parked op is already being retried.)
+  const wasLockedRef = useRef(locked);
+  useEffect(() => {
+    const wasLocked = wasLockedRef.current;
+    wasLockedRef.current = locked;
+    if (wasLocked && !locked) {
+      runtimeMacro.clearError();
+      runtimeCombo.clearError();
+      if (macroAvailable) void runtimeMacro.loadMacros();
+      if (comboAvailable) void runtimeCombo.reload();
+    }
+  }, [locked, macroAvailable, comboAvailable, runtimeMacro, runtimeCombo]);
 
   // --- Selection routing (exclusive across the two lists) ---
 


### PR DESCRIPTION
## Description

Macro&Combo ページで、Studio unlock modal 表示中に出たエラーが unlock 後も表示され続ける不具合を修正します。

### 問題

unlock modal が開いている間、park されない経路でロード RPC が失敗すると（ユーザーがモーダルを Cancel した後や、post-cancel cooldown 中にリクエストが到達した場合）、`callRpc` が "device is locked" メッセージを `runtimeMacro.error` / `runtimeCombo.error` にセットします。

その後 unlock しても:
- unlock 時の `retryAll` は **park 済みの op しか再実行しない**
- auto-load エフェクトは subsystem ごとに **一度しか発火しない**

ため、このエラーはクリアされず画面に残り続けていました。

### 修正

Macro&Combo ページに locked → unlocked 遷移を検知するエフェクトを追加し、両フックの `error` をクリアしてデータを再取得します。これにより、ユーザーが要望した「理想的には RPC を unlock まで待機」（park 経路で実現済み）の隙間を、「unlock 時点でその部分のリロードを走らせる」フォールバックで埋めます。

`loadMacros` / `reload` は in-flight ガードがあるため、park 済み op を `retryAll` が再実行中の場合はこのリロードは no-op になり、二重取得はしません。

### 検証

- `tsc -b` / `eslint`: パス
- pre-commit フックでフルテストスイート実行: パス（`StudioUnlockContext` / `useRuntimeMacro` / `useRuntimeCombo` を含む）
- 実機のロック状態が必要なためブラウザでの実地確認は未実施

## CLA (Contributor License Agreement)

By submitting this pull request, I agree that my contributions
are licensed under the project's current license.

I also grant the maintainer(s) of this project the right to relicense
my contributions under any license, for use in future versions of the project.
This does not affect the license of any previously released versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)