### PR TITLE
WebSerial ⇄ Renode e2e: full connect over emulated USB CDC (POC)

### DIFF
--- a/.github/workflows/renode-webserial-e2e.yml
+++ b/.github/workflows/renode-webserial-e2e.yml
@@ -1,13 +1,14 @@
-# POC: run the REAL dya-studio in a headless browser and have it talk to REAL
-# ZMK firmware running in the Renode emulator over (a shim of) the WebSerial API
-# -- no hardware. The DUT is the exact hardware-flashable studio-rpc-usb-uart
-# image; Studio RPC rides the emulated USB CDC (NRF_USBD_Full + DualCdcAcmBridge
-# from zmk-west-commands), which drains large replies, so the app reaches the
-# fully-connected screen. See e2e/renode/README.md for the architecture.
+# End-to-end: run the real dya-studio in a headless browser and have it fully
+# connect to real ZMK firmware running in the Renode emulator over (a shim of)
+# the WebSerial API -- no hardware. The DUT is the exact hardware-flashable
+# studio-rpc-usb-uart image; Studio RPC rides the emulated USB CDC (NRF_USBD_Full
+# + DualCdcAcmBridge from zmk-west-commands), which drains large replies, so the
+# app reaches the fully-connected screen. See e2e/renode/README.md for the
+# architecture.
 #
 # Opt-in / path-scoped so it never burdens ordinary PRs (the firmware build is
-# a full Zephyr build, ~15-20 min).
-name: renode-webserial-e2e (POC)
+# a full Zephyr build, ~15-20 min cold).
+name: renode-webserial-e2e
 
 on:
   workflow_dispatch:

--- a/.github/workflows/renode-webserial-e2e.yml
+++ b/.github/workflows/renode-webserial-e2e.yml
@@ -1,0 +1,111 @@
+# POC: run the REAL dya-studio in a headless browser and have it talk to REAL
+# ZMK firmware running in the Renode emulator over (a shim of) the WebSerial API
+# -- no hardware. See e2e/renode/README.md for the architecture and the one
+# known limitation (Renode's UARTE TX-IRQ model stalls Studio replies >~30B, so
+# only the GetDeviceInfo round-trip is asserted today).
+#
+# Opt-in / path-scoped so it never burdens ordinary PRs (the firmware build is
+# a full Zephyr build, ~15-20 min).
+name: renode-webserial-e2e (POC)
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - "e2e/renode/**"
+      - ".github/workflows/renode-webserial-e2e.yml"
+
+env:
+  # cormoran/zmk-west-commands provides the Renode harness + the Studio-on-UART
+  # DUT build config. Pin a ref for reproducibility.
+  ZMK_WC_REPO: cormoran/zmk-west-commands
+  ZMK_WC_REF: main
+  # Keyboard name the DUT advertises via GetDeviceInfo (zmk-west-commands'
+  # renode_tester shield). Swap both this and the DUT below for a real dya build.
+  DEVICE_NAME: Renode
+
+jobs:
+  build-dut:
+    name: Build Studio-on-UART DUT (Renode firmware)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    container:
+      image: zmkfirmware/zmk-build-arm:4.1
+    steps:
+      - name: Checkout zmk-west-commands
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ env.ZMK_WC_REPO }}
+          ref: ${{ env.ZMK_WC_REF }}
+      - name: West init/update (Renode manifest)
+        run: |
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          west init -l . --mf scripts/west-test-renode-standalone.yml
+          west update --narrow
+          west zephyr-export
+      - name: Build DUT (renode-studio-uart snippet image)
+        run: west zmk-build tests/zmk-config --build-yaml tests/zmk-config/build-renode.yaml -af renode -d build
+      - name: Upload DUT ELF
+        uses: actions/upload-artifact@v4
+        with:
+          name: dut-elf
+          path: build/renode/zephyr/zmk.elf
+
+  e2e:
+    name: dya-studio ⇄ WebSerial ⇄ Renode
+    needs: build-dut
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout dya-studio
+        uses: actions/checkout@v5
+
+      - name: Build dya-studio dist
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+      - run: npm ci
+      - run: npm run build
+        env:
+          VITE_BASE: /
+
+      - name: Checkout zmk-west-commands (Renode harness)
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ env.ZMK_WC_REPO }}
+          ref: ${{ env.ZMK_WC_REF }}
+          path: zmk-west-commands
+      - name: Install Renode 1.16.1
+        run: bash zmk-west-commands/scripts/lib/renode/install_renode.sh
+
+      - name: Download DUT ELF
+        uses: actions/download-artifact@v4
+        with:
+          name: dut-elf
+          path: fw
+
+      - name: Install e2e deps (Playwright + ws)
+        working-directory: e2e/renode
+        run: |
+          npm install
+          npx playwright install --with-deps chromium
+
+      - name: Run WebSerial ⇄ Renode e2e
+        working-directory: e2e/renode
+        env:
+          ZMK_WC_RENODE_LIB: ${{ github.workspace }}/zmk-west-commands/scripts/lib/renode
+          DIST_DIR: ${{ github.workspace }}/dist
+          DEVICE_NAME: ${{ env.DEVICE_NAME }}
+        run: bash run-local.sh "${{ github.workspace }}/fw/zmk.elf"
+
+      - name: Upload Playwright artifacts on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-artifacts
+          path: |
+            e2e/renode/playwright-report
+            e2e/renode/test-results
+            e2e/renode/renode_serve.err
+            e2e/renode/bridge.out
+          if-no-files-found: ignore

--- a/.github/workflows/renode-webserial-e2e.yml
+++ b/.github/workflows/renode-webserial-e2e.yml
@@ -1,8 +1,9 @@
 # POC: run the REAL dya-studio in a headless browser and have it talk to REAL
 # ZMK firmware running in the Renode emulator over (a shim of) the WebSerial API
-# -- no hardware. See e2e/renode/README.md for the architecture and the one
-# known limitation (Renode's UARTE TX-IRQ model stalls Studio replies >~30B, so
-# only the GetDeviceInfo round-trip is asserted today).
+# -- no hardware. The DUT is the exact hardware-flashable studio-rpc-usb-uart
+# image; Studio RPC rides the emulated USB CDC (NRF_USBD_Full + DualCdcAcmBridge
+# from zmk-west-commands), which drains large replies, so the app reaches the
+# fully-connected screen. See e2e/renode/README.md for the architecture.
 #
 # Opt-in / path-scoped so it never burdens ordinary PRs (the firmware build is
 # a full Zephyr build, ~15-20 min).
@@ -16,8 +17,8 @@ on:
       - ".github/workflows/renode-webserial-e2e.yml"
 
 env:
-  # cormoran/zmk-west-commands provides the Renode harness + the Studio-on-UART
-  # DUT build config. Pin a ref for reproducibility.
+  # cormoran/zmk-west-commands provides the Renode harness + the real-image DUT
+  # build config. Pin a ref for reproducibility.
   ZMK_WC_REPO: cormoran/zmk-west-commands
   ZMK_WC_REF: main
   # Keyboard name the DUT advertises via GetDeviceInfo (zmk-west-commands'
@@ -26,30 +27,33 @@ env:
 
 jobs:
   build-dut:
-    name: Build Studio-on-UART DUT (Renode firmware)
+    name: Build studio-rpc-usb-uart DUT (real image)
     runs-on: ubuntu-latest
     timeout-minutes: 30
     container:
-      image: zmkfirmware/zmk-build-arm:4.1
+      image: zmkfirmware/zmk-build-arm:stable
     steps:
       - name: Checkout zmk-west-commands
         uses: actions/checkout@v4
         with:
           repository: ${{ env.ZMK_WC_REPO }}
           ref: ${{ env.ZMK_WC_REF }}
-      - name: West init/update (Renode manifest)
+      - name: West init/update
         run: |
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
-          west init -l . --mf scripts/west-test-renode-standalone.yml
+          west init -l . --mf scripts/west-test-standalone.yml
           west update --narrow
           west zephyr-export
-      - name: Build DUT (renode-studio-uart snippet image)
-        run: west zmk-build tests/zmk-config --build-yaml tests/zmk-config/build-renode.yaml -af renode -d build
+      - name: Build DUT (real studio-rpc-usb-uart image)
+        # The EXACT hardware-flashable image (xiao_ble//zmk + renode_tester shield
+        # + studio-rpc-usb-uart snippet). Renode's usb mode boots this same image;
+        # no Renode-specific build config. Produces build/ble/zephyr/zmk.elf.
+        run: west zmk-build tests/zmk-config --build-yaml tests/zmk-config/build-ble.yaml -af ble -d build
       - name: Upload DUT ELF
         uses: actions/upload-artifact@v4
         with:
           name: dut-elf
-          path: build/renode/zephyr/zmk.elf
+          path: build/ble/zephyr/zmk.elf
 
   e2e:
     name: dya-studio ⇄ WebSerial ⇄ Renode

--- a/e2e/renode/.gitignore
+++ b/e2e/renode/.gitignore
@@ -1,0 +1,6 @@
+node_modules/
+test-results/
+playwright-report/
+*.out
+*.err
+*.log

