### PR TITLE
Add factory reset to Settings; refine keymap Reset/Discard buttons

### DIFF
--- a/src/hooks/useResetSettings.ts
+++ b/src/hooks/useResetSettings.ts
@@ -1,0 +1,87 @@
+/**
+ * useResetSettings Hook
+ *
+ * Wraps the ZMK core `reset_settings` RPC, which wipes every persisted setting
+ * on the keyboard back to its firmware defaults — including the keymap and all
+ * custom-settings subsystems. This is the app-wide "factory reset" affordance
+ * exposed from the Settings tab, distinct from the keymap-only reset (which
+ * only rewrites key bindings) and the per-section custom-settings reset.
+ *
+ * The call is routed through the shared Studio-unlock gate so a locked device
+ * transparently surfaces the unlock modal and retries after unlock, mirroring
+ * every other device mutation in the app.
+ */
+import { useState, useCallback, useContext } from "react";
+import { ZMKAppContext } from "@cormoran/zmk-studio-react-hook";
+import { loggedCallRpc } from "../lib/rpcLogging";
+import { useStudioUnlock } from "./useStudioUnlock";
+import { studioLockErrorText } from "../lib/studioUnlock";
+
+export interface UseResetSettingsReturn {
+  /**
+   * Reset every persisted setting on the keyboard to firmware defaults.
+   * Resolves `true` on success, `false` if it failed (error is set). Gated on
+   * unlock: a locked device opens the shared unlock modal and retries.
+   */
+  resetAllSettings: () => Promise<boolean>;
+  /** True while a reset RPC is in flight. */
+  isResetting: boolean;
+  /** i18n key / message of the last failure, or null. */
+  error: string | null;
+  /** Clear the current error. */
+  clearError: () => void;
+}
+
+export function useResetSettings(): UseResetSettingsReturn {
+  const zmkApp = useContext(ZMKAppContext);
+  const connection = zmkApp?.state.connection ?? null;
+  const { runWithUnlock } = useStudioUnlock();
+  const [isResetting, setIsResetting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const clearError = useCallback(() => setError(null), []);
+
+  const resetAllSettings = useCallback(async (): Promise<boolean> => {
+    if (!connection) {
+      setError("Not connected to keyboard");
+      return false;
+    }
+
+    setIsResetting(true);
+    setError(null);
+
+    try {
+      // Route through the unlock gate: a locked device opens the shared modal
+      // and this call is retried once unlocked. The core `reset_settings`
+      // request is a plain boolean flag.
+      const response = await runWithUnlock(() =>
+        loggedCallRpc(connection, { core: { resetSettings: true } }),
+      );
+
+      if (response.meta?.simpleError !== undefined) {
+        setError(`RPC error: ${response.meta.simpleError}`);
+        return false;
+      }
+
+      // Treat any non-error response as success: the firmware wipes settings
+      // and may reboot immediately, so it can answer with `resetSettings: true`
+      // or with an empty core response before the reset takes effect.
+      return true;
+    } catch (err) {
+      const locked = studioLockErrorText(err);
+      if (locked !== null) {
+        // Blocked by the unlock gate (modal dismissed / cooldown): surface the
+        // shared "device is locked" message.
+        setError(locked);
+        return false;
+      }
+      console.error("Reset settings failed:", err);
+      setError(err instanceof Error ? err.message : "Unknown error");
+      return false;
+    } finally {
+      setIsResetting(false);
+    }
+  }, [connection, runWithUnlock]);
+
+  return { resetAllSettings, isResetting, error, clearError };
+}

--- a/src/i18n/translations.ts
+++ b/src/i18n/translations.ts
@@ -106,8 +106,8 @@ const ja: Record<string, string> = {
     "未保存の変更を破棄してキーマップを再読み込みします",
   "Reset the saved keymap to the default keymap":
     "保存済みのキーマップをデフォルトのキーマップにリセットします",
-  "Resetting to the default keymap requires the fast-keymap firmware module, which this keyboard does not expose.":
-    "デフォルトのキーマップへのリセットには fast-keymap ファームウェアモジュールが必要ですが、このキーボードは対応していません。",
+  'This keyboard cannot reset the keymap on its own. To clear the keymap, use "Reset all settings" in the Settings tab, which restores every setting to its firmware default.':
+    "このキーボードはキーマップ単体をリセットできません。キーマップを消去するには、設定タブの「すべての設定をリセット」を使用してください。すべての設定がファームウェアのデフォルトに戻ります。",
   "Reset to default keymap?": "デフォルトのキーマップにリセットしますか？",
   "This resets the saved keymap on your keyboard back to its hard-coded default and writes it to flash immediately. All saved key bindings will be lost. This cannot be undone.":
     "キーボードに保存されたキーマップをハードコードされたデフォルトに戻し、直ちにフラッシュへ書き込みます。保存済みのすべてのキー割り当ては失われます。この操作は元に戻せません。",
@@ -325,6 +325,14 @@ const ja: Record<string, string> = {
   "Current Settings by Device": "デバイス別の現在の設定",
   "Idle: {{idle}}, Sleep: {{sleep}}": "アイドル: {{idle}}, スリープ: {{sleep}}",
   "Waiting for device connection...": "デバイス接続を待機中...",
+  "Danger Zone": "危険な操作",
+  "Reset all settings": "すべての設定をリセット",
+  "Erase every saved setting on the keyboard — including the keymap and all custom settings — and restore firmware defaults.":
+    "キーマップやすべてのカスタム設定を含む、キーボードに保存されたすべての設定を消去し、ファームウェアのデフォルトに戻します。",
+  "Reset all settings?": "すべての設定をリセットしますか？",
+  "This erases every saved setting on your keyboard — the keymap and all custom settings — and restores firmware defaults. This cannot be undone.":
+    "キーマップやすべてのカスタム設定を含む、キーボードに保存されたすべての設定を消去し、ファームウェアのデフォルトに戻します。この操作は元に戻せません。",
+  "Not connected to keyboard": "キーボードに接続されていません",
   Never: "なし",
   "30 seconds": "30 秒",
   "1 minute": "1 分",

--- a/src/lib/transport/demo.ts
+++ b/src/lib/transport/demo.ts
@@ -378,6 +378,10 @@ class Keyboard {
       // The demo keyboard is always unlocked
       // (LockState.ZMK_STUDIO_CORE_LOCK_STATE_UNLOCKED = 1).
       rr.core = { getLockState: 1 };
+    } else if (req.core?.resetSettings) {
+      // Factory reset: acknowledge success. The demo keeps its in-memory
+      // keymap as-is (a real device would wipe flash and reload defaults).
+      rr.core = { resetSettings: true };
     } else if (req.keymap?.getPhysicalLayouts) {
       rr.keymap = { getPhysicalLayouts: this.data.layouts };
     } else if (req.keymap?.getKeymap) {

--- a/src/pages/KeymapPage.tsx
+++ b/src/pages/KeymapPage.tsx
@@ -426,23 +426,23 @@ export function KeymapPage() {
                 </button>
               ) : (
                 <>
-                  <button
-                    className="btn-ghost text-sm flex items-center gap-1.5 flex-shrink-0"
-                    onClick={handleDiscard}
-                    disabled={
-                      isDiscarding ||
-                      !keymap.hasUnsavedChanges ||
-                      keymap.isLoading
-                    }
-                    title={t("Discard unsaved changes and reload the keymap")}
-                  >
-                    {isDiscarding ? (
-                      <IconLoader2 size={16} className="animate-spin" />
-                    ) : (
-                      <IconRestore size={16} />
-                    )}
-                    {t("Discard")}
-                  </button>
+                  {/* Discard only makes sense with on-memory (unsaved) edits,
+                      so it's hidden entirely when there's nothing to discard. */}
+                  {keymap.hasUnsavedChanges && (
+                    <button
+                      className="btn-ghost text-sm flex items-center gap-1.5 flex-shrink-0"
+                      onClick={handleDiscard}
+                      disabled={isDiscarding || keymap.isLoading}
+                      title={t("Discard unsaved changes and reload the keymap")}
+                    >
+                      {isDiscarding ? (
+                        <IconLoader2 size={16} className="animate-spin" />
+                      ) : (
+                        <IconRestore size={16} />
+                      )}
+                      {t("Discard")}
+                    </button>
+                  )}
                   <Tooltip.Provider delayDuration={200}>
                     <Tooltip.Root>
                       <Tooltip.Trigger asChild>
@@ -476,7 +476,7 @@ export function KeymapPage() {
                           {keymap.isFastKeymapAvailable
                             ? t("Reset the saved keymap to the default keymap")
                             : t(
-                                "Resetting to the default keymap requires the fast-keymap firmware module, which this keyboard does not expose.",
+                                'This keyboard cannot reset the keymap on its own. To clear the keymap, use "Reset all settings" in the Settings tab, which restores every setting to its firmware default.',
                               )}
                           <Tooltip.Arrow className="fill-[var(--color-surface-elevated)]" />
                         </Tooltip.Content>

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -1,13 +1,26 @@
-import { useState, useMemo, useRef, useEffect, useCallback } from "react";
+import {
+  useState,
+  useMemo,
+  useRef,
+  useEffect,
+  useCallback,
+  useContext,
+} from "react";
 import { createPortal } from "react-dom";
 import {
   IconSettings,
   IconChevronDown,
   IconAlertTriangleFilled,
+  IconAlertTriangle,
+  IconTrash,
+  IconLoader2,
 } from "@tabler/icons-react";
+import * as Dialog from "@radix-ui/react-dialog";
 import { AdvancedSettingsSection } from "../components/AdvancedSettingsSection";
 import { LoadingIndicator } from "../components/LoadingIndicator";
+import { ConnectionContext } from "../components/DeviceConnection";
 import { useSettings } from "../hooks/useSettings";
+import { useResetSettings } from "../hooks/useResetSettings";
 import { useDebouncedMemoryWrite } from "../hooks/useDebouncedMemoryWrite";
 import { useLanguage } from "../hooks/useLanguage";
 
@@ -230,8 +243,25 @@ function TimeDropdown({ value, onChange, presets }: TimeDropdownProps) {
 
 export function SettingsPage() {
   const { t } = useLanguage();
+  const connection = useContext(ConnectionContext);
   const { isAvailable, devices, isLoading, error, setActivitySettings } =
     useSettings();
+  const {
+    resetAllSettings,
+    isResetting,
+    error: resetError,
+    clearError: clearResetError,
+  } = useResetSettings();
+
+  // Confirmation modal for the full "reset all settings" action.
+  const [showResetAllDialog, setShowResetAllDialog] = useState(false);
+
+  const handleResetAll = useCallback(async () => {
+    const ok = await resetAllSettings();
+    if (ok) {
+      setShowResetAllDialog(false);
+    }
+  }, [resetAllSettings]);
 
   // Get central device settings (source 0)
   const centralSettings = useMemo(
@@ -422,52 +452,6 @@ export function SettingsPage() {
             </div>
 
             <AdvancedSettingsSection />
-
-            {/* Danger Zone
-            <div className="glass-card p-6 border-red-500/20">
-              <h3 className="text-sm font-medium text-red-400 mb-4">
-                Danger Zone
-              </h3>
-              <div className="space-y-4">
-                <div className="flex items-center justify-between">
-                  <div>
-                    <p className="text-sm text-[var(--color-text-secondary)]">
-                      Reset to Defaults
-                    </p>
-                    <p className="text-xs text-[var(--color-text-muted)]">
-                      Restore power settings to factory defaults (Idle: 30s,
-                      Sleep: 15m)
-                    </p>
-                  </div>
-                  {!showResetConfirm ? (
-                    <button
-                      className="px-4 py-2 rounded-lg text-sm font-medium text-red-400 border border-red-500/30 hover:bg-red-500/10 transition-colors"
-                      onClick={() => setShowResetConfirm(true)}
-                      disabled={isLoading}
-                    >
-                      Reset
-                    </button>
-                  ) : (
-                    <div className="flex items-center gap-2">
-                      <button
-                        className="px-4 py-2 rounded-lg text-sm font-medium text-[var(--color-text-secondary)] border border-[var(--color-border)] hover:bg-[var(--color-border)] transition-colors"
-                        onClick={() => setShowResetConfirm(false)}
-                      >
-                        Cancel
-                      </button>
-                      <button
-                        className="px-4 py-2 rounded-lg text-sm font-medium text-white bg-red-500 hover:bg-red-600 transition-colors flex items-center gap-2"
-                        onClick={handleResetToDefaults}
-                        disabled={isLoading}
-                      >
-                        <IconAlertTriangle size={16} />
-                        {isLoading ? "Resetting..." : "Confirm Reset"}
-                      </button>
-                    </div>
-                  )}
-                </div>
-              </div>
-            </div> */}
           </div>
         ) : (
           !isLoading && (
@@ -478,7 +462,87 @@ export function SettingsPage() {
             </div>
           )
         )}
+
+        {/* Danger Zone: a full factory reset that wipes every persisted
+            setting — keymap and all custom settings included. Available
+            whenever a device is connected, independent of the settings RPC
+            subsystem, since it is a core-protocol call. */}
+        {connection.isConnected && (
+          <div className="glass-card p-6 border border-red-500/20 mt-6">
+            <h3 className="text-sm font-medium text-red-400 mb-4">
+              {t("Danger Zone")}
+            </h3>
+            <div className="flex items-center justify-between gap-4">
+              <div>
+                <p className="text-sm text-[var(--color-text-secondary)]">
+                  {t("Reset all settings")}
+                </p>
+                <p className="text-xs text-[var(--color-text-muted)]">
+                  {t(
+                    "Erase every saved setting on the keyboard — including the keymap and all custom settings — and restore firmware defaults.",
+                  )}
+                </p>
+              </div>
+              <button
+                className="px-4 py-2 rounded-lg text-sm font-medium text-red-400 border border-red-500/30 hover:bg-red-500/10 transition-colors flex items-center gap-2 flex-shrink-0"
+                onClick={() => {
+                  clearResetError();
+                  setShowResetAllDialog(true);
+                }}
+                disabled={isResetting}
+              >
+                <IconTrash size={16} />
+                {t("Reset all settings")}
+              </button>
+            </div>
+            {resetError && (
+              <p className="mt-3 text-xs text-red-400">{t(resetError)}</p>
+            )}
+          </div>
+        )}
       </div>
+
+      {/* Reset-all Confirmation Dialog */}
+      <Dialog.Root
+        open={showResetAllDialog}
+        onOpenChange={(open) => {
+          if (!open && !isResetting) setShowResetAllDialog(false);
+        }}
+      >
+        <Dialog.Portal>
+          <Dialog.Overlay className="fixed inset-0 bg-black/50 backdrop-blur-sm z-50" />
+          <Dialog.Content className="fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[90vw] max-w-md bg-[var(--color-surface)] rounded-xl border border-[var(--color-border)] shadow-2xl z-50 p-6">
+            <Dialog.Title className="text-base font-medium text-[var(--color-text)] mb-2 flex items-center gap-2">
+              <IconAlertTriangle size={18} className="text-red-400" />
+              {t("Reset all settings?")}
+            </Dialog.Title>
+            <Dialog.Description className="text-sm text-[var(--color-text-muted)] mb-5">
+              {t(
+                "This erases every saved setting on your keyboard — the keymap and all custom settings — and restores firmware defaults. This cannot be undone.",
+              )}
+            </Dialog.Description>
+            <div className="flex gap-3">
+              <button
+                className="flex-1 btn-ghost border border-[var(--color-border)]"
+                onClick={() => setShowResetAllDialog(false)}
+                disabled={isResetting}
+              >
+                {t("Cancel")}
+              </button>
+              <button
+                className="flex-1 px-4 py-2 rounded-lg text-sm font-medium text-white bg-red-500 hover:bg-red-600 transition-colors flex items-center justify-center gap-2 disabled:opacity-50"
+                onClick={() => void handleResetAll()}
+                disabled={isResetting}
+              >
+                {isResetting && (
+                  <IconLoader2 size={16} className="animate-spin" />
+                )}
+                {t("Reset all settings")}
+              </button>
+            </div>
+          </Dialog.Content>
+        </Dialog.Portal>
+      </Dialog.Root>
     </div>
   );
 }

--- a/src/pages/__tests__/KeymapPage.test.tsx
+++ b/src/pages/__tests__/KeymapPage.test.tsx
@@ -332,8 +332,35 @@ describe("KeymapPage", () => {
       );
 
       expect(screen.getByText("Save")).toBeInTheDocument();
-      expect(screen.getByText("Discard")).toBeInTheDocument();
       expect(screen.getByText("Reset")).toBeInTheDocument();
+    });
+
+    it("hides the Discard button when there are no unsaved changes", () => {
+      renderComponent(
+        { isConnected: true },
+        {
+          keymap: mockKeymap,
+          physicalLayouts: mockPhysicalLayouts,
+          behaviors: mockBehaviors,
+          hasUnsavedChanges: false,
+        },
+      );
+
+      expect(screen.queryByText("Discard")).not.toBeInTheDocument();
+    });
+
+    it("shows the Discard button only when there are unsaved changes", () => {
+      renderComponent(
+        { isConnected: true },
+        {
+          keymap: mockKeymap,
+          physicalLayouts: mockPhysicalLayouts,
+          behaviors: mockBehaviors,
+          hasUnsavedChanges: true,
+        },
+      );
+
+      expect(screen.getByText("Discard")).toBeInTheDocument();
     });
 
     it("disables Reset when the fast-keymap subsystem is unavailable", () => {


### PR DESCRIPTION
## What & why

Three related UI changes around resetting keyboard state:

### 1. Settings tab — "Reset all settings" (factory reset)
A new **Danger Zone** section with a "Reset all settings" button that, after a confirmation modal, calls the ZMK **core** `reset_settings` RPC. This wipes **every** persisted setting on the keyboard — the keymap and all custom-settings subsystems included. (Built on the assumption that the firmware side clears everything managed by `zmk-feature-custom-settings` too, which is being handled in parallel.)

- New hook `useResetSettings` issues `{ core: { resetSettings: true } }` and routes through the shared Studio-unlock gate, mirroring every other device mutation.
- The section renders whenever a device is connected — independent of the Settings RPC subsystem — since it's a core-protocol call.
- Demo transport handles the RPC so it works in Demo Mode.
- Removed the old commented-out "Danger Zone" dead code that this replaces.

### 2. Keymap tab — Reset button tooltip when fast-keymap is unavailable
The Reset button was already disabled without the fast-keymap module. Its tooltip now points the user to **"Reset all settings" in the Settings tab** instead of the old firmware-module message, giving them a real path to clear the keymap.

### 3. Keymap tab — Discard button only when there are unsaved changes
The Discard button is now **hidden** unless there are on-memory (unsaved) changes, rather than always shown-but-disabled.

## Notes for reviewers
- After a real reset the firmware may reboot and drop the connection. `useResetSettings` treats any non-error response as success and closes the dialog; if the device disconnects, the UI falls back to the connect screen. Happy to add an explicit "resetting — reconnecting…" message if preferred.
- Added EN/JA translations for all new strings.
- Updated `KeymapPage` tests for the new Discard visibility behavior.

## Verification
- `tsc`, ESLint, and the full Jest suite (56 files, 491 tests) pass.
- Manually drove the demo keyboard: confirmed the reset confirmation modal + RPC, the Discard show/hide toggle on edit, and the Danger Zone rendering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)