### PR TITLE
Lower trackball scaling minimum to 0.01x

### DIFF
--- a/src/i18n/translations.ts
+++ b/src/i18n/translations.ts
@@ -193,8 +193,8 @@ const ja: Record<string, string> = {
     "プロセッサーはすべてのレイヤーで有効です",
   "Loading layers...": "レイヤーを読み込み中...",
   Scaling: "スケーリング",
-  "Adjust sensitivity from 0.1x to 10x":
-    "感度を 0.1x から 10x の範囲で調整します",
+  "Adjust sensitivity from 0.01x to 10x":
+    "感度を 0.01x から 10x の範囲で調整します",
   "Decrease scaling": "スケーリングを下げる",
   "Increase scaling": "スケーリングを上げる",
   "Sensor Rotation": "センサー回転",

--- a/src/pages/TrackballPage.tsx
+++ b/src/pages/TrackballPage.tsx
@@ -91,7 +91,7 @@ function LayerGrid({
   );
 }
 
-const SCALING_MIN = 0.1;
+const SCALING_MIN = 0.01;
 const SCALING_MAX = 10;
 const SCALING_STEPS = 100;
 const SCALING_BUTTON_STEP = 0.05;
@@ -850,7 +850,7 @@ export function TrackballPage() {
                             {t("Scaling")}
                           </h3>
                           <p className="text-xs text-[var(--color-text-muted)]">
-                            {t("Adjust sensitivity from 0.1x to 10x")}
+                            {t("Adjust sensitivity from 0.01x to 10x")}
                           </p>
                         </div>
                         <span className="text-lg font-mono text-[var(--color-electric)]">
@@ -898,8 +898,8 @@ export function TrackballPage() {
                       [&::-moz-range-thumb]:shadow-[0_0_8px_var(--color-electric)]"
                           />
                           <div className="mt-2 flex justify-between text-xs text-[var(--color-text-muted)]">
-                            <span>0.1x</span>
-                            <span>10x</span>
+                            <span>{formatScalingValue(SCALING_MIN)}x</span>
+                            <span>{SCALING_MAX}x</span>
                           </div>
                         </div>
 


### PR DESCRIPTION
## Description

Lower the trackball scaling minimum from **0.1x** to **0.01x** so sensitivity can be tuned to much smaller multipliers.

**What changed**
- `SCALING_MIN` in `src/pages/TrackballPage.tsx`: `0.1` → `0.01`. This single constant drives the log-scale slider mapping, the step-button clamping, and the disable thresholds, so the whole scaling control now reaches down to 0.01x.
- The slider's lower-bound label is now derived from `SCALING_MIN` (renders `0.01x`) instead of being hardcoded.
- Updated the scaling description string ("Adjust sensitivity from 0.01x to 10x") and its Japanese translation in `src/i18n/translations.ts`.

**Notes for reviewers**
- The step-button increment (`SCALING_BUTTON_STEP = 0.05`) is left unchanged — values between 0.01x and 0.05x are reachable via the slider. Let me know if the button granularity should also be reduced.
- Verified: `tsc --noEmit` passes, and the full test suite (including all 12 TrackballPage tests) passes via the pre-commit hook.

## CLA (Contributor License Agreement)

By submitting this pull request, I agree that my contributions
are licensed under the project's current license.

I also grant the maintainer(s) of this project the right to relicense
my contributions under any license, for use in future versions of the project.
This does not affect the license of any previously released versions.