--- a/e2e/renode/README.md
+++ b/e2e/renode/README.md
@@ -1,4 +1,4 @@
-# WebSerial ⇄ Renode end-to-end (POC)
+# WebSerial ⇄ Renode end-to-end
 
 Run the **real dya-studio** in a headless browser and have it **fully connect** to
 **real ZMK firmware** running in the [Renode](https://renode.io) emulator over the
@@ -29,16 +29,15 @@ Everything except the browser↔OS serial-driver layer is real: the app, the
 transport, the RPC/protobuf framing, and the firmware. Only the last-mile serial
 driver is replaced by a WebSocket — there is no serial device in CI anyway.
 
-## Why USB CDC (and what changed)
+## Why USB CDC
 
-An earlier version of this POC carried Studio RPC over a **UART** TCP socket and
-could only assert a bare `GetDeviceInfo`: Renode's nRF52840 **UARTE TX-IRQ model
-stalls partway through any Studio reply of ~≥30 framed bytes**, and the app's full
-connect fetches replies far larger than that, so the UI never reached the
-connected screen.
+Renode's nRF52840 **UARTE TX-IRQ model stalls partway through any Studio reply of
+~≥30 framed bytes**, and the app's full connect fetches replies far larger than
+that — so a UART-based Studio transport can only round-trip a bare
+`GetDeviceInfo` and never reaches the connected screen.
 
 zmk-west-commands' **usb mode** (NRF_USBD_Full + DualCdcAcmBridge) has no such
-limit — it drains large device→host bursts — so this POC now boots the exact
+limit — it drains large device→host bursts — so this harness boots the exact
 hardware-flashable `studio-rpc-usb-uart` image and asserts the app reaches the
 **fully-connected** screen. `renode_serve.py` attaches the USB CDC bridge via the
 zmk-west-commands harness and relays the Studio CDC byte stream over a plain TCP
@@ -72,7 +71,7 @@ npm install && npx playwright install chromium
 ZMK_WC_RENODE_LIB=/path/to/zmk-west-commands/scripts/lib/renode \
 DEVICE_NAME=Renode \
   bash run-local.sh /path/to/build/ble/zephyr/zmk.elf
-POC_DEBUG=1 ...   # verbose page/shim/bridge byte logging
+E2E_DEBUG=1 ...   # verbose page/shim/bridge byte logging
 ```
 
 CI wiring lives in `.github/workflows/renode-webserial-e2e.yml` (builds the real
@@ -82,8 +81,8 @@ its keyboard name.
 
 ## Toward the real flashable image over a real OS serial port (next step)
 
-This POC drives the DUT's USB CDC through Renode's in-emulator DualCdcAcmBridge and
-relays it to the browser over a WebSocket shim. The last fidelity step would be to
+This harness drives the DUT's USB CDC through Renode's in-emulator DualCdcAcmBridge
+and relays it to the browser over a WebSocket shim. The last fidelity step would be to
 export that emulated USB device to the host OS as a real `/dev/ttyACM*` (e.g. via
 USB/IP) so an **unshimmed** `navigator.serial` opens it — removing the shim
 entirely. That is a zmk-west-commands concern and is untested here.

--- a/e2e/renode/README.md
+++ b/e2e/renode/README.md
@@ -1,0 +1,77 @@
+# WebSerial ⇄ Renode end-to-end (POC)
+
+Run the **real dya-studio** in a headless browser and have it talk to **real ZMK
+firmware** running in the [Renode](https://renode.io) emulator over the
+**WebSerial** API — with no hardware, in CI.
+
+## What this proves
+
+The built dya-studio app, in headless Chromium, using the real
+`@zmkfirmware/zmk-studio-ts-client` serial transport (unchanged), performs a full
+protobuf `GetDeviceInfo` round-trip against real firmware emulated in Renode, and
+the device's own name comes back over the (shimmed) WebSerial stream.
+
+```
+dya-studio (dist, headless Chromium)
+   │  navigator.serial  ← injected shim: real API surface, ts-client unchanged
+   ▼  WebSocket
+bridge.mjs (Node)  ──raw TCP (transparent bytes)──▶  Renode ServerSocketTerminal (uart1)
+                                                          │
+                                                   renode_serve.py  holds real fw.elf running
+```
+
+Everything except the browser↔OS serial-driver layer is real: the app, the
+transport, the RPC/protobuf framing, and the firmware. Only the last-mile serial
+driver is replaced by a WebSocket — there is no serial device in CI anyway.
+
+## Known limitation (why only `GetDeviceInfo` is asserted)
+
+A full app connect next issues `GetCustomSubsystems`, whose reply is >30 bytes.
+Renode's nRF52840 **UARTE TX-IRQ model stalls partway through any Studio reply of
+~≥30 framed bytes** (confirmed: raising `CONFIG_ZMK_STUDIO_RPC_TX_BUF_SIZE`
+64→2048 does not move the stall point → it's the emulator's UARTE model, not
+buffer size). So the UI does not reach the connected screen under Renode today.
+This is a Renode-fidelity issue in
+[zmk-west-commands](https://github.com/cormoran/zmk-west-commands), orthogonal to
+the browser integration — on real hardware, or once that TX model drains large
+bursts, the same test can assert the connected UI instead.
+
+## Files
+
+| file                    | role                                                                                                                                                                                                                                                                                                                                    |
+| ----------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `renode_serve.py`       | boots the DUT ELF via the zmk-west-commands Renode harness and holds it running; exposes the Studio-RPC UART as a TCP socket. Drains the console UART on a raw socket (an unread console terminal back-pressures the firmware and stalls it); leaves the RPC UART free for the bridge (Renode serves only the first client per socket). |
+| `bridge.mjs`            | transparent WebSocket ⇄ Renode-UART-TCP byte pipe (the browser can't open raw TCP).                                                                                                                                                                                                                                                     |
+| `serial-shim.mjs`       | injects a `navigator.serial` shim implementing only the SerialPort surface the ts-client uses, bridged to the WebSocket.                                                                                                                                                                                                                |
+| `serve.mjs`             | dependency-free static server for the built `dist/`.                                                                                                                                                                                                                                                                                    |
+| `tests/connect.spec.ts` | Playwright: clicks the real "Connect via USB" button and asserts the device name round-trips.                                                                                                                                                                                                                                           |
+| `run-local.sh`          | orchestrates renode_serve → bridge → Playwright.                                                                                                                                                                                                                                                                                        |
+
+## Run locally
+
+```bash
+# prerequisites:
+#   - Renode 1.16.1 at ~/.renode/1.16.1
+#   - a checkout of cormoran/zmk-west-commands (for the Renode harness)
+#   - a built dist/ (npm run build at the repo root)
+#   - a Studio-on-UART DUT ELF (CONFIG_ZMK_STUDIO=y + the renode-studio-uart snippet)
+cd e2e/renode
+npm install && npx playwright install chromium
+ZMK_WC_RENODE_LIB=/path/to/zmk-west-commands/scripts/lib/renode \
+DEVICE_NAME=Renode \
+  bash run-local.sh /path/to/studio-on-uart.elf
+POC_DEBUG=1 ...   # verbose page/shim/bridge byte logging
+```
+
+CI wiring lives in `.github/workflows/renode-webserial-e2e.yml` (builds the DUT
+from zmk-west-commands' Renode fixtures, then runs this). To point at a real dya
+keyboard, build its firmware with the `renode-studio-uart` snippet and set
+`DEVICE_NAME` to its keyboard name.
+
+## Toward the real flashable image over real USB-CDC (next step)
+
+This POC uses the UART path (the only one a browser can reach). Driving the exact
+hardware-flashable image over **real** USB-CDC would require wiring Renode's
+`NRF_USBD` and exporting it to the host as `/dev/ttyACM*` via USB/IP → real
+WebSerial (untested; a zmk-west-commands concern), plus resolving the ≥30B UARTE
+stall above.

--- a/e2e/renode/README.md
+++ b/e2e/renode/README.md
@@ -1,51 +1,59 @@
 # WebSerial ⇄ Renode end-to-end (POC)
 
-Run the **real dya-studio** in a headless browser and have it talk to **real ZMK
-firmware** running in the [Renode](https://renode.io) emulator over the
+Run the **real dya-studio** in a headless browser and have it **fully connect** to
+**real ZMK firmware** running in the [Renode](https://renode.io) emulator over the
 **WebSerial** API — with no hardware, in CI.
 
 ## What this proves
 
 The built dya-studio app, in headless Chromium, using the real
-`@zmkfirmware/zmk-studio-ts-client` serial transport (unchanged), performs a full
-protobuf `GetDeviceInfo` round-trip against real firmware emulated in Renode, and
-the device's own name comes back over the (shimmed) WebSerial stream.
+`@zmkfirmware/zmk-studio-ts-client` serial transport (unchanged), completes its
+full Studio connect handshake against real firmware emulated in Renode and reaches
+the **connected screen** (the device's own name appears in the app header). The
+DUT is the exact hardware-flashable `studio-rpc-usb-uart` image; its Studio RPC
+rides the **emulated USB CDC-ACM**, so it is the same transport class the browser
+uses on real hardware.
 
 ```
 dya-studio (dist, headless Chromium)
    │  navigator.serial  ← injected shim: real API surface, ts-client unchanged
    ▼  WebSocket
-bridge.mjs (Node)  ──raw TCP (transparent bytes)──▶  Renode ServerSocketTerminal (uart1)
+bridge.mjs (Node)  ──raw TCP (transparent bytes)──▶  renode_serve.py relay
+                                                          │  (Studio CDC bytes)
+                                    DualCdcAcmBridge USB host ⇄ NRF_USBD_Full
                                                           │
-                                                   renode_serve.py  holds real fw.elf running
+                                                   real ZMK fw.elf in Renode
 ```
 
 Everything except the browser↔OS serial-driver layer is real: the app, the
 transport, the RPC/protobuf framing, and the firmware. Only the last-mile serial
 driver is replaced by a WebSocket — there is no serial device in CI anyway.
 
-## Known limitation (why only `GetDeviceInfo` is asserted)
+## Why USB CDC (and what changed)
 
-A full app connect next issues `GetCustomSubsystems`, whose reply is >30 bytes.
-Renode's nRF52840 **UARTE TX-IRQ model stalls partway through any Studio reply of
-~≥30 framed bytes** (confirmed: raising `CONFIG_ZMK_STUDIO_RPC_TX_BUF_SIZE`
-64→2048 does not move the stall point → it's the emulator's UARTE model, not
-buffer size). So the UI does not reach the connected screen under Renode today.
-This is a Renode-fidelity issue in
-[zmk-west-commands](https://github.com/cormoran/zmk-west-commands), orthogonal to
-the browser integration — on real hardware, or once that TX model drains large
-bursts, the same test can assert the connected UI instead.
+An earlier version of this POC carried Studio RPC over a **UART** TCP socket and
+could only assert a bare `GetDeviceInfo`: Renode's nRF52840 **UARTE TX-IRQ model
+stalls partway through any Studio reply of ~≥30 framed bytes**, and the app's full
+connect fetches replies far larger than that, so the UI never reached the
+connected screen.
+
+zmk-west-commands' **usb mode** (NRF_USBD_Full + DualCdcAcmBridge) has no such
+limit — it drains large device→host bursts — so this POC now boots the exact
+hardware-flashable `studio-rpc-usb-uart` image and asserts the app reaches the
+**fully-connected** screen. `renode_serve.py` attaches the USB CDC bridge via the
+zmk-west-commands harness and relays the Studio CDC byte stream over a plain TCP
+socket (`RPC_PORT`) that the Node bridge speaks to, unchanged.
 
 ## Files
 
-| file                    | role                                                                                                                                                                                                                                                                                                                                    |
-| ----------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `renode_serve.py`       | boots the DUT ELF via the zmk-west-commands Renode harness and holds it running; exposes the Studio-RPC UART as a TCP socket. Drains the console UART on a raw socket (an unread console terminal back-pressures the firmware and stalls it); leaves the RPC UART free for the bridge (Renode serves only the first client per socket). |
-| `bridge.mjs`            | transparent WebSocket ⇄ Renode-UART-TCP byte pipe (the browser can't open raw TCP).                                                                                                                                                                                                                                                     |
-| `serial-shim.mjs`       | injects a `navigator.serial` shim implementing only the SerialPort surface the ts-client uses, bridged to the WebSocket.                                                                                                                                                                                                                |
-| `serve.mjs`             | dependency-free static server for the built `dist/`.                                                                                                                                                                                                                                                                                    |
-| `tests/connect.spec.ts` | Playwright: clicks the real "Connect via USB" button and asserts the device name round-trips.                                                                                                                                                                                                                                           |
-| `run-local.sh`          | orchestrates renode_serve → bridge → Playwright.                                                                                                                                                                                                                                                                                        |
+| file                    | role                                                                                                                                                                                                                                                                   |
+| ----------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `renode_serve.py`       | boots the real DUT ELF on the zmk-west-commands USB platform, attaches the DualCdcAcmBridge, and relays the Studio USB-CDC byte stream as a TCP socket (`RPC_PORT`). Drains the console CDC + UART console so the firmware never back-pressures on an unread terminal. |
+| `bridge.mjs`            | transparent WebSocket ⇄ TCP byte pipe (the browser can't open raw TCP); the single client of the relay.                                                                                                                                                                |
+| `serial-shim.mjs`       | injects a `navigator.serial` shim implementing only the SerialPort surface the ts-client uses, bridged to the WebSocket.                                                                                                                                               |
+| `serve.mjs`             | dependency-free static server for the built `dist/`.                                                                                                                                                                                                                   |
+| `tests/connect.spec.ts` | Playwright: clicks the real "Connect via USB" button, asserts the device name round-trips **and** the app reaches the connected screen.                                                                                                                                |
+| `run-local.sh`          | orchestrates renode_serve → bridge → Playwright.                                                                                                                                                                                                                       |
 
 ## Run locally
 
@@ -54,24 +62,28 @@ bursts, the same test can assert the connected UI instead.
 #   - Renode 1.16.1 at ~/.renode/1.16.1
 #   - a checkout of cormoran/zmk-west-commands (for the Renode harness)
 #   - a built dist/ (npm run build at the repo root)
-#   - a Studio-on-UART DUT ELF (CONFIG_ZMK_STUDIO=y + the renode-studio-uart snippet)
+#   - a real studio-rpc-usb-uart DUT ELF. Build one from zmk-west-commands:
+#       west init -l . --mf scripts/west-test-standalone.yml
+#       west update --narrow && west zephyr-export
+#       west zmk-build tests/zmk-config --build-yaml tests/zmk-config/build-ble.yaml -af ble -d build
+#     -> build/ble/zephyr/zmk.elf (advertises the name "Renode")
 cd e2e/renode
 npm install && npx playwright install chromium
 ZMK_WC_RENODE_LIB=/path/to/zmk-west-commands/scripts/lib/renode \
 DEVICE_NAME=Renode \
-  bash run-local.sh /path/to/studio-on-uart.elf
+  bash run-local.sh /path/to/build/ble/zephyr/zmk.elf
 POC_DEBUG=1 ...   # verbose page/shim/bridge byte logging
 ```
 
-CI wiring lives in `.github/workflows/renode-webserial-e2e.yml` (builds the DUT
-from zmk-west-commands' Renode fixtures, then runs this). To point at a real dya
-keyboard, build its firmware with the `renode-studio-uart` snippet and set
-`DEVICE_NAME` to its keyboard name.
+CI wiring lives in `.github/workflows/renode-webserial-e2e.yml` (builds the real
+DUT from zmk-west-commands' fixtures, then runs this). To point at a real dya
+keyboard, build its own `studio-rpc-usb-uart` firmware and set `DEVICE_NAME` to
+its keyboard name.
 
-## Toward the real flashable image over real USB-CDC (next step)
+## Toward the real flashable image over a real OS serial port (next step)
 
-This POC uses the UART path (the only one a browser can reach). Driving the exact
-hardware-flashable image over **real** USB-CDC would require wiring Renode's
-`NRF_USBD` and exporting it to the host as `/dev/ttyACM*` via USB/IP → real
-WebSerial (untested; a zmk-west-commands concern), plus resolving the ≥30B UARTE
-stall above.
+This POC drives the DUT's USB CDC through Renode's in-emulator DualCdcAcmBridge and
+relays it to the browser over a WebSocket shim. The last fidelity step would be to
+export that emulated USB device to the host OS as a real `/dev/ttyACM*` (e.g. via
+USB/IP) so an **unshimmed** `navigator.serial` opens it — removing the shim
+entirely. That is a zmk-west-commands concern and is untested here.

--- a/e2e/renode/bridge.mjs
+++ b/e2e/renode/bridge.mjs
@@ -1,13 +1,13 @@
-// WebSocket <-> Renode-UART-TCP bridge.
+// WebSocket <-> TCP bridge.
 //
 // The browser cannot open a raw TCP socket, so this tiny Node process is the
-// single TCP client of Renode's Studio-RPC UART server socket and relays its
-// bytes, transparently and unframed, over a WebSocket that the injected
+// single TCP client of renode_serve.py's Studio relay (RPC_PORT) -- which
+// carries the DUT's raw Studio USB-CDC byte stream -- and relays those bytes,
+// transparently and unframed, over a WebSocket that the injected
 // `navigator.serial` shim in the page connects to.
 //
-// It opens the TCP connection to Renode ONCE at startup (so it is the first and
-// only client Renode's ServerSocketTerminal will serve) and buffers any
-// device->host bytes until a browser WebSocket attaches.
+// It opens the TCP connection ONCE at startup and buffers any device->host
+// bytes until a browser WebSocket attaches.
 import net from "node:net";
 import { WebSocketServer } from "ws";
 
@@ -23,7 +23,7 @@ let ws = null; // current browser socket (single client for the POC)
 const pending = []; // device->host bytes buffered until a browser attaches
 
 const tcp = net.createConnection({ host: "127.0.0.1", port: RPC_PORT }, () => {
-  console.error(`bridge: TCP connected to Renode RPC UART :${RPC_PORT}`);
+  console.error(`bridge: TCP connected to Studio relay :${RPC_PORT}`);
 });
 tcp.on("data", (buf) => {
   if (DEBUG) console.error(`bridge: device->host ${buf.length}B ${buf.subarray(0, 16).toString("hex")}`);

--- a/e2e/renode/bridge.mjs
+++ b/e2e/renode/bridge.mjs
@@ -1,0 +1,56 @@
+// WebSocket <-> Renode-UART-TCP bridge.
+//
+// The browser cannot open a raw TCP socket, so this tiny Node process is the
+// single TCP client of Renode's Studio-RPC UART server socket and relays its
+// bytes, transparently and unframed, over a WebSocket that the injected
+// `navigator.serial` shim in the page connects to.
+//
+// It opens the TCP connection to Renode ONCE at startup (so it is the first and
+// only client Renode's ServerSocketTerminal will serve) and buffers any
+// device->host bytes until a browser WebSocket attaches.
+import net from "node:net";
+import { WebSocketServer } from "ws";
+
+const RPC_PORT = Number(process.env.RPC_PORT);
+const WS_PORT = Number(process.env.WS_PORT || 8788);
+const DEBUG = !!process.env.POC_DEBUG;
+if (!RPC_PORT) {
+  console.error("RPC_PORT env var required");
+  process.exit(1);
+}
+
+let ws = null; // current browser socket (single client for the POC)
+const pending = []; // device->host bytes buffered until a browser attaches
+
+const tcp = net.createConnection({ host: "127.0.0.1", port: RPC_PORT }, () => {
+  console.error(`bridge: TCP connected to Renode RPC UART :${RPC_PORT}`);
+});
+tcp.on("data", (buf) => {
+  if (DEBUG) console.error(`bridge: device->host ${buf.length}B ${buf.subarray(0, 16).toString("hex")}`);
+  if (ws && ws.readyState === ws.OPEN) ws.send(buf);
+  else pending.push(buf);
+});
+tcp.on("error", (e) => console.error("bridge: TCP error", e.message));
+tcp.on("close", () => {
+  console.error("bridge: TCP closed");
+  if (ws) ws.close();
+});
+
+const wss = new WebSocketServer({ port: WS_PORT }, () => {
+  console.error(`BRIDGE_READY ws://127.0.0.1:${WS_PORT} -> tcp :${RPC_PORT}`);
+});
+wss.on("connection", (sock) => {
+  console.error("bridge: browser WebSocket attached");
+  ws = sock;
+  sock.binaryType = "nodebuffer";
+  while (pending.length) sock.send(pending.shift());
+  sock.on("message", (data) => {
+    if (DEBUG) console.error(`bridge: host->device ${data.length}B ${data.subarray(0, 16).toString("hex")}`);
+    tcp.write(data);
+  });
+  sock.on("close", () => {
+    console.error("bridge: browser WebSocket detached");
+    if (ws === sock) ws = null;
+  });
+  sock.on("error", (e) => console.error("bridge: ws error", e.message));
+});

--- a/e2e/renode/bridge.mjs
+++ b/e2e/renode/bridge.mjs
@@ -13,13 +13,13 @@ import { WebSocketServer } from "ws";
 
 const RPC_PORT = Number(process.env.RPC_PORT);
 const WS_PORT = Number(process.env.WS_PORT || 8788);
-const DEBUG = !!process.env.POC_DEBUG;
+const DEBUG = !!process.env.E2E_DEBUG;
 if (!RPC_PORT) {
   console.error("RPC_PORT env var required");
   process.exit(1);
 }
 
-let ws = null; // current browser socket (single client for the POC)
+let ws = null; // current browser socket (single browser client)
 const pending = []; // device->host bytes buffered until a browser attaches
 
 const tcp = net.createConnection({ host: "127.0.0.1", port: RPC_PORT }, () => {

--- a/e2e/renode/package-lock.json
+++ b/e2e/renode/package-lock.json
@@ -1,0 +1,99 @@
+{
+  "name": "dya-studio-renode-e2e",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "dya-studio-renode-e2e",
+      "devDependencies": {
+        "@playwright/test": "^1.49.0",
+        "ws": "^8.18.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/e2e/renode/package.json
+++ b/e2e/renode/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "dya-studio-renode-e2e",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "playwright test"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.49.0",
+    "ws": "^8.18.0"
+  }
+}

--- a/e2e/renode/playwright.config.ts
+++ b/e2e/renode/playwright.config.ts
@@ -2,7 +2,7 @@ import { defineConfig, devices } from "@playwright/test";
 
 const SERVE_PORT = Number(process.env.SERVE_PORT || 4173);
 
-// renode_serve.py + bridge.mjs are started by run-local.sh (local proof) or the
+// renode_serve.py + bridge.mjs are started by run-local.sh (local runs) or the
 // CI workflow BEFORE playwright runs; they export WS_URL. This config only owns
 // the static server for the built dya-studio dist.
 export default defineConfig({

--- a/e2e/renode/playwright.config.ts
+++ b/e2e/renode/playwright.config.ts
@@ -1,0 +1,31 @@
+import { defineConfig, devices } from "@playwright/test";
+
+const SERVE_PORT = Number(process.env.SERVE_PORT || 4173);
+
+// renode_serve.py + bridge.mjs are started by run-local.sh (local proof) or the
+// CI workflow BEFORE playwright runs; they export WS_URL. This config only owns
+// the static server for the built dya-studio dist.
+export default defineConfig({
+  testDir: "./tests",
+  timeout: 120_000,
+  expect: { timeout: 30_000 },
+  fullyParallel: false,
+  workers: 1,
+  reporter: [["list"]],
+  use: {
+    baseURL: `http://127.0.0.1:${SERVE_PORT}`,
+    trace: "retain-on-failure",
+  },
+  projects: [{ name: "chromium", use: { ...devices["Desktop Chrome"] } }],
+  webServer: {
+    command: "node serve.mjs",
+    port: SERVE_PORT,
+    reuseExistingServer: !process.env.CI,
+    env: {
+      DIST_DIR: process.env.DIST_DIR || "dist",
+      SERVE_PORT: String(SERVE_PORT),
+    },
+    stdout: "pipe",
+    stderr: "pipe",
+  },
+});

--- a/e2e/renode/renode_serve.py
+++ b/e2e/renode/renode_serve.py
@@ -1,17 +1,27 @@
 #!/usr/bin/env python3
-"""Boot a Studio-on-UART ZMK ELF under Renode and hold the emulation running,
-exposing the Studio-RPC UART as a plain TCP server socket (Renode's own
-CreateServerSocketTerminal). Prints `RPC_PORT=<n>` on stdout once ready, then
-blocks until killed.
+"""Boot a real, hardware-flashable ZMK `studio-rpc-usb-uart` ELF under Renode and
+hold the emulation running, exposing its ZMK Studio RPC endpoint -- carried over
+the emulated **USB CDC-ACM** -- as a plain TCP server socket. Prints `RPC_PORT=<n>`
+on stdout once ready, then blocks until killed.
 
-Design (see POC README): Python attaches ONLY to the console UART (drains it so
-the firmware never back-pressures on logs, and so we capture a boot log for
-debugging). It deliberately does NOT connect to the Studio-RPC UART -- Renode's
-ServerSocketTerminal only serves its first client for the life of the process,
-so we leave that socket free for the Node WebSocket bridge, which becomes the
-single RPC client. Losing the unsolicited boot notification that the firmware
-emits before the bridge attaches is harmless: the real ts-client re-issues
-GetDeviceInfo itself.
+Why USB CDC (not UART): this is the SAME image you flash to hardware, and its
+Studio transport is USB CDC. Renode's nRF52840 UARTE TX-IRQ model stalls Studio
+replies of ~>=30 framed bytes, which capped an earlier UART-based version of this
+POC at a bare `GetDeviceInfo`; the emulated USB CDC path (NRF_USBD_Full +
+DualCdcAcmBridge, from zmk-west-commands) has no such limit, so the browser can
+complete dya-studio's full connect handshake (which fetches replies far larger
+than that). See e2e/renode/README.md.
+
+How the endpoint is exposed: zmk-west-commands' harness attaches a
+DualCdcAcmBridge USB host and hands us the Studio CDC channel as a Python socket
+(Renode serves a ServerSocketTerminal to only its first client, so we must own
+it here rather than let the browser bridge connect to Renode directly). This
+process then runs a tiny transparent TCP relay -- `RPC_PORT` -- that pipes those
+raw Studio bytes to/from the single Node `bridge.mjs` client, keeping the exact
+`RPC_PORT=` contract the rest of the harness (bridge, shim, test) already speaks.
+The console CDC channel (present on CONFIG_ZMK_USB_LOGGING images) and the UART
+console are drained in the background so the firmware never back-pressures on an
+unread terminal.
 """
 import os
 import socket
@@ -28,82 +38,179 @@ HARNESS = Path(
 )
 sys.path.insert(0, str(HARNESS))
 
-from renode_harness import RenodeSession, PLATFORMS_DIR  # noqa: E402
+import renode_harness as H  # noqa: E402
+
+USB_REPL_TEMPLATE = "xiao_nrf52840_usb.repl"
+BRIDGE_NAME = "bridge"
+
+
+def _mon_is_wired(mon, channel: str) -> bool:
+    """True/False for a `sysbus.<channel> IsWired` monitor query (parses the
+    ANSI-colored, echo-prefixed reply); False when nothing parseable is found."""
+    import re
+
+    text = re.sub(r"\x1b\[[0-9;]*m", "", mon.execute(f"sysbus.{channel} IsWired", settle=0.3))
+    for line in text.splitlines():
+        if line.strip() in ("True", "False"):
+            return line.strip() == "True"
+    return False
+
+
+def _drain_forever(sock, label: str) -> None:
+    """Continuously read + discard (echo to stderr) a console socket so the
+    firmware never back-pressures on an unread terminal."""
+    sock.settimeout(1.0)
+    while True:
+        try:
+            chunk = sock.recv(4096)
+            if not chunk:
+                time.sleep(0.2)
+                continue
+            sys.stderr.buffer.write(f"[{label}] ".encode() + chunk)
+            sys.stderr.flush()
+        except socket.timeout:
+            continue
+        except OSError:
+            return
+
+
+def _pump(src: socket.socket, dst: socket.socket) -> None:
+    """Copy bytes from `src` to `dst` until either side closes. Never closes the
+    Renode-facing socket -- the caller keeps it for the process lifetime."""
+    src.settimeout(0.5)
+    while True:
+        try:
+            data = src.recv(4096)
+        except socket.timeout:
+            continue
+        except OSError:
+            return
+        if not data:
+            return
+        try:
+            dst.sendall(data)
+        except OSError:
+            return
+
+
+def _serve_relay(srv: socket.socket, studio_sock: socket.socket) -> None:
+    """Accept the single Node bridge client and transparently pipe its bytes
+    to/from the Studio CDC socket. Loops so a bridge restart re-attaches; the
+    Renode-facing `studio_sock` is never closed here (it lives for the session)."""
+    while True:
+        try:
+            conn, _ = srv.accept()
+        except OSError:
+            return
+        print("relay: bridge client attached", file=sys.stderr, flush=True)
+        threading.Thread(target=_pump, args=(conn, studio_sock), daemon=True).start()
+        _pump(studio_sock, conn)  # returns when the bridge disconnects
+        print("relay: bridge client detached", file=sys.stderr, flush=True)
+        try:
+            conn.close()
+        except OSError:
+            pass
 
 
 def main() -> None:
     elf = Path(sys.argv[1]).resolve()
     if not elf.exists():
         raise SystemExit(f"ELF not found: {elf}")
-    renode = os.environ.get("RENODE_BIN", str(Path.home() / ".renode" / "1.16.1" / "renode"))
+
+    renode = os.environ.get("RENODE_BIN") or H.find_or_install_renode(
+        version=os.environ.get("RENODE_VERSION", "1.16.1")
+    )
+    if not renode:
+        raise SystemExit("Renode is not installed and could not be auto-installed")
 
     import random
 
     port_base = int(os.environ.get("RENODE_PORT_BASE", "0")) or random.randint(26000, 40000)
     console_port = port_base + 1
-    rpc_port = port_base + 2
+    relay_port = port_base + 6
+    boot_settle = float(os.environ.get("RENODE_BOOT_SETTLE", "8"))
+    wiring_timeout = float(os.environ.get("RENODE_WIRING_TIMEOUT", "30"))
+    # Renode's mono cold-start can take ~15-20s on a loaded box; boot_single_real
+    # waits boot_wait + 10s for the monitor, so give margin.
+    boot_wait = float(os.environ.get("RENODE_BOOT_WAIT", "20"))
 
-    session = RenodeSession(
+    # Boot the real flashable image on the NRF_USBD_Full usb platform. console =
+    # uart0 (silent on a real image), rpc = idle uart1 -- both owned for symmetry.
+    session, console, rpc = H.boot_single_real(
         renode,
-        PLATFORMS_DIR / "single.resc",
-        monitor_port=port_base,
-        variables={
-            "bin": f"@{elf}",
-            "console_port": console_port,
-            "rpc_port": rpc_port,
-        },
-        cwd=HARNESS,
+        elf,
+        port_base=port_base,
+        repl_template=USB_REPL_TEMPLATE,
+        boot_wait=boot_wait,
     )
-    # Renode's mono cold-start can take ~15-20s on a loaded box before the
-    # monitor port opens; start()'s deadline is boot_wait + 10s, so give margin.
-    session.start(boot_wait=float(os.environ.get("RENODE_BOOT_WAIT", "20")))
-
-    # Attach to the console UART with a RAW socket and drain it continuously in
-    # the background. This is essential, not just for logs: a client that
-    # connects to Renode's console ServerSocketTerminal but never reads will
-    # back-pressure the firmware's log writes and stall it before it can service
-    # RPC. (We deliberately do NOT touch the RPC UART socket -- that is left free
-    # for the Node bridge, which becomes its single client.)
-    deadline = time.monotonic() + 20.0
-    console = None
-    while time.monotonic() < deadline:
-        try:
-            console = socket.create_connection(("127.0.0.1", console_port), timeout=2.0)
-            break
-        except OSError:
-            time.sleep(0.3)
-    if console is None:
-        raise SystemExit("could not connect to console UART socket")
-    console.settimeout(1.0)
-
-    def _drain_console() -> None:
-        while True:
-            try:
-                chunk = console.recv(4096)
-                if not chunk:
-                    time.sleep(0.2)
-                    continue
-                sys.stderr.buffer.write(chunk)
-                sys.stderr.flush()
-            except socket.timeout:
-                continue
-            except OSError:
-                return
-
-    threading.Thread(target=_drain_console, daemon=True).start()
-
-    session.go()  # start the emulation
-
-    print(f"RPC_PORT={rpc_port}", flush=True)
-    print(f"CONSOLE_PORT={console_port}", flush=True)
-    print("RENODE_READY", flush=True)
-
+    assert session.mon is not None
+    mon = session.mon
+    cdc: list = []
     try:
-        while True:
-            time.sleep(3600)
-    except KeyboardInterrupt:
-        pass
+        # Let the guest finish USB bring-up (ENABLE + USBPULLUP) before the host
+        # attaches -- a SETUP fired before the guest's INTEN is set is lost.
+        t0 = time.monotonic()
+        while time.monotonic() - t0 < boot_settle:
+            H.drain_text(console._sock, timeout=0.5)
+
+        # Attach the USB host + expose both CDC channels as sockets (Python owns
+        # them, as the harness requires: one client per Renode terminal).
+        cdc = list(H.attach_dual_cdc_bridge(session, port_base + 4, port_base + 5))
+
+        deadline = time.monotonic() + wiring_timeout
+        while time.monotonic() < deadline:
+            if _mon_is_wired(mon, f"{BRIDGE_NAME}_cdc0"):
+                break
+        else:
+            raise SystemExit(
+                "USB enumeration never wired the first CDC channel -- is the ELF a "
+                "studio-rpc-usb-uart (USB-CDC) image?"
+            )
+        dual = _mon_is_wired(mon, f"{BRIDGE_NAME}_cdc1")
+        # Let the bridge finish its post-wiring control sequence (SET_LINE_CODING /
+        # DTR) and arm the device->host pumps.
+        time.sleep(2.0)
+
+        # Single-CDC studio-rpc-usb-uart image: cdc0 IS Studio, no console CDC.
+        # CONFIG_ZMK_USB_LOGGING image: console CDC enumerates first (cdc0),
+        # Studio second (cdc1) -- drain the console CDC so it can't back-pressure.
+        if dual:
+            studio = cdc[1]
+            threading.Thread(
+                target=_drain_forever, args=(cdc[0]._sock, "usb-console"), daemon=True
+            ).start()
+            print("two CDC functions (console + Studio); Studio = cdc1", file=sys.stderr)
+        else:
+            studio = cdc[0]
+            print("single CDC function (Studio only); Studio = cdc0", file=sys.stderr)
+
+        # Drain the (usually silent) UART console too.
+        threading.Thread(
+            target=_drain_forever, args=(console._sock, "uart0"), daemon=True
+        ).start()
+
+        # Transparent TCP relay carrying the raw Studio byte stream -- the exact
+        # RPC_PORT= contract bridge.mjs already connects to.
+        srv = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        srv.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        srv.bind(("127.0.0.1", relay_port))
+        srv.listen(1)
+        threading.Thread(target=_serve_relay, args=(srv, studio._sock), daemon=True).start()
+
+        print(f"RPC_PORT={relay_port}", flush=True)
+        print(f"CONSOLE_PORT={console_port}", flush=True)
+        print("RENODE_READY", flush=True)
+
+        try:
+            while True:
+                time.sleep(3600)
+        except KeyboardInterrupt:
+            pass
     finally:
+        for sock in cdc:
+            sock.close()
+        rpc.close()
+        console.close()
         session.stop()
 
 

--- a/e2e/renode/renode_serve.py
+++ b/e2e/renode/renode_serve.py
@@ -6,8 +6,7 @@ on stdout once ready, then blocks until killed.
 
 Why USB CDC (not UART): this is the SAME image you flash to hardware, and its
 Studio transport is USB CDC. Renode's nRF52840 UARTE TX-IRQ model stalls Studio
-replies of ~>=30 framed bytes, which capped an earlier UART-based version of this
-POC at a bare `GetDeviceInfo`; the emulated USB CDC path (NRF_USBD_Full +
+replies of ~>=30 framed bytes; the emulated USB CDC path (NRF_USBD_Full +
 DualCdcAcmBridge, from zmk-west-commands) has no such limit, so the browser can
 complete dya-studio's full connect handshake (which fetches replies far larger
 than that). See e2e/renode/README.md.

--- a/e2e/renode/renode_serve.py
+++ b/e2e/renode/renode_serve.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""Boot a Studio-on-UART ZMK ELF under Renode and hold the emulation running,
+exposing the Studio-RPC UART as a plain TCP server socket (Renode's own
+CreateServerSocketTerminal). Prints `RPC_PORT=<n>` on stdout once ready, then
+blocks until killed.
+
+Design (see POC README): Python attaches ONLY to the console UART (drains it so
+the firmware never back-pressures on logs, and so we capture a boot log for
+debugging). It deliberately does NOT connect to the Studio-RPC UART -- Renode's
+ServerSocketTerminal only serves its first client for the life of the process,
+so we leave that socket free for the Node WebSocket bridge, which becomes the
+single RPC client. Losing the unsolicited boot notification that the firmware
+emits before the bridge attaches is harmless: the real ts-client re-issues
+GetDeviceInfo itself.
+"""
+import os
+import socket
+import sys
+import threading
+import time
+from pathlib import Path
+
+HARNESS = Path(
+    os.environ.get(
+        "ZMK_WC_RENODE_LIB",
+        str(Path.home() / "zmk-west-commands" / "scripts" / "lib" / "renode"),
+    )
+)
+sys.path.insert(0, str(HARNESS))
+
+from renode_harness import RenodeSession, PLATFORMS_DIR  # noqa: E402
+
+
+def main() -> None:
+    elf = Path(sys.argv[1]).resolve()
+    if not elf.exists():
+        raise SystemExit(f"ELF not found: {elf}")
+    renode = os.environ.get("RENODE_BIN", str(Path.home() / ".renode" / "1.16.1" / "renode"))
+
+    import random
+
+    port_base = int(os.environ.get("RENODE_PORT_BASE", "0")) or random.randint(26000, 40000)
+    console_port = port_base + 1
+    rpc_port = port_base + 2
+
+    session = RenodeSession(
+        renode,
+        PLATFORMS_DIR / "single.resc",
+        monitor_port=port_base,
+        variables={
+            "bin": f"@{elf}",
+            "console_port": console_port,
+            "rpc_port": rpc_port,
+        },
+        cwd=HARNESS,
+    )
+    # Renode's mono cold-start can take ~15-20s on a loaded box before the
+    # monitor port opens; start()'s deadline is boot_wait + 10s, so give margin.
+    session.start(boot_wait=float(os.environ.get("RENODE_BOOT_WAIT", "20")))
+
+    # Attach to the console UART with a RAW socket and drain it continuously in
+    # the background. This is essential, not just for logs: a client that
+    # connects to Renode's console ServerSocketTerminal but never reads will
+    # back-pressure the firmware's log writes and stall it before it can service
+    # RPC. (We deliberately do NOT touch the RPC UART socket -- that is left free
+    # for the Node bridge, which becomes its single client.)
+    deadline = time.monotonic() + 20.0
+    console = None
+    while time.monotonic() < deadline:
+        try:
+            console = socket.create_connection(("127.0.0.1", console_port), timeout=2.0)
+            break
+        except OSError:
+            time.sleep(0.3)
+    if console is None:
+        raise SystemExit("could not connect to console UART socket")
+    console.settimeout(1.0)
+
+    def _drain_console() -> None:
+        while True:
+            try:
+                chunk = console.recv(4096)
+                if not chunk:
+                    time.sleep(0.2)
+                    continue
+                sys.stderr.buffer.write(chunk)
+                sys.stderr.flush()
+            except socket.timeout:
+                continue
+            except OSError:
+                return
+
+    threading.Thread(target=_drain_console, daemon=True).start()
+
+    session.go()  # start the emulation
+
+    print(f"RPC_PORT={rpc_port}", flush=True)
+    print(f"CONSOLE_PORT={console_port}", flush=True)
+    print("RENODE_READY", flush=True)
+
+    try:
+        while True:
+            time.sleep(3600)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        session.stop()
+
+
+if __name__ == "__main__":
+    main()

--- a/e2e/renode/run-local.sh
+++ b/e2e/renode/run-local.sh
@@ -1,19 +1,20 @@
 #!/usr/bin/env bash
 # Local (and CI) driver for the WebSerial<->Renode e2e:
-#   Renode(real fw over UART) <- TCP - bridge - WS -> shimmed navigator.serial
-#   in headless Chromium running the built dya-studio, driven by Playwright.
+#   Renode(real fw, Studio over emulated USB CDC) <- TCP - bridge - WS ->
+#   shimmed navigator.serial in headless Chromium running the built dya-studio,
+#   driven by Playwright.
 #
 # Requirements:
 #   - Renode 1.16.1 at ~/.renode/1.16.1 (RENODE_BIN to override)
 #   - ZMK_WC_RENODE_LIB -> a checkout of cormoran/zmk-west-commands'
 #     scripts/lib/renode (the Renode harness + platforms)
 #   - DIST_DIR -> a built dya-studio dist (defaults to <repo>/dist)
-#   - a Studio-on-UART DUT ELF (arg $1)
+#   - a real studio-rpc-usb-uart DUT ELF (arg $1)
 set -euo pipefail
 cd "$(dirname "$0")"
 REPO_ROOT="$(cd ../.. && pwd)"
 
-ELF="${1:?usage: run-local.sh <studio-on-uart.elf>}"
+ELF="${1:?usage: run-local.sh <studio-rpc-usb-uart.elf>}"
 export DIST_DIR="${DIST_DIR:-$REPO_ROOT/dist}"
 export ZMK_WC_RENODE_LIB="${ZMK_WC_RENODE_LIB:?set ZMK_WC_RENODE_LIB to zmk-west-commands/scripts/lib/renode}"
 export WS_PORT="${WS_PORT:-8788}"
@@ -28,18 +29,21 @@ cleanup() {
 }
 trap cleanup EXIT
 
-echo ">>> [1/3] booting Renode with $ELF"
+echo ">>> [1/3] booting Renode with $ELF (real image; Studio over USB CDC)"
 python3 renode_serve.py "$ELF" > renode_serve.out 2> renode_serve.err &
 pids+=($!)
 
+# Booting the real image, enumerating USB and wiring the CDC bridge is slower
+# than a bare UART boot -- and Renode's mono cold-start can take ~20s on a loaded
+# box -- so allow generous time for RENODE_READY.
 RPC_PORT=""
-for _ in $(seq 1 60); do
+for _ in $(seq 1 "${RENODE_READY_TIMEOUT:-180}"); do
   RPC_PORT="$(sed -n 's/^RPC_PORT=//p' renode_serve.out | head -1)"
   [ -n "$RPC_PORT" ] && grep -q RENODE_READY renode_serve.out && break
   sleep 1
 done
 [ -n "$RPC_PORT" ] || { echo "!! Renode never reported RPC_PORT"; cat renode_serve.err; exit 1; }
-echo ">>> Renode RPC UART on TCP :$RPC_PORT"
+echo ">>> Renode Studio USB CDC relayed on TCP :$RPC_PORT"
 
 echo ">>> [2/3] starting WS bridge on $WS_URL"
 RPC_PORT="$RPC_PORT" WS_PORT="$WS_PORT" node bridge.mjs > bridge.out 2>&1 &

--- a/e2e/renode/run-local.sh
+++ b/e2e/renode/run-local.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Local (and CI) driver for the WebSerial<->Renode e2e:
+#   Renode(real fw over UART) <- TCP - bridge - WS -> shimmed navigator.serial
+#   in headless Chromium running the built dya-studio, driven by Playwright.
+#
+# Requirements:
+#   - Renode 1.16.1 at ~/.renode/1.16.1 (RENODE_BIN to override)
+#   - ZMK_WC_RENODE_LIB -> a checkout of cormoran/zmk-west-commands'
+#     scripts/lib/renode (the Renode harness + platforms)
+#   - DIST_DIR -> a built dya-studio dist (defaults to <repo>/dist)
+#   - a Studio-on-UART DUT ELF (arg $1)
+set -euo pipefail
+cd "$(dirname "$0")"
+REPO_ROOT="$(cd ../.. && pwd)"
+
+ELF="${1:?usage: run-local.sh <studio-on-uart.elf>}"
+export DIST_DIR="${DIST_DIR:-$REPO_ROOT/dist}"
+export ZMK_WC_RENODE_LIB="${ZMK_WC_RENODE_LIB:?set ZMK_WC_RENODE_LIB to zmk-west-commands/scripts/lib/renode}"
+export WS_PORT="${WS_PORT:-8788}"
+export WS_URL="ws://127.0.0.1:${WS_PORT}"
+export DEVICE_NAME="${DEVICE_NAME:-Renode}"
+
+pids=()
+cleanup() {
+  for p in "${pids[@]:-}"; do kill "$p" 2>/dev/null || true; done
+  # kill only our own Renode instance (scoped to this ELF), never a broad pkill
+  pgrep -af '\.renode/1\.16\.1/renode' | grep -F "$ELF" | awk '{print $1}' | xargs -r kill -9 2>/dev/null || true
+}
+trap cleanup EXIT
+
+echo ">>> [1/3] booting Renode with $ELF"
+python3 renode_serve.py "$ELF" > renode_serve.out 2> renode_serve.err &
+pids+=($!)
+
+RPC_PORT=""
+for _ in $(seq 1 60); do
+  RPC_PORT="$(sed -n 's/^RPC_PORT=//p' renode_serve.out | head -1)"
+  [ -n "$RPC_PORT" ] && grep -q RENODE_READY renode_serve.out && break
+  sleep 1
+done
+[ -n "$RPC_PORT" ] || { echo "!! Renode never reported RPC_PORT"; cat renode_serve.err; exit 1; }
+echo ">>> Renode RPC UART on TCP :$RPC_PORT"
+
+echo ">>> [2/3] starting WS bridge on $WS_URL"
+RPC_PORT="$RPC_PORT" WS_PORT="$WS_PORT" node bridge.mjs > bridge.out 2>&1 &
+pids+=($!)
+for _ in $(seq 1 20); do grep -q BRIDGE_READY bridge.out && break; sleep 0.5; done
+grep -q BRIDGE_READY bridge.out || { echo "!! bridge never ready"; cat bridge.out; exit 1; }
+
+echo ">>> [3/3] running Playwright (DEVICE_NAME=$DEVICE_NAME)"
+shift || true
+npx playwright test "$@" || { echo "renode log tail:"; tail -20 renode_serve.err; exit 1; }

--- a/e2e/renode/serial-shim.mjs
+++ b/e2e/renode/serial-shim.mjs
@@ -1,0 +1,76 @@
+// Returns the source of an init script that installs a fake `navigator.serial`
+// backed by a WebSocket. This is the shim approach ("案B"): the real dya-studio
+// app, the real @zmkfirmware/zmk-studio-ts-client serial transport, the real
+// RPC/protobuf framing and the real firmware (in Renode) all run unchanged --
+// only the browser<->OS serial driver layer is replaced by a WebSocket to the
+// bridge (there is no real serial device in CI).
+//
+// It implements exactly the SerialPort surface the ts-client uses
+// (requestPort/getPorts, port.open/getInfo/close, port.readable/.writable as
+// Web Streams) plus EventTarget so any 'connect'/'disconnect' listeners are safe.
+export function serialShimSource(wsUrl) {
+  return `(() => {
+  const WS_URL = ${JSON.stringify(wsUrl)};
+  const DEBUG = ${JSON.stringify(process.env.POC_DEBUG ? true : false)};
+  const log = (...a) => { if (DEBUG) console.log("SHIM", ...a); };
+
+  class FakeSerialPort extends EventTarget {
+    constructor() { super(); this._ws = null; this.readable = null; this.writable = null; }
+    getInfo() { return { usbVendorId: 0x1d50, usbProductId: 0x615e }; }
+    async open(_options) {
+      const ws = new WebSocket(WS_URL);
+      ws.binaryType = "arraybuffer";
+      this._ws = ws;
+      await new Promise((resolve, reject) => {
+        ws.onopen = () => resolve();
+        ws.onerror = () => reject(new DOMException("WebSocket bridge failed", "NetworkError"));
+      });
+
+      this.readable = new ReadableStream({
+        start(controller) {
+          ws.onmessage = (ev) => {
+            const chunk = ev.data instanceof ArrayBuffer ? new Uint8Array(ev.data) : new Uint8Array(0);
+            if (!chunk.byteLength) return;
+            log("read", chunk.byteLength, "B");
+            controller.enqueue(chunk);
+            // Record raw device->host bytes so a test can prove the real
+            // firmware's GetDeviceInfo reply (which carries the device name)
+            // travelled the whole browser<->Renode loop.
+            let s = window.__SHIM_RX__ || "";
+            for (let i = 0; i < chunk.length; i++) s += String.fromCharCode(chunk[i]);
+            window.__SHIM_RX__ = s;
+          };
+          ws.onclose = () => { try { controller.close(); } catch (_) {} };
+        },
+        cancel() { try { ws.close(); } catch (_) {} },
+      });
+
+      this.writable = new WritableStream({
+        write(chunk) {
+          if (ws.readyState !== WebSocket.OPEN) return;
+          const u8 = chunk instanceof Uint8Array ? chunk : new Uint8Array(chunk);
+          log("write", u8.byteLength, "B");
+          ws.send(u8);
+        },
+        close() { /* stream close does not close the shared ws */ },
+        abort() { try { ws.close(); } catch (_) {} },
+      });
+    }
+    async close() {
+      try { this._ws && this._ws.close(); } catch (_) {}
+      this._ws = null; this.readable = null; this.writable = null;
+    }
+  }
+
+  const sharedPort = new FakeSerialPort();
+  const serial = new EventTarget();
+  serial.requestPort = async () => sharedPort;
+  serial.getPorts = async () => [sharedPort];
+
+  Object.defineProperty(navigator, "serial", {
+    configurable: true,
+    enumerable: true,
+    get() { return serial; },
+  });
+})();`;
+}

--- a/e2e/renode/serial-shim.mjs
+++ b/e2e/renode/serial-shim.mjs
@@ -1,9 +1,9 @@
 // Returns the source of an init script that installs a fake `navigator.serial`
-// backed by a WebSocket. This is the shim approach ("案B"): the real dya-studio
-// app, the real @zmkfirmware/zmk-studio-ts-client serial transport, the real
-// RPC/protobuf framing and the real firmware (in Renode) all run unchanged --
-// only the browser<->OS serial driver layer is replaced by a WebSocket to the
-// bridge (there is no real serial device in CI).
+// backed by a WebSocket: the real dya-studio app, the real
+// @zmkfirmware/zmk-studio-ts-client serial transport, the real RPC/protobuf
+// framing and the real firmware (in Renode) all run unchanged -- only the
+// browser<->OS serial driver layer is replaced by a WebSocket to the bridge
+// (there is no real serial device in CI).
 //
 // It implements exactly the SerialPort surface the ts-client uses
 // (requestPort/getPorts, port.open/getInfo/close, port.readable/.writable as
@@ -11,7 +11,7 @@
 export function serialShimSource(wsUrl) {
   return `(() => {
   const WS_URL = ${JSON.stringify(wsUrl)};
-  const DEBUG = ${JSON.stringify(process.env.POC_DEBUG ? true : false)};
+  const DEBUG = ${JSON.stringify(process.env.E2E_DEBUG ? true : false)};
   const log = (...a) => { if (DEBUG) console.log("SHIM", ...a); };
 
   class FakeSerialPort extends EventTarget {

--- a/e2e/renode/serve.mjs
+++ b/e2e/renode/serve.mjs
@@ -1,0 +1,36 @@
+// Minimal static file server for the built dya-studio `dist/` (SPA: unknown
+// paths fall back to index.html). No dependencies.
+import http from "node:http";
+import { readFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import path from "node:path";
+
+const ROOT = path.resolve(process.env.DIST_DIR || "dist");
+const PORT = Number(process.env.SERVE_PORT || 4173);
+const MIME = {
+  ".html": "text/html",
+  ".js": "text/javascript",
+  ".mjs": "text/javascript",
+  ".css": "text/css",
+  ".json": "application/json",
+  ".svg": "image/svg+xml",
+  ".png": "image/png",
+  ".wasm": "application/wasm",
+  ".woff2": "font/woff2",
+};
+
+http
+  .createServer(async (req, res) => {
+    try {
+      let rel = decodeURIComponent(new URL(req.url, "http://x").pathname);
+      let file = path.join(ROOT, rel);
+      if (!file.startsWith(ROOT)) return res.writeHead(403).end();
+      if (rel === "/" || !existsSync(file)) file = path.join(ROOT, "index.html");
+      const body = await readFile(file);
+      res.writeHead(200, { "content-type": MIME[path.extname(file)] || "application/octet-stream" });
+      res.end(body);
+    } catch (e) {
+      res.writeHead(500).end(String(e));
+    }
+  })
+  .listen(PORT, () => console.error(`serve: dist on http://127.0.0.1:${PORT} (root ${ROOT})`));

--- a/e2e/renode/tests/connect.spec.ts
+++ b/e2e/renode/tests/connect.spec.ts
@@ -3,8 +3,8 @@ import { serialShimSource } from "../serial-shim.mjs";
 
 const WS_URL = process.env.WS_URL || "ws://127.0.0.1:8788";
 
-// Name the DUT firmware advertises via GetDeviceInfo. The POC ships the
-// zmk-west-commands real studio-rpc-usb-uart DUT (renode_tester shield → name
+// Name the DUT firmware advertises via GetDeviceInfo. The default DUT is
+// zmk-west-commands' real studio-rpc-usb-uart image (renode_tester shield → name
 // "Renode"); override for a real dya build.
 const DEVICE_NAME = process.env.DEVICE_NAME || "Renode";
 
@@ -15,10 +15,10 @@ test("dya-studio (real app) fully connects to real firmware in Renode over WebSe
   page.on("console", (m) => {
     const line = `[${m.type()}] ${m.text()}`;
     logs.push(line);
-    if (process.env.POC_DEBUG) console.log("PAGE " + line);
+    if (process.env.E2E_DEBUG) console.log("PAGE " + line);
   });
   page.on("pageerror", (e) => {
-    if (process.env.POC_DEBUG) console.log("PAGE ERROR " + e.message);
+    if (process.env.E2E_DEBUG) console.log("PAGE ERROR " + e.message);
   });
 
   // 1) install the fake navigator.serial (backed by the WS bridge -> the DUT's
@@ -67,8 +67,7 @@ test("dya-studio (real app) fully connects to real firmware in Renode over WebSe
   // 5) SECOND PROOF — the app reaches the FULLY-CONNECTED screen. The app's
   //    connect handshake (via @cormoran/zmk-studio-react-hook's useZMKApp) does
   //    far more than GetDeviceInfo — including replies well over the ~30 bytes
-  //    that Renode's UARTE TX-IRQ model used to stall (which capped the earlier
-  //    UART-based version of this POC at GetDeviceInfo). The emulated USB CDC
+  //    that Renode's UARTE TX-IRQ model stalls on. The emulated USB CDC
   //    path drains those large bursts, so `isConnected` flips true and the app
   //    swaps the splash for the connected layout: the header shows the device's
   //    own name and the splash "Connect via USB" button is gone.

--- a/e2e/renode/tests/connect.spec.ts
+++ b/e2e/renode/tests/connect.spec.ts
@@ -4,11 +4,11 @@ import { serialShimSource } from "../serial-shim.mjs";
 const WS_URL = process.env.WS_URL || "ws://127.0.0.1:8788";
 
 // Name the DUT firmware advertises via GetDeviceInfo. The POC ships the
-// zmk-west-commands renode-studio-uart DUT ("Module Test"); override for a
-// real dya build.
-const DEVICE_NAME = process.env.DEVICE_NAME || "Module Test";
+// zmk-west-commands real studio-rpc-usb-uart DUT (renode_tester shield → name
+// "Renode"); override for a real dya build.
+const DEVICE_NAME = process.env.DEVICE_NAME || "Renode";
 
-test("dya-studio (real app) talks to the real firmware in Renode over WebSerial", async ({
+test("dya-studio (real app) fully connects to real firmware in Renode over WebSerial", async ({
   page,
 }) => {
   const logs: string[] = [];
@@ -21,7 +21,8 @@ test("dya-studio (real app) talks to the real firmware in Renode over WebSerial"
     if (process.env.POC_DEBUG) console.log("PAGE ERROR " + e.message);
   });
 
-  // 1) install the fake navigator.serial (backed by the WS bridge -> Renode UART)
+  // 1) install the fake navigator.serial (backed by the WS bridge -> the DUT's
+  //    emulated USB CDC in Renode)
   await page.addInitScript(serialShimSource(WS_URL));
   // 2) pre-accept the connection notice + force English so the picker/notice
   //    don't get in the way (both are pure UX, unrelated to the transport).
@@ -46,18 +47,16 @@ test("dya-studio (real app) talks to the real firmware in Renode over WebSerial"
 
   // 3) click the REAL "Connect via USB" button -> the app's ts-client serial
   //    transport -> navigator.serial.requestPort()/open() -> our shim -> WS ->
-  //    bridge -> Renode UART -> the real ZMK firmware.
+  //    bridge -> the DUT's emulated USB CDC -> the real ZMK firmware.
   const usbButton = page.getByRole("button", { name: /Connect via USB/i });
   await expect(usbButton).toBeVisible();
   await usbButton.click({ force: true });
 
-  // 4) PROOF of the end-to-end loop: the real firmware's GetDeviceInfo reply,
-  //    which carries the device's own name, must arrive back in the browser's
-  //    (shimmed) WebSerial stream. This is a full protobuf RPC round-trip:
-  //    the app framed+encoded a real Request, the emulated firmware decoded it,
-  //    ran the real handler, and framed+encoded a real Response that the app
-  //    received. Asserting on the received bytes (rather than the fully-
-  //    connected UI) is deliberate -- see the KNOWN LIMITATION below.
+  // 4) FIRST PROOF — the loop is live: the real firmware's GetDeviceInfo reply,
+  //    which carries the device's own name, arrives back in the browser's
+  //    (shimmed) WebSerial stream. This is a full protobuf RPC round-trip: the
+  //    app framed+encoded a real Request, the emulated firmware decoded it, ran
+  //    the real handler, and framed+encoded a real Response the app received.
   await expect
     .poll(() => page.evaluate(() => (window as any).__SHIM_RX__ || ""), {
       timeout: 60_000,
@@ -65,13 +64,16 @@ test("dya-studio (real app) talks to the real firmware in Renode over WebSerial"
     })
     .toContain(DEVICE_NAME);
 
-  // KNOWN LIMITATION (documented, pre-existing, NOT a browser-integration bug):
-  // the app's full connect handshake then issues GetCustomSubsystems, whose
-  // reply is >30 bytes. Renode's nRF52840 UARTE TX-IRQ model stalls partway
-  // through any Studio response of ~>=30 framed bytes (confirmed: raising
-  // CONFIG_ZMK_STUDIO_RPC_TX_BUF_SIZE 64->2048 did NOT change the stall point,
-  // ruling out buffer size and pointing at the emulator's UARTE TX-IRQ model).
-  // So the UI does not reach the fully-connected screen under Renode today.
-  // On real hardware, or once zmk-west-commands' Renode UARTE model drains
-  // large TX bursts, this same test can assert the connected UI instead.
+  // 5) SECOND PROOF — the app reaches the FULLY-CONNECTED screen. The app's
+  //    connect handshake (via @cormoran/zmk-studio-react-hook's useZMKApp) does
+  //    far more than GetDeviceInfo — including replies well over the ~30 bytes
+  //    that Renode's UARTE TX-IRQ model used to stall (which capped the earlier
+  //    UART-based version of this POC at GetDeviceInfo). The emulated USB CDC
+  //    path drains those large bursts, so `isConnected` flips true and the app
+  //    swaps the splash for the connected layout: the header shows the device's
+  //    own name and the splash "Connect via USB" button is gone.
+  await expect(page.locator("header").getByText(DEVICE_NAME)).toBeVisible({
+    timeout: 60_000,
+  });
+  await expect(usbButton).toBeHidden();
 });

--- a/e2e/renode/tests/connect.spec.ts
+++ b/e2e/renode/tests/connect.spec.ts
@@ -1,0 +1,72 @@
+import { test, expect } from "@playwright/test";
+import { serialShimSource } from "../serial-shim.mjs";
+
+const WS_URL = process.env.WS_URL || "ws://127.0.0.1:8788";
+
+// Name the DUT firmware advertises via GetDeviceInfo. The POC ships the
+// zmk-west-commands renode-studio-uart DUT ("Module Test"); override for a
+// real dya build.
+const DEVICE_NAME = process.env.DEVICE_NAME || "Module Test";
+
+test("dya-studio (real app) talks to the real firmware in Renode over WebSerial", async ({
+  page,
+}) => {
+  const logs: string[] = [];
+  page.on("console", (m) => {
+    const line = `[${m.type()}] ${m.text()}`;
+    logs.push(line);
+    if (process.env.POC_DEBUG) console.log("PAGE " + line);
+  });
+  page.on("pageerror", (e) => {
+    if (process.env.POC_DEBUG) console.log("PAGE ERROR " + e.message);
+  });
+
+  // 1) install the fake navigator.serial (backed by the WS bridge -> Renode UART)
+  await page.addInitScript(serialShimSource(WS_URL));
+  // 2) pre-accept the connection notice + force English so the picker/notice
+  //    don't get in the way (both are pure UX, unrelated to the transport).
+  await page.addInitScript(() => {
+    try {
+      localStorage.setItem(
+        "dya-studio-connection-notice-accepted-serial",
+        "1.1.0",
+      );
+      localStorage.setItem("dya-studio-language", "en");
+    } catch {
+      /* ignore */
+    }
+  });
+
+  await page.goto("/");
+
+  // 3) click the REAL "Connect via USB" button -> the app's ts-client serial
+  //    transport -> navigator.serial.requestPort()/open() -> our shim -> WS ->
+  //    bridge -> Renode UART -> the real ZMK firmware.
+  const usbButton = page.getByRole("button", { name: /Connect via USB/i });
+  await expect(usbButton).toBeVisible();
+  await usbButton.click();
+
+  // 4) PROOF of the end-to-end loop: the real firmware's GetDeviceInfo reply,
+  //    which carries the device's own name, must arrive back in the browser's
+  //    (shimmed) WebSerial stream. This is a full protobuf RPC round-trip:
+  //    the app framed+encoded a real Request, the emulated firmware decoded it,
+  //    ran the real handler, and framed+encoded a real Response that the app
+  //    received. Asserting on the received bytes (rather than the fully-
+  //    connected UI) is deliberate -- see the KNOWN LIMITATION below.
+  await expect
+    .poll(() => page.evaluate(() => (window as any).__SHIM_RX__ || ""), {
+      timeout: 60_000,
+      message: `firmware GetDeviceInfo reply ("${DEVICE_NAME}") never reached the browser over WebSerial`,
+    })
+    .toContain(DEVICE_NAME);
+
+  // KNOWN LIMITATION (documented, pre-existing, NOT a browser-integration bug):
+  // the app's full connect handshake then issues GetCustomSubsystems, whose
+  // reply is >30 bytes. Renode's nRF52840 UARTE TX-IRQ model stalls partway
+  // through any Studio response of ~>=30 framed bytes (confirmed: raising
+  // CONFIG_ZMK_STUDIO_RPC_TX_BUF_SIZE 64->2048 did NOT change the stall point,
+  // ruling out buffer size and pointing at the emulator's UARTE TX-IRQ model).
+  // So the UI does not reach the fully-connected screen under Renode today.
+  // On real hardware, or once zmk-west-commands' Renode UARTE model drains
+  // large TX bursts, this same test can assert the connected UI instead.
+});

--- a/e2e/renode/tests/connect.spec.ts
+++ b/e2e/renode/tests/connect.spec.ts
@@ -37,6 +37,11 @@ test("dya-studio (real app) talks to the real firmware in Renode over WebSerial"
     }
   });
 
+  // The splash screen animates continuously (framer-motion rings/opacity), which
+  // keeps the connect button from ever being "stable" for a normal click in CI.
+  // Reduce motion and force the click (the button is present and visible).
+  await page.emulateMedia({ reducedMotion: "reduce" });
+
   await page.goto("/");
 
   // 3) click the REAL "Connect via USB" button -> the app's ts-client serial
@@ -44,7 +49,7 @@ test("dya-studio (real app) talks to the real firmware in Renode over WebSerial"
   //    bridge -> Renode UART -> the real ZMK firmware.
   const usbButton = page.getByRole("button", { name: /Connect via USB/i });
   await expect(usbButton).toBeVisible();
-  await usbButton.click();
+  await usbButton.click({ force: true });
 
   // 4) PROOF of the end-to-end loop: the real firmware's GetDeviceInfo reply,
   //    which carries the device's own name, must arrive back in the browser's

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -6,7 +6,7 @@ import tseslint from "typescript-eslint";
 import { defineConfig, globalIgnores } from "eslint/config";
 
 export default defineConfig([
-  globalIgnores(["dist"]),
+  globalIgnores(["dist", "e2e"]),
   {
     files: ["**/*.{ts,tsx}"],
     extends: [


### PR DESCRIPTION
## What

Run the **real dya-studio** in a headless browser and have it **fully connect**
to **real ZMK firmware** running in the [Renode](https://renode.io) emulator over
the **WebSerial** API — no hardware, in CI. This is the POC "案B" (a
`navigator.serial` shim) requested for making dya-studio testing closer to
hardware.

```
dya-studio (dist, headless Chromium)
   │  navigator.serial  ← injected shim: real API surface, ts-client unchanged
   ▼  WebSocket
bridge.mjs (Node)  ──raw TCP (transparent bytes)──▶  renode_serve.py relay
                                                          │  (Studio CDC bytes)
                                    DualCdcAcmBridge USB host ⇄ NRF_USBD_Full
                                                          │
                                                   real ZMK fw.elf in Renode
```

The app, the `@zmkfirmware/zmk-studio-ts-client` serial transport, the RPC/protobuf
framing and the firmware are **all real**; only the browser↔OS serial-driver layer
is replaced by a WebSocket bridge (there is no serial device in CI anyway). The
DUT is the exact hardware-flashable **`studio-rpc-usb-uart`** image and its Studio
RPC rides the **emulated USB CDC-ACM**, so it's the same transport class the
browser uses on real hardware.

## What changed in this refinement

The [zmk-west-commands](https://github.com/cormoran/zmk-west-commands) Renode
harness has since been restructured and stabilized. The **UART host-link this POC
originally relied on was dropped** in favor of an emulated **USB CDC** path
(`NRF_USBD_Full` + `DualCdcAcmBridge`). This PR tracks that — and, importantly,
**turns the old known limitation into the headline result**:

- The old UART transport stalled on Renode's nRF52840 UARTE TX-IRQ model for any
  Studio reply of ~≥30 framed bytes, so the app could only round-trip a bare
  `GetDeviceInfo` and never reached the connected screen.
- **USB CDC drains large device→host bursts**, so the test now asserts the app
  **fully connects**: the device's own name appears in the connected header and
  the splash screen is gone.

## Contents

- **`e2e/renode/renode_serve.py`** — boots the **real** image on the harness' USB
  platform (`boot_single_real(repl=xiao_nrf52840_usb.repl)` + `attach_dual_cdc_bridge`),
  auto-detects the Studio CDC channel, and **relays its raw byte stream over a TCP
  socket** — keeping the exact `RPC_PORT=` contract, so `bridge.mjs` /
  `serial-shim.mjs` / `serve.mjs` are essentially unchanged. Drains the console CDC
  + UART console so the firmware never back-pressures on an unread terminal.
- **`e2e/renode/tests/connect.spec.ts`** — asserts the **fully-connected screen**
  (device name in the header + splash gone), in addition to the `GetDeviceInfo`
  round-trip through the shimmed WebSerial stream.
- **`.github/workflows/renode-webserial-e2e.yml`** — opt-in (`workflow_dispatch`)
  and path-scoped; builds the real `studio-rpc-usb-uart` DUT via the current
  standalone manifest + `build-ble.yaml` (`-af ble`) on `zmk-build-arm:stable`,
  then runs the e2e.
- **eslint**: `e2e/` stays ignored (separate tooling). App `lint` / `test` /
  `build` are unchanged and pass.

## Verified

- App CI locally: `npm run lint`, `npm run build`, `npm test` (pre-commit) all green.
- e2e locally green (`1 passed`): real dya-studio dist → shimmed WebSerial → bridge
  → `renode_serve.py` USB-CDC relay → Renode → real firmware; the device name
  ("Renode") round-trips **and the app reaches the connected screen**.

## Notes for review

- The DUT is zmk-west-commands' generic real image (keyboard name `Renode`). To
  point at a **real dya keyboard**, build its own `studio-rpc-usb-uart` firmware
  and set `DEVICE_NAME` in the workflow.
- Next-fidelity step (out of scope here): export the emulated USB device to the
  host OS as a real `/dev/ttyACM*` (e.g. via USB/IP) so an **unshimmed**
  `navigator.serial` opens it — removing the shim entirely (a zmk-west-commands
  concern).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
