### PR TITLE
Add release notes page + date-based release versioning

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -12,6 +12,7 @@ When a change is user-visible, add an entry to the `upcoming` section of
 `src/i18n/releaseNotes.json`. If the `upcoming` section is missing, create it at
 the top of `releases` (`{ "version": "upcoming", "date": null, "changes": { "major": [], "minor": [], "patch": [] } }`).
 Each entry is `{ "en": "...", "ja": "..." }` (write both languages) and goes
-under `major`, `minor`, or `patch` according to its user impact. See
+under `major`, `minor`, or `patch` according to its user impact. Optionally add
+a `pr` field (a number or array of numbers) to link the pull request(s). See
 `docs/RELEASE_GUIDE.md` for the classification rules and how releases are cut.
 Purely internal changes (refactors, tests, CI) don't need an entry.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -5,3 +5,13 @@ Before starting any work, read README.md, docs/DEVELOPMENT_GUIDE.md, and docs/TE
 Use the information in these files to guide your work on the codebase.
 
 Please always run tests and lint after making changes to ensure nothing is broken.
+
+## Release notes
+
+When a change is user-visible, add an entry to the `upcoming` section of
+`src/i18n/releaseNotes.json`. If the `upcoming` section is missing, create it at
+the top of `releases` (`{ "version": "upcoming", "date": null, "changes": { "major": [], "minor": [], "patch": [] } }`).
+Each entry is `{ "en": "...", "ja": "..." }` (write both languages) and goes
+under `major`, `minor`, or `patch` according to its user impact. See
+`docs/RELEASE_GUIDE.md` for the classification rules and how releases are cut.
+Purely internal changes (refactors, tests, CI) don't need an entry.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,6 +2,17 @@
 
 <!-- Describe your changes -->
 
+## Release notes
+
+<!--
+For user-visible changes, add an entry to the `upcoming` section of
+src/i18n/releaseNotes.json (create the section if missing), in both en and ja,
+under major / minor / patch. See docs/RELEASE_GUIDE.md. Skip for internal-only
+changes.
+-->
+
+- [ ] Added an `upcoming` release notes entry, or this change is internal-only
+
 ## CLA (Contributor License Agreement)
 
 By submitting this pull request, I agree that my contributions

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,12 @@ name: Release DYA Studio
 on:
   workflow_dispatch:
 
+# Needed to commit the version bump back to main, push the tag, and create the
+# GitHub Release. If `main` is a protected branch, the pushing identity must be
+# allowed to bypass protection (or swap `token` below for a suitable PAT).
+permissions:
+  contents: write
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -11,16 +17,40 @@ jobs:
       name: cloudflare-release
     steps:
       - uses: actions/checkout@v5
+        with:
+          # Full history + tags so scripts/release.ts can resolve the next
+          # increment, and so we can push the version-bump commit to main.
+          fetch-depth: 0
       - uses: actions/setup-node@v6
         with:
           node-version: 24
       - name: Install dependencies
         run: npm ci
+
+      - name: Resolve version and update release notes
+        id: version
+        # Promotes the `upcoming` section to a dated YYYY.MM.DD.N version and
+        # prepends a fresh empty `upcoming`. Exposes `version` as an output.
+        run: node scripts/release.ts
+
+      - name: Commit, tag, and push version bump
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add src/i18n/releaseNotes.json
+          git commit -m "chore(release): $VERSION"
+          git tag "v$VERSION"
+          git push origin HEAD:main
+          git push origin "v$VERSION"
+
       - name: Build
         run: npm run build
         env:
           VITE_BASE: /
           VITE_GOOGLE_ANALYTICS_ID: ${{ secrets.VITE_GOOGLE_ANALYTICS_ID }}
+
       - name: Deploy to Cloudflare Pages
         id: deploy
         uses: cloudflare/wrangler-action@v3
@@ -29,3 +59,14 @@ jobs:
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID_RELEASE }}
           environment: release
           wranglerVersion: "4.58.0"
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ steps.version.outputs.version }}
+        # The release body just deep-links to the matching section of the
+        # release notes page deployed above.
+        run: |
+          gh release create "v$VERSION" \
+            --title "$VERSION" \
+            --notes "Release notes: https://studio.dya.cormoran.works/release-notes#$VERSION"

--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@
 
 <p align="center">
   <a href="https://studio.dya.cormoran.works"><strong>🚀 Open DYA Studio →</strong></a>
+  &nbsp;·&nbsp;
+  <a href="https://dya-studio-dev.cormoran707.workers.dev/">🧪 Dev preview</a>
+  <br />
+  <sub><strong>Open DYA Studio</strong> is the stable release. <strong>Dev preview</strong> tracks the latest <code>main</code> and may be unstable.</sub>
   <br />
   <sub>No keyboard at hand? Hit the <em>Demo</em> button on the splash screen to explore every feature with a simulated keyboard.</sub>
 </p>

--- a/docs/RELEASE_GUIDE.md
+++ b/docs/RELEASE_GUIDE.md
@@ -53,6 +53,14 @@ the `upcoming` section of `src/i18n/releaseNotes.json`.**
   { "en": "Short user-facing description.", "ja": "利用者向けの短い説明。" }
   ```
 
+- Optionally reference the pull request(s) with a `pr` field — a single number
+  or an array. It renders as a `#123` link to GitHub on the release notes page:
+
+  ```json
+  { "en": "Added X.", "ja": "X を追加しました。", "pr": 153 }
+  { "en": "Reworked Y.", "ja": "Y を刷新しました。", "pr": [150, 128] }
+  ```
+
 - Write from the user's perspective (what changed for them), not the
   implementation. Keep each entry to one sentence.
 

--- a/docs/RELEASE_GUIDE.md
+++ b/docs/RELEASE_GUIDE.md
@@ -1,0 +1,75 @@
+# Release & Release Notes Guide
+
+DYA Studio ships from `main` via a manually triggered release, and every release
+is recorded in the in-app **Release Notes** page
+(`https://studio.dya.cormoran.works/release-notes`).
+
+## Versioning
+
+Versions are date based: `YYYY.MM.DD.N`, where `N` starts at `0` and increments
+for each additional release on the same day (e.g. `2026.04.01.0`,
+`2026.04.01.1`). The version is decided by the release CI at dispatch time — you
+never set it by hand.
+
+## How a release happens
+
+The **Release DYA Studio** workflow (`.github/workflows/release.yml`) is run
+manually (`workflow_dispatch`). It:
+
+1. Runs `node scripts/release.ts`, which resolves the next `YYYY.MM.DD.N` from
+   today's date and existing git tags, then rewrites
+   `src/i18n/releaseNotes.json`: the `upcoming` section becomes that version
+   (dated today) and a fresh empty `upcoming` is prepended.
+2. Commits that change to `main`, tags it `vYYYY.MM.DD.N`, and pushes.
+3. Builds and deploys to Cloudflare Pages.
+4. Creates a GitHub Release whose body links to the matching section of the
+   release notes page (`/release-notes#YYYY.MM.DD.N`).
+
+The version-resolution and JSON-rewrite logic lives in
+`src/lib/releaseVersioning.ts` and is unit-tested
+(`src/lib/__tests__/releaseVersioning.test.ts`).
+
+## Editing release notes in a PR
+
+**When your PR adds or changes something a user would notice, add an entry to
+the `upcoming` section of `src/i18n/releaseNotes.json`.**
+
+- The `upcoming` section is the first entry in `releases`, with
+  `"version": "upcoming"`. **If it is missing, create it** at the top of
+  `releases`:
+
+  ```json
+  {
+    "version": "upcoming",
+    "date": null,
+    "changes": { "major": [], "minor": [], "patch": [] }
+  }
+  ```
+
+- Add each change as an object under the right category with **both English and
+  Japanese** text:
+
+  ```json
+  { "en": "Short user-facing description.", "ja": "利用者向けの短い説明。" }
+  ```
+
+- Write from the user's perspective (what changed for them), not the
+  implementation. Keep each entry to one sentence.
+
+Purely internal changes (refactors, test-only changes, CI tweaks, dependency
+bumps with no user-visible effect) do **not** need an entry.
+
+## Classifying a change: major / minor / patch
+
+Put each entry under the category that matches its user impact:
+
+- **major** — new capability or a significant, visible change to how the app
+  works: a new tab/page, a new editor, a redesign, a new integration, or
+  anything that changes existing behavior in a way users must notice.
+- **minor** — a new but self-contained enhancement to existing functionality:
+  an added option, a new control, a quality-of-life improvement, a performance
+  win users can feel.
+- **patch** — bug fixes, small polish, copy/wording updates, and other
+  corrections that don't add functionality.
+
+When in doubt, pick the lower category (a fix is a `patch`, not a `minor`).

--- a/docs/RELEASE_GUIDE.md
+++ b/docs/RELEASE_GUIDE.md
@@ -64,6 +64,28 @@ the `upcoming` section of `src/i18n/releaseNotes.json`.**
 - Write from the user's perspective (what changed for them), not the
   implementation. Keep each entry to one sentence.
 
+### Optional release summary
+
+A release can carry an optional `summary` above the categorized changes — a
+`lead` sentence and a few `highlights` — for a human overview of a big release.
+Both are bilingual `{ "en": ..., "ja": ... }`. Add it to the `upcoming` section
+(it carries into the release), and only when it adds value:
+
+```json
+{
+  "version": "upcoming",
+  "date": null,
+  "summary": {
+    "lead": {
+      "en": "A big update across the board.",
+      "ja": "全体的に大規模にアップデートしました。"
+    },
+    "highlights": [{ "en": "Added X.", "ja": "X を追加しました。" }]
+  },
+  "changes": { "major": [], "minor": [], "patch": [] }
+}
+```
+
 Purely internal changes (refactors, test-only changes, CI tweaks, dependency
 bumps with no user-visible effect) do **not** need an entry.
 

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -1,0 +1,78 @@
+/**
+ * Release CLI, run by `.github/workflows/release.yml` on a manual dispatch.
+ *
+ * It resolves the next `YYYY.MM.DD.N` version from today's date and the
+ * existing git tags, then rewrites `src/i18n/releaseNotes.json`: the
+ * `upcoming` section becomes that version (dated today) and a fresh empty
+ * `upcoming` is prepended. The workflow commits the result, pushes, builds,
+ * deploys, and creates a matching GitHub Release.
+ *
+ * The version-resolution and JSON-rewrite logic lives in
+ * `src/lib/releaseVersioning.ts` so it is unit-tested by Jest; this file only
+ * does the filesystem/git plumbing.
+ *
+ * Run with Node 24's built-in TypeScript support:
+ *   node scripts/release.ts
+ * Optional env:
+ *   RELEASE_DATE=YYYY-MM-DD   override the release date (defaults to UTC today)
+ *   GITHUB_OUTPUT=<file>      when set, appends `version=<version>`
+ */
+import { execSync } from "node:child_process";
+import { readFileSync, writeFileSync, appendFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import {
+  applyRelease,
+  nextReleaseVersion,
+} from "../src/lib/releaseVersioning.ts";
+import type { ReleaseNotesData } from "../src/i18n/releaseNotes.ts";
+
+const RELEASE_NOTES_PATH = fileURLToPath(
+  new URL("../src/i18n/releaseNotes.json", import.meta.url),
+);
+
+/** UTC `YYYY-MM-DD` for the release date (overridable for reproducibility). */
+function releaseDateIso(): string {
+  const override = process.env.RELEASE_DATE;
+  if (override) {
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(override)) {
+      throw new Error(`Invalid RELEASE_DATE: ${override} (want YYYY-MM-DD)`);
+    }
+    return override;
+  }
+  return new Date().toISOString().slice(0, 10);
+}
+
+/** Existing released versions, derived from `vX` git tags. */
+function existingVersions(): string[] {
+  let raw = "";
+  try {
+    raw = execSync("git tag --list", { encoding: "utf8" });
+  } catch {
+    return [];
+  }
+  return raw
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((tag) => (tag.startsWith("v") ? tag.slice(1) : tag));
+}
+
+function main(): void {
+  const dateIso = releaseDateIso();
+  const dateDots = dateIso.replaceAll("-", ".");
+  const version = nextReleaseVersion(dateDots, existingVersions());
+
+  const data = JSON.parse(
+    readFileSync(RELEASE_NOTES_PATH, "utf8"),
+  ) as ReleaseNotesData;
+  const updated = applyRelease(data, version, dateIso);
+  writeFileSync(RELEASE_NOTES_PATH, JSON.stringify(updated, null, 2) + "\n");
+
+  // Expose the resolved version to the workflow.
+  process.stdout.write(`${version}\n`);
+  if (process.env.GITHUB_OUTPUT) {
+    appendFileSync(process.env.GITHUB_OUTPUT, `version=${version}\n`);
+  }
+}
+
+main();

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,7 @@ import {
 } from "@tabler/icons-react";
 
 import { SplashScreen } from "./components/SplashScreen";
+import { ReleaseNotesPage, RELEASE_NOTES_PATH } from "./pages/ReleaseNotesPage";
 import { ReconnectingOverlay } from "./components/ReconnectingOverlay";
 import {
   DeviceConnectionProvider,
@@ -116,12 +117,34 @@ function AppContent() {
   const [devtoolOpen, setDevtoolOpen] = useState(false);
   const activeTab = tabs.some((tab) => tab.id === urlTab) ? urlTab : "home";
 
+  // The release notes page is a standalone, connection-independent route so it
+  // stays reachable from the splash screen and via GitHub Release deep links.
+  const [pathname, setPathname] = useState(() => window.location.pathname);
   useEffect(() => {
-    // Canonicalize unknown paths (e.g. a stale/typo'd link) to the home tab.
-    if (urlTab !== activeTab && window.location.pathname !== "/") {
+    const onPopState = () => setPathname(window.location.pathname);
+    window.addEventListener("popstate", onPopState);
+    return () => window.removeEventListener("popstate", onPopState);
+  }, []);
+  const navigatePath = useCallback((path: string) => {
+    if (window.location.pathname !== path) {
+      window.history.pushState(null, "", path);
+    }
+    // Notify both this route state and useUrlTab's own popstate listener.
+    window.dispatchEvent(new PopStateEvent("popstate"));
+  }, []);
+  const onReleaseNotes = pathname === RELEASE_NOTES_PATH;
+
+  useEffect(() => {
+    // Canonicalize unknown paths (e.g. a stale/typo'd link) to the home tab,
+    // but leave the standalone release notes route alone.
+    if (
+      !onReleaseNotes &&
+      urlTab !== activeTab &&
+      window.location.pathname !== "/"
+    ) {
       window.history.replaceState(null, "", "/");
     }
-  }, [urlTab, activeTab]);
+  }, [urlTab, activeTab, onReleaseNotes]);
 
   const setActiveTabWithTracking = useCallback(
     (tabId: string) => {
@@ -136,6 +159,10 @@ function AppContent() {
     },
     [navigateToTab, tabs],
   );
+
+  if (onReleaseNotes) {
+    return <ReleaseNotesPage onBack={() => navigatePath("/")} />;
+  }
 
   return (
     <>
@@ -157,6 +184,7 @@ function AppContent() {
                 onConnect={connection.onConnect}
                 isConnecting={connection.isLoading}
                 error={connection.error}
+                onShowReleaseNotes={() => navigatePath(RELEASE_NOTES_PATH)}
               />
             </motion.div>
           )

--- a/src/components/SplashScreen.tsx
+++ b/src/components/SplashScreen.tsx
@@ -11,11 +11,14 @@ import { ConnectionNoticeDialog } from "./ConnectionNoticeDialog";
 import { hasAcceptedNotice } from "../lib/connectionNoticeStorage";
 import { LanguageToggle } from "./LanguageToggle";
 import { useLanguage } from "../hooks/useLanguage";
+import { getCurrentVersion } from "../i18n/releaseNotes";
 
 interface SplashScreenProps {
   onConnect: (method: ConnectionMethod) => void;
   isConnecting: boolean;
   error: string | null;
+  /** Navigate to the standalone release notes page. */
+  onShowReleaseNotes: () => void;
 }
 
 function LoadingDots() {
@@ -53,8 +56,10 @@ export function SplashScreen({
   onConnect,
   isConnecting,
   error,
+  onShowReleaseNotes,
 }: SplashScreenProps) {
   const { t } = useLanguage();
+  const version = getCurrentVersion();
   // Dialog state
   const [showNotice, setShowNotice] = useState(false);
   const [pendingMethod, setPendingMethod] = useState<ConnectionMethod | null>(
@@ -280,6 +285,19 @@ export function SplashScreen({
         </a>
         .
       </motion.p>
+
+      {/* Release notes link */}
+      <motion.button
+        onClick={onShowReleaseNotes}
+        className="absolute bottom-5 text-xs font-light tracking-wider text-[var(--color-text-muted)] hover:text-[var(--color-electric)] transition-colors underline"
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        transition={{ delay: 1.1 }}
+      >
+        {version
+          ? t("Release notes ({{version}})", { version })
+          : t("Release notes")}
+      </motion.button>
 
       {/* Connection Notice Dialog */}
       <ConnectionNoticeDialog

--- a/src/i18n/releaseNotes.json
+++ b/src/i18n/releaseNotes.json
@@ -11,11 +11,13 @@
           },
           {
             "en": "Redesigned Trackball tab with live sensor streaming and advanced PMW3610 driver settings.",
-            "ja": "トラックボールタブを再設計。センサーのライブストリーミング表示と PMW3610 ドライバの詳細設定に対応しました。"
+            "ja": "トラックボールタブを再設計。センサーのライブストリーミング表示と PMW3610 ドライバの詳細設定に対応しました。",
+            "pr": 138
           },
           {
             "en": "Macro and Combo tabs merged into a single Macro & Combo tab, with runtime macro and combo editors.",
-            "ja": "マクロタブとコンボタブを 1 つの Macro & Combo タブに統合し、ランタイムマクロ・コンボエディタを追加しました。"
+            "ja": "マクロタブとコンボタブを 1 つの Macro & Combo タブに統合し、ランタイムマクロ・コンボエディタを追加しました。",
+            "pr": 136
           },
           {
             "en": "Custom Subsystems support: browse and edit vendor-specific settings (e.g. fast-keymap, setting-expose) exposed by the keyboard.",
@@ -27,7 +29,8 @@
           },
           {
             "en": "Japanese localization: the entire UI is now available in Japanese, auto-detected from your browser.",
-            "ja": "日本語ローカライズに対応。UI 全体が日本語で利用でき、ブラウザ設定から自動判定します。"
+            "ja": "日本語ローカライズに対応。UI 全体が日本語で利用でき、ブラウザ設定から自動判定します。",
+            "pr": 142
           },
           {
             "en": "Faster keymap loading via the fast-keymap module with incremental per-layer loading and an official-protocol fallback.",
@@ -41,7 +44,8 @@
           },
           {
             "en": "Keymap: rename layers, delete and individually restore layers, and a key-layout mode in the keycode selector.",
-            "ja": "キーマップ：レイヤー名の変更、レイヤーの削除と個別復元、キーコードセレクタのキーレイアウト表示モードを追加しました。"
+            "ja": "キーマップ：レイヤー名の変更、レイヤーの削除と個別復元、キーコードセレクタのキーレイアウト表示モードを追加しました。",
+            "pr": 143
           },
           {
             "en": "Keymap: highlight keys that differ from the default, per-key reset-to-default, and Discard/Reset controls.",
@@ -49,7 +53,8 @@
           },
           {
             "en": "Settings: factory reset action and a redesigned, lazy-loaded advanced settings table.",
-            "ja": "設定：ファクトリーリセット操作と、遅延読み込み対応の刷新された詳細設定テーブルを追加しました。"
+            "ja": "設定：ファクトリーリセット操作と、遅延読み込み対応の刷新された詳細設定テーブルを追加しました。",
+            "pr": [150, 128]
           },
           {
             "en": "Auto-reconnect to the last used serial port on page load, with a reconnecting indicator.",
@@ -65,7 +70,8 @@
           },
           {
             "en": "Anonymous usage analytics to help prioritize improvements (no keymap or configuration data is ever sent).",
-            "ja": "改善の優先度付けのため匿名の利用状況分析を追加しました（キーマップや設定データは一切送信されません）。"
+            "ja": "改善の優先度付けのため匿名の利用状況分析を追加しました（キーマップや設定データは一切送信されません）。",
+            "pr": 145
           }
         ],
         "patch": [

--- a/src/i18n/releaseNotes.json
+++ b/src/i18n/releaseNotes.json
@@ -1,0 +1,88 @@
+{
+  "releases": [
+    {
+      "version": "upcoming",
+      "date": null,
+      "changes": {
+        "major": [
+          {
+            "en": "New Connection tab (evolved from the BLE tab) with OS detection and a default-layer selector for supported keyboards.",
+            "ja": "接続タブを刷新（旧 BLE タブ）。対応キーボード向けに OS 検出とデフォルトレイヤー選択の UI を追加しました。"
+          },
+          {
+            "en": "Redesigned Trackball tab with live sensor streaming and advanced PMW3610 driver settings.",
+            "ja": "トラックボールタブを再設計。センサーのライブストリーミング表示と PMW3610 ドライバの詳細設定に対応しました。"
+          },
+          {
+            "en": "Macro and Combo tabs merged into a single Macro & Combo tab, with runtime macro and combo editors.",
+            "ja": "マクロタブとコンボタブを 1 つの Macro & Combo タブに統合し、ランタイムマクロ・コンボエディタを追加しました。"
+          },
+          {
+            "en": "Custom Subsystems support: browse and edit vendor-specific settings (e.g. fast-keymap, setting-expose) exposed by the keyboard.",
+            "ja": "カスタムサブシステムに対応。キーボードが公開するベンダー独自設定（fast-keymap、setting-expose など）を参照・編集できます。"
+          },
+          {
+            "en": "New Troubleshooting tab (replacing the Battery tab) with human-readable crash reasons and accurate device counts.",
+            "ja": "トラブルシューティングタブを追加（旧バッテリータブを置き換え）。クラッシュ理由を分かりやすく表示し、デバイス数を正確に集計します。"
+          },
+          {
+            "en": "Japanese localization: the entire UI is now available in Japanese, auto-detected from your browser.",
+            "ja": "日本語ローカライズに対応。UI 全体が日本語で利用でき、ブラウザ設定から自動判定します。"
+          },
+          {
+            "en": "Faster keymap loading via the fast-keymap module with incremental per-layer loading and an official-protocol fallback.",
+            "ja": "fast-keymap モジュールによりキーマップ読み込みを高速化。レイヤーごとの逐次読み込みに対応し、非対応時は公式プロトコルにフォールバックします。"
+          }
+        ],
+        "minor": [
+          {
+            "en": "URL-based routing for tabs — every tab is now directly linkable, shareable, and works with browser back/forward.",
+            "ja": "タブの URL ルーティングに対応。各タブに直接リンク・共有でき、ブラウザの戻る/進むにも対応しました。"
+          },
+          {
+            "en": "Keymap: rename layers, delete and individually restore layers, and a key-layout mode in the keycode selector.",
+            "ja": "キーマップ：レイヤー名の変更、レイヤーの削除と個別復元、キーコードセレクタのキーレイアウト表示モードを追加しました。"
+          },
+          {
+            "en": "Keymap: highlight keys that differ from the default, per-key reset-to-default, and Discard/Reset controls.",
+            "ja": "キーマップ：デフォルトと異なるキーのハイライト、キー単位のデフォルト復元、破棄/リセット操作を追加しました。"
+          },
+          {
+            "en": "Settings: factory reset action and a redesigned, lazy-loaded advanced settings table.",
+            "ja": "設定：ファクトリーリセット操作と、遅延読み込み対応の刷新された詳細設定テーブルを追加しました。"
+          },
+          {
+            "en": "Auto-reconnect to the last used serial port on page load, with a reconnecting indicator.",
+            "ja": "ページ読み込み時に前回使用したシリアルポートへ自動再接続し、再接続中インジケータを表示します。"
+          },
+          {
+            "en": "Feature-doc tooltips on card headers explaining what each feature does.",
+            "ja": "各カード見出しに機能説明のツールチップを追加しました。"
+          },
+          {
+            "en": "Unified studio-unlock retry flow with a clear \"device is locked\" message across all tabs.",
+            "ja": "全タブで共通の Studio ロック解除リトライフローと、分かりやすい「デバイスがロックされています」表示を追加しました。"
+          },
+          {
+            "en": "Anonymous usage analytics to help prioritize improvements (no keymap or configuration data is ever sent).",
+            "ja": "改善の優先度付けのため匿名の利用状況分析を追加しました（キーマップや設定データは一切送信されません）。"
+          }
+        ],
+        "patch": [
+          {
+            "en": "Numerous stability fixes for the studio-unlock flow, including stopping infinite request loops while the device is locked.",
+            "ja": "Studio ロック解除まわりの安定性を多数改善。ロック中にリクエストが無限ループする問題などを修正しました。"
+          },
+          {
+            "en": "Rewrote the README and refreshed the on-app FAQ and home content for end users.",
+            "ja": "README を書き直し、アプリ内の FAQ・ホーム内容をエンドユーザー向けに更新しました。"
+          },
+          {
+            "en": "Improved combo validation warning contrast and various UI polish across tabs.",
+            "ja": "コンボ検証警告のコントラストを改善し、各タブの UI を細かく調整しました。"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/src/i18n/releaseNotes.json
+++ b/src/i18n/releaseNotes.json
@@ -3,6 +3,26 @@
     {
       "version": "upcoming",
       "date": null,
+      "summary": {
+        "lead": {
+          "en": "A big update across the board.",
+          "ja": "全体的に大規模にアップデートしました。"
+        },
+        "highlights": [
+          {
+            "en": "Added the long-awaited Macro and Combo features.",
+            "ja": "待望のマクロ・コンボ機能を追加しました。"
+          },
+          {
+            "en": "Dramatically faster loading over wireless — especially the second and later loads are now fast enough for everyday use.",
+            "ja": "無線接続での読み込みを爆速化。特に 2 回目以降の読み込みが超高速になり、実用的になりました。"
+          },
+          {
+            "en": "Added a Troubleshooting tab — smoother support, plus tools that help debug keyboards during development.",
+            "ja": "トラブルシューティング用のタブを追加。サポート対応を円滑にするほか、キーボード開発時のデバッグを支援する機能も含みます。"
+          }
+        ]
+      },
       "changes": {
         "major": [
           {
@@ -15,8 +35,8 @@
             "pr": 138
           },
           {
-            "en": "Macro and Combo tabs merged into a single Macro & Combo tab, with runtime macro and combo editors.",
-            "ja": "マクロタブとコンボタブを 1 つの Macro & Combo タブに統合し、ランタイムマクロ・コンボエディタを追加しました。",
+            "en": "Added Macro and Combo support — a unified Macro & Combo tab with runtime macro and combo editors.",
+            "ja": "マクロ・コンボに対応。統合された Macro & Combo タブと、ランタイムマクロ・コンボエディタを追加しました。",
             "pr": 136
           },
           {

--- a/src/i18n/releaseNotes.ts
+++ b/src/i18n/releaseNotes.ts
@@ -25,6 +25,27 @@ export const CHANGE_CATEGORIES: ChangeCategory[] = ["major", "minor", "patch"];
 export interface LocalizedChange {
   en: string;
   ja: string;
+  /**
+   * Optional related pull request number(s) on GitHub. Rendered as links on
+   * the release notes page. Accepts a single number or an array.
+   */
+  pr?: number | number[];
+}
+
+/** GitHub repository the release notes link back to. */
+export const GITHUB_REPO_URL = "https://github.com/cormoran/dya-studio";
+
+/** Normalize a change's optional `pr` field to a list of PR numbers. */
+export function prNumbers(change: LocalizedChange): number[] {
+  if (change.pr == null) {
+    return [];
+  }
+  return Array.isArray(change.pr) ? change.pr : [change.pr];
+}
+
+/** GitHub URL for a pull request number. */
+export function pullRequestUrl(pr: number): string {
+  return `${GITHUB_REPO_URL}/pull/${pr}`;
 }
 
 export interface Release {

--- a/src/i18n/releaseNotes.ts
+++ b/src/i18n/releaseNotes.ts
@@ -1,0 +1,77 @@
+/**
+ * Release notes data + helpers.
+ *
+ * The source of truth is {@link ./releaseNotes.json}. It is edited by hand in
+ * PRs (add entries to the `upcoming` release) and by the release CI, which
+ * rewrites the `upcoming` entry's version/date and prepends a fresh empty
+ * `upcoming` on every release. See docs/RELEASE_GUIDE.md.
+ *
+ * The app derives the current shipped version from this data — there is no
+ * separate version file — so a build always shows whatever the newest released
+ * entry says.
+ */
+import data from "./releaseNotes.json";
+import type { Language } from "./translations";
+import { UPCOMING } from "../lib/releaseVersioning";
+
+export { UPCOMING };
+
+/** Change severity, ordered most- to least-significant for display. */
+export type ChangeCategory = "major" | "minor" | "patch";
+
+export const CHANGE_CATEGORIES: ChangeCategory[] = ["major", "minor", "patch"];
+
+/** A single change entry, authored in both supported languages. */
+export interface LocalizedChange {
+  en: string;
+  ja: string;
+}
+
+export interface Release {
+  /** Semantic-ish version `YYYY.MM.DD.N`, or {@link UPCOMING}. */
+  version: string;
+  /** Release date `YYYY-MM-DD`, or `null` for the upcoming section. */
+  date: string | null;
+  changes: Record<ChangeCategory, LocalizedChange[]>;
+}
+
+export interface ReleaseNotesData {
+  releases: Release[];
+}
+
+const releaseNotes = data as ReleaseNotesData;
+
+/** All releases, newest first, exactly as stored (upcoming may be first). */
+export function getReleases(): Release[] {
+  return releaseNotes.releases;
+}
+
+/** True when a release is the in-progress `upcoming` section. */
+export function isUpcoming(release: Release): boolean {
+  return release.version === UPCOMING;
+}
+
+/** True when a release has no change entries in any category. */
+export function isEmptyRelease(release: Release): boolean {
+  return CHANGE_CATEGORIES.every(
+    (c) => (release.changes[c]?.length ?? 0) === 0,
+  );
+}
+
+/**
+ * The newest actually-released version, or `null` if nothing has shipped yet
+ * (only an `upcoming` section exists). Drives the version shown on the splash
+ * screen link.
+ */
+export function getCurrentVersion(): string | null {
+  const released = releaseNotes.releases.find((r) => !isUpcoming(r));
+  return released ? released.version : null;
+}
+
+/** Pick the text for a change in the active language. */
+export function localizeChange(
+  change: LocalizedChange,
+  language: Language,
+): string {
+  return change[language] || change.en;
+}

--- a/src/i18n/releaseNotes.ts
+++ b/src/i18n/releaseNotes.ts
@@ -21,15 +21,28 @@ export type ChangeCategory = "major" | "minor" | "patch";
 
 export const CHANGE_CATEGORIES: ChangeCategory[] = ["major", "minor", "patch"];
 
-/** A single change entry, authored in both supported languages. */
-export interface LocalizedChange {
+/** A piece of text authored in both supported languages. */
+export interface LocalizedText {
   en: string;
   ja: string;
+}
+
+/** A single change entry, authored in both supported languages. */
+export interface LocalizedChange extends LocalizedText {
   /**
    * Optional related pull request number(s) on GitHub. Rendered as links on
    * the release notes page. Accepts a single number or an array.
    */
   pr?: number | number[];
+}
+
+/**
+ * Optional free-form summary shown above the categorized changes — a lead
+ * sentence and a few headline highlights for the release.
+ */
+export interface ReleaseSummary {
+  lead?: LocalizedText;
+  highlights?: LocalizedText[];
 }
 
 /** GitHub repository the release notes link back to. */
@@ -53,6 +66,8 @@ export interface Release {
   version: string;
   /** Release date `YYYY-MM-DD`, or `null` for the upcoming section. */
   date: string | null;
+  /** Optional headline summary shown above the categorized changes. */
+  summary?: ReleaseSummary;
   changes: Record<ChangeCategory, LocalizedChange[]>;
 }
 
@@ -72,10 +87,17 @@ export function isUpcoming(release: Release): boolean {
   return release.version === UPCOMING;
 }
 
-/** True when a release has no change entries in any category. */
+/** True when a release has a non-empty summary (lead or highlights). */
+export function hasSummary(release: Release): boolean {
+  const s = release.summary;
+  return !!s && (!!s.lead || (s.highlights?.length ?? 0) > 0);
+}
+
+/** True when a release has no summary and no change entries in any category. */
 export function isEmptyRelease(release: Release): boolean {
-  return CHANGE_CATEGORIES.every(
-    (c) => (release.changes[c]?.length ?? 0) === 0,
+  return (
+    !hasSummary(release) &&
+    CHANGE_CATEGORIES.every((c) => (release.changes[c]?.length ?? 0) === 0)
   );
 }
 
@@ -89,10 +111,15 @@ export function getCurrentVersion(): string | null {
   return released ? released.version : null;
 }
 
+/** Pick the text of a localized value in the active language. */
+export function localizeText(text: LocalizedText, language: Language): string {
+  return text[language] || text.en;
+}
+
 /** Pick the text for a change in the active language. */
 export function localizeChange(
   change: LocalizedChange,
   language: Language,
 ): string {
-  return change[language] || change.en;
+  return localizeText(change, language);
 }

--- a/src/i18n/translations.ts
+++ b/src/i18n/translations.ts
@@ -620,6 +620,18 @@ const ja: Record<string, string> = {
   "DYA Studio is maintained by": "DYA Studio のメンテナー",
   "Special thanks to": "Special thanks to",
   "ZMK community": "ZMK community",
+  "Release notes": "リリースノート",
+  "Release notes ({{version}})": "リリースノート ({{version}})",
+  "Release Notes": "リリースノート",
+  "What's new in DYA Studio": "DYA Studio の新機能",
+  Back: "戻る",
+  Upcoming: "次回リリース予定",
+  "No upcoming changes yet.": "次回リリース予定の変更はまだありません。",
+  "No changes recorded for this release.":
+    "このリリースに記録された変更はありません。",
+  Major: "メジャー",
+  Minor: "マイナー",
+  Patch: "パッチ",
   "Connect via {{method}}": "{{method}} で接続",
   "Data Collection Notice": "データ収集に関するお知らせ",
   "DYA Studio collects your keyboard name and anonymous usage data — such as which features you use, how you connect, and connection errors — for usage analysis. No keymaps, settings, or other keyboard configuration data is ever sent; everything is handled locally on your device.":

--- a/src/lib/__tests__/releaseVersioning.test.ts
+++ b/src/lib/__tests__/releaseVersioning.test.ts
@@ -1,0 +1,113 @@
+import {
+  applyRelease,
+  emptyUpcoming,
+  isReleaseEmpty,
+  isUpcomingVersion,
+  nextReleaseVersion,
+  UPCOMING,
+} from "../releaseVersioning";
+import type { ReleaseNotesData } from "../../i18n/releaseNotes";
+
+describe("nextReleaseVersion", () => {
+  it("starts at .0 when no version exists for the date", () => {
+    expect(nextReleaseVersion("2026.04.01", [])).toBe("2026.04.01.0");
+    expect(nextReleaseVersion("2026.04.01", ["2026.03.31.0"])).toBe(
+      "2026.04.01.0",
+    );
+  });
+
+  it("increments past the highest N for the same date", () => {
+    expect(
+      nextReleaseVersion("2026.04.01", [
+        "2026.04.01.0",
+        "2026.04.01.1",
+        "2026.03.31.9",
+      ]),
+    ).toBe("2026.04.01.2");
+  });
+
+  it("ignores non-numeric or mismatched suffixes", () => {
+    expect(
+      nextReleaseVersion("2026.04.01", [
+        "2026.04.01.x",
+        "2026.04.010",
+        "upcoming",
+      ]),
+    ).toBe("2026.04.01.0");
+  });
+});
+
+describe("applyRelease", () => {
+  function seed(): ReleaseNotesData {
+    return {
+      releases: [
+        {
+          version: UPCOMING,
+          date: null,
+          changes: {
+            major: [{ en: "Big thing", ja: "大きな変更" }],
+            minor: [],
+            patch: [{ en: "Small fix", ja: "小さな修正" }],
+          },
+        },
+        {
+          version: "2026.03.31.0",
+          date: "2026-03-31",
+          changes: { major: [], minor: [], patch: [] },
+        },
+      ],
+    };
+  }
+
+  it("promotes upcoming to a dated release and prepends a fresh upcoming", () => {
+    const out = applyRelease(seed(), "2026.04.01.0", "2026-04-01");
+    expect(out.releases).toHaveLength(3);
+
+    const [fresh, released, previous] = out.releases;
+    expect(fresh.version).toBe(UPCOMING);
+    expect(isReleaseEmpty(fresh)).toBe(true);
+
+    expect(released.version).toBe("2026.04.01.0");
+    expect(released.date).toBe("2026-04-01");
+    expect(released.changes.major).toEqual([
+      { en: "Big thing", ja: "大きな変更" },
+    ]);
+    expect(released.changes.patch).toHaveLength(1);
+
+    expect(previous.version).toBe("2026.03.31.0");
+  });
+
+  it("does not mutate the input data", () => {
+    const input = seed();
+    applyRelease(input, "2026.04.01.0", "2026-04-01");
+    expect(input.releases[0].version).toBe(UPCOMING);
+    expect(input.releases).toHaveLength(2);
+  });
+
+  it("throws when there is no upcoming section", () => {
+    const data: ReleaseNotesData = {
+      releases: [
+        {
+          version: "2026.03.31.0",
+          date: "2026-03-31",
+          changes: { major: [], minor: [], patch: [] },
+        },
+      ],
+    };
+    expect(() => applyRelease(data, "2026.04.01.0", "2026-04-01")).toThrow();
+  });
+});
+
+describe("helpers", () => {
+  it("isUpcomingVersion recognizes the marker", () => {
+    expect(isUpcomingVersion(UPCOMING)).toBe(true);
+    expect(isUpcomingVersion("2026.04.01.0")).toBe(false);
+  });
+
+  it("emptyUpcoming produces an empty upcoming section", () => {
+    const u = emptyUpcoming();
+    expect(u.version).toBe(UPCOMING);
+    expect(u.date).toBeNull();
+    expect(isReleaseEmpty(u)).toBe(true);
+  });
+});

--- a/src/lib/__tests__/releaseVersioning.test.ts
+++ b/src/lib/__tests__/releaseVersioning.test.ts
@@ -84,6 +84,26 @@ describe("applyRelease", () => {
     expect(input.releases).toHaveLength(2);
   });
 
+  it("carries the upcoming summary into the release and clears it on the fresh upcoming", () => {
+    const data: ReleaseNotesData = {
+      releases: [
+        {
+          version: UPCOMING,
+          date: null,
+          summary: {
+            lead: { en: "Big update.", ja: "大型アップデート。" },
+            highlights: [{ en: "Added X.", ja: "X を追加。" }],
+          },
+          changes: { major: [], minor: [], patch: [] },
+        },
+      ],
+    };
+    const out = applyRelease(data, "2026.04.01.0", "2026-04-01");
+    expect(out.releases[0].summary).toBeUndefined();
+    expect(out.releases[1].summary?.lead?.en).toBe("Big update.");
+    expect(out.releases[1].summary?.highlights).toHaveLength(1);
+  });
+
   it("throws when there is no upcoming section", () => {
     const data: ReleaseNotesData = {
       releases: [

--- a/src/lib/releaseVersioning.ts
+++ b/src/lib/releaseVersioning.ts
@@ -1,0 +1,94 @@
+/**
+ * Pure release-versioning logic, shared by the app and the release CI script
+ * (`scripts/release.ts`).
+ *
+ * Kept free of any runtime import of `releaseNotes.json` so the Node CLI can
+ * load it via type-stripping without JSON import attributes. Types are pulled
+ * in with `import type` (erased at runtime), so there is no runtime cycle with
+ * `src/i18n/releaseNotes.ts`.
+ */
+import type {
+  ChangeCategory,
+  Release,
+  ReleaseNotesData,
+} from "../i18n/releaseNotes";
+
+/** Marker version for the not-yet-released, in-progress section. */
+export const UPCOMING = "upcoming";
+
+const CATEGORIES: ChangeCategory[] = ["major", "minor", "patch"];
+
+export function isUpcomingVersion(version: string): boolean {
+  return version === UPCOMING;
+}
+
+/** A fresh, empty `upcoming` section for the top of the release list. */
+export function emptyUpcoming(): Release {
+  return {
+    version: UPCOMING,
+    date: null,
+    changes: { major: [], minor: [], patch: [] },
+  };
+}
+
+/**
+ * Compute the next release version for a given day.
+ *
+ * Version format is `YYYY.MM.DD.N` where `N` increments per release on the
+ * same date. `dateDots` is the day as `YYYY.MM.DD`; `existingVersions` is the
+ * set of versions already released (e.g. from git tags). Returns the smallest
+ * unused `N` for that date, starting at 0.
+ */
+export function nextReleaseVersion(
+  dateDots: string,
+  existingVersions: string[],
+): string {
+  const prefix = `${dateDots}.`;
+  let maxN = -1;
+  for (const version of existingVersions) {
+    if (!version.startsWith(prefix)) continue;
+    const suffix = version.slice(prefix.length);
+    if (!/^\d+$/.test(suffix)) continue;
+    maxN = Math.max(maxN, Number(suffix));
+  }
+  return `${dateDots}.${maxN + 1}`;
+}
+
+/**
+ * Turn the `upcoming` section into a released version and prepend a fresh
+ * empty `upcoming`.
+ *
+ * @param data          the current release notes data
+ * @param version       the resolved version, e.g. `2026.04.01.0`
+ * @param dateIso       release date as `YYYY-MM-DD`
+ * @throws if there is no `upcoming` section to release
+ */
+export function applyRelease(
+  data: ReleaseNotesData,
+  version: string,
+  dateIso: string,
+): ReleaseNotesData {
+  const index = data.releases.findIndex((r) => isUpcomingVersion(r.version));
+  if (index < 0) {
+    throw new Error(
+      "No `upcoming` section found in release notes; nothing to release.",
+    );
+  }
+  const upcoming = data.releases[index];
+  const released: Release = {
+    version,
+    date: dateIso,
+    changes: {
+      major: [...(upcoming.changes.major ?? [])],
+      minor: [...(upcoming.changes.minor ?? [])],
+      patch: [...(upcoming.changes.patch ?? [])],
+    },
+  };
+  const rest = data.releases.filter((_, i) => i !== index);
+  return { releases: [emptyUpcoming(), released, ...rest] };
+}
+
+/** True when a release section has no entries in any category. */
+export function isReleaseEmpty(release: Release): boolean {
+  return CATEGORIES.every((c) => (release.changes[c]?.length ?? 0) === 0);
+}

--- a/src/lib/releaseVersioning.ts
+++ b/src/lib/releaseVersioning.ts
@@ -78,6 +78,8 @@ export function applyRelease(
   const released: Release = {
     version,
     date: dateIso,
+    // Carry the upcoming section's summary (if any) into the release.
+    ...(upcoming.summary ? { summary: upcoming.summary } : {}),
     changes: {
       major: [...(upcoming.changes.major ?? [])],
       minor: [...(upcoming.changes.minor ?? [])],

--- a/src/pages/ReleaseNotesPage.tsx
+++ b/src/pages/ReleaseNotesPage.tsx
@@ -8,7 +8,10 @@ import {
   isEmptyRelease,
   isUpcoming,
   localizeChange,
+  prNumbers,
+  pullRequestUrl,
   type ChangeCategory,
+  type LocalizedChange,
   type Release,
 } from "../i18n/releaseNotes";
 
@@ -26,6 +29,30 @@ const CATEGORY_ACCENT: Record<ChangeCategory, string> = {
   minor: "var(--color-neon)",
   patch: "var(--color-cyber)",
 };
+
+/** Renders the optional PR reference(s) for a change as GitHub links. */
+function PrLinks({ change }: { change: LocalizedChange }) {
+  const prs = prNumbers(change);
+  if (prs.length === 0) {
+    return null;
+  }
+  return (
+    <>
+      {prs.map((pr) => (
+        <a
+          key={pr}
+          href={pullRequestUrl(pr)}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="ml-1.5 align-baseline text-xs text-[var(--color-electric)] hover:text-[var(--color-neon)] hover:underline whitespace-nowrap"
+          title={`Pull request #${pr}`}
+        >
+          #{pr}
+        </a>
+      ))}
+    </>
+  );
+}
 
 function CategoryGroup({
   category,
@@ -59,6 +86,7 @@ function CategoryGroup({
             className="text-sm text-[var(--color-text-secondary)] leading-relaxed"
           >
             {localizeChange(change, language)}
+            <PrLinks change={change} />
           </li>
         ))}
       </ul>

--- a/src/pages/ReleaseNotesPage.tsx
+++ b/src/pages/ReleaseNotesPage.tsx
@@ -1,5 +1,6 @@
 import { useEffect } from "react";
 import { IconArrowLeft, IconTag } from "@tabler/icons-react";
+import DyaLogo from "../assets/dya.svg?react";
 import { useLanguage } from "../hooks/useLanguage";
 import { LanguageToggle } from "../components/LanguageToggle";
 import {
@@ -150,26 +151,43 @@ export function ReleaseNotesPage({ onBack }: { onBack: () => void }) {
   return (
     <div className="fixed inset-0 z-40 overflow-auto bg-[var(--color-bg)]">
       <div className="absolute inset-0 bg-gradient-cyber opacity-20 pointer-events-none" />
-      <div className="relative max-w-3xl mx-auto px-6 py-10">
-        <div className="flex items-center justify-between mb-8">
-          <button
-            onClick={onBack}
-            className="btn-ghost border border-[var(--color-border)] flex items-center gap-2 text-sm"
-          >
-            <IconArrowLeft size={18} />
-            {t("Back")}
-          </button>
-          <LanguageToggle />
-        </div>
 
-        <header className="mb-8">
-          <h1 className="text-2xl font-light tracking-wide text-[var(--color-text)]">
+      {/* Top bar: brand on the left (mirrors the app header), controls right */}
+      <header className="sticky top-0 z-10 border-b border-[var(--color-border)] bg-[var(--color-surface)]/80 backdrop-blur-sm">
+        <div className="max-w-5xl mx-auto px-6 py-4 flex items-center justify-between gap-4">
+          <div className="flex items-center gap-3 flex-shrink-0">
+            <DyaLogo className="w-8 h-8 [&_polygon]:fill-[var(--color-text)]" />
+            <div className="flex items-center gap-2">
+              <span className="text-lg font-light tracking-widest text-[var(--color-text)]">
+                DYA
+              </span>
+              <span className="text-xs font-light tracking-wider text-[var(--color-text-muted)] uppercase pt-1">
+                Studio
+              </span>
+            </div>
+          </div>
+          <div className="flex items-center gap-3">
+            <button
+              onClick={onBack}
+              className="btn-ghost border border-[var(--color-border)] flex items-center gap-2 text-sm"
+            >
+              <IconArrowLeft size={18} />
+              <span className="hidden sm:inline">{t("Back")}</span>
+            </button>
+            <LanguageToggle />
+          </div>
+        </div>
+      </header>
+
+      <div className="relative max-w-5xl mx-auto px-6 py-10">
+        <div className="mb-8">
+          <h1 className="text-3xl font-light tracking-wide text-[var(--color-text)]">
             {t("Release Notes")}
           </h1>
           <p className="text-sm text-[var(--color-text-muted)] mt-1">
             {t("What's new in DYA Studio")}
           </p>
-        </header>
+        </div>
 
         {releases.map((release) => (
           <ReleaseSection key={release.version} release={release} />

--- a/src/pages/ReleaseNotesPage.tsx
+++ b/src/pages/ReleaseNotesPage.tsx
@@ -1,14 +1,16 @@
 import { useEffect } from "react";
-import { IconArrowLeft, IconTag } from "@tabler/icons-react";
+import { IconArrowLeft, IconSparkles, IconTag } from "@tabler/icons-react";
 import DyaLogo from "../assets/dya.svg?react";
 import { useLanguage } from "../hooks/useLanguage";
 import { LanguageToggle } from "../components/LanguageToggle";
 import {
   CHANGE_CATEGORIES,
   getReleases,
+  hasSummary,
   isEmptyRelease,
   isUpcoming,
   localizeChange,
+  localizeText,
   prNumbers,
   pullRequestUrl,
   type ChangeCategory,
@@ -95,6 +97,40 @@ function CategoryGroup({
   );
 }
 
+/** Headline summary block shown above the categorized changes. */
+function SummaryBlock({ release }: { release: Release }) {
+  const { language } = useLanguage();
+  if (!hasSummary(release)) {
+    return null;
+  }
+  const { lead, highlights } = release.summary!;
+  return (
+    <div className="mb-6 rounded-lg border border-[var(--color-electric)]/25 bg-[var(--color-electric)]/5 p-4">
+      {lead && (
+        <p className="text-[15px] font-medium text-[var(--color-text)] leading-relaxed flex items-start gap-2">
+          <IconSparkles
+            size={18}
+            className="text-[var(--color-electric)] mt-0.5 flex-shrink-0"
+          />
+          <span>{localizeText(lead, language)}</span>
+        </p>
+      )}
+      {highlights && highlights.length > 0 && (
+        <ul className="mt-3 space-y-1.5 list-disc pl-5">
+          {highlights.map((h, i) => (
+            <li
+              key={i}
+              className="text-sm text-[var(--color-text-secondary)] leading-relaxed"
+            >
+              {localizeText(h, language)}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
 function ReleaseSection({ release }: { release: Release }) {
   const { t } = useLanguage();
   const upcoming = isUpcoming(release);
@@ -122,9 +158,16 @@ function ReleaseSection({ release }: { release: Release }) {
             : t("No changes recorded for this release.")}
         </p>
       ) : (
-        CHANGE_CATEGORIES.map((category) => (
-          <CategoryGroup key={category} category={category} release={release} />
-        ))
+        <>
+          <SummaryBlock release={release} />
+          {CHANGE_CATEGORIES.map((category) => (
+            <CategoryGroup
+              key={category}
+              category={category}
+              release={release}
+            />
+          ))}
+        </>
       )}
     </section>
   );

--- a/src/pages/ReleaseNotesPage.tsx
+++ b/src/pages/ReleaseNotesPage.tsx
@@ -1,0 +1,152 @@
+import { useEffect } from "react";
+import { IconArrowLeft, IconTag } from "@tabler/icons-react";
+import { useLanguage } from "../hooks/useLanguage";
+import { LanguageToggle } from "../components/LanguageToggle";
+import {
+  CHANGE_CATEGORIES,
+  getReleases,
+  isEmptyRelease,
+  isUpcoming,
+  localizeChange,
+  type ChangeCategory,
+  type Release,
+} from "../i18n/releaseNotes";
+
+/** Route path for the standalone release notes page. */
+export const RELEASE_NOTES_PATH = "/release-notes";
+
+const CATEGORY_LABEL: Record<ChangeCategory, string> = {
+  major: "Major",
+  minor: "Minor",
+  patch: "Patch",
+};
+
+const CATEGORY_ACCENT: Record<ChangeCategory, string> = {
+  major: "var(--color-electric)",
+  minor: "var(--color-neon)",
+  patch: "var(--color-cyber)",
+};
+
+function CategoryGroup({
+  category,
+  release,
+}: {
+  category: ChangeCategory;
+  release: Release;
+}) {
+  const { language, t } = useLanguage();
+  const changes = release.changes[category] ?? [];
+  if (changes.length === 0) {
+    return null;
+  }
+  const accent = CATEGORY_ACCENT[category];
+  return (
+    <div className="mb-4 last:mb-0">
+      <span
+        className="inline-block text-[11px] font-medium uppercase tracking-wider px-2 py-0.5 rounded-full mb-2"
+        style={{
+          color: accent,
+          backgroundColor: `color-mix(in srgb, ${accent} 12%, transparent)`,
+          border: `1px solid color-mix(in srgb, ${accent} 30%, transparent)`,
+        }}
+      >
+        {t(CATEGORY_LABEL[category])}
+      </span>
+      <ul className="list-disc pl-5 space-y-1.5">
+        {changes.map((change, i) => (
+          <li
+            key={i}
+            className="text-sm text-[var(--color-text-secondary)] leading-relaxed"
+          >
+            {localizeChange(change, language)}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function ReleaseSection({ release }: { release: Release }) {
+  const { t } = useLanguage();
+  const upcoming = isUpcoming(release);
+  const empty = isEmptyRelease(release);
+  return (
+    <section
+      id={release.version}
+      className="glass-card p-5 mb-6 scroll-mt-6 last:mb-0"
+    >
+      <div className="flex items-baseline gap-3 mb-4 flex-wrap">
+        <h2 className="text-lg font-medium text-[var(--color-text)] flex items-center gap-2">
+          <IconTag size={18} className="text-[var(--color-electric)]" />
+          {upcoming ? t("Upcoming") : release.version}
+        </h2>
+        {release.date && (
+          <span className="text-xs text-[var(--color-text-muted)]">
+            {release.date}
+          </span>
+        )}
+      </div>
+      {empty ? (
+        <p className="text-sm text-[var(--color-text-muted)]">
+          {upcoming
+            ? t("No upcoming changes yet.")
+            : t("No changes recorded for this release.")}
+        </p>
+      ) : (
+        CHANGE_CATEGORIES.map((category) => (
+          <CategoryGroup key={category} category={category} release={release} />
+        ))
+      )}
+    </section>
+  );
+}
+
+/**
+ * Standalone, connection-independent release notes page served at
+ * {@link RELEASE_NOTES_PATH}. Each release renders with `id={version}` so the
+ * release CI's GitHub Release can deep-link to `#<version>`.
+ */
+export function ReleaseNotesPage({ onBack }: { onBack: () => void }) {
+  const { t } = useLanguage();
+  const releases = getReleases();
+
+  // Deep links (e.g. #2026.04.01.0) — scroll the target into view once the
+  // sections have rendered client-side.
+  useEffect(() => {
+    const hash = decodeURIComponent(window.location.hash.replace(/^#/, ""));
+    if (hash) {
+      document.getElementById(hash)?.scrollIntoView({ block: "start" });
+    }
+  }, []);
+
+  return (
+    <div className="fixed inset-0 z-40 overflow-auto bg-[var(--color-bg)]">
+      <div className="absolute inset-0 bg-gradient-cyber opacity-20 pointer-events-none" />
+      <div className="relative max-w-3xl mx-auto px-6 py-10">
+        <div className="flex items-center justify-between mb-8">
+          <button
+            onClick={onBack}
+            className="btn-ghost border border-[var(--color-border)] flex items-center gap-2 text-sm"
+          >
+            <IconArrowLeft size={18} />
+            {t("Back")}
+          </button>
+          <LanguageToggle />
+        </div>
+
+        <header className="mb-8">
+          <h1 className="text-2xl font-light tracking-wide text-[var(--color-text)]">
+            {t("Release Notes")}
+          </h1>
+          <p className="text-sm text-[var(--color-text-muted)] mt-1">
+            {t("What's new in DYA Studio")}
+          </p>
+        </header>
+
+        {releases.map((release) => (
+          <ReleaseSection key={release.version} release={release} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -11,6 +11,7 @@
     /* Bundler mode */
     "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
     "verbatimModuleSyntax": true,
     "moduleDetection": "force",
     "noEmit": true,


### PR DESCRIPTION
## Description

Adds an in-app **Release Notes** page and a date-based release/versioning pipeline.

### What changed

**Release notes page**
- New standalone route `/release-notes` (`src/pages/ReleaseNotesPage.tsx`) that renders pre-connection, handles direct loads (for GitHub Release deep links), and gives each release an `id={version}` anchor. Bilingual (en/ja), split by version, grouped into major/minor/patch.
- Link added under the "DYA Studio is maintained by…" tagline on the splash screen, showing the current version (e.g. `Release notes (2026.07.19.0)`) once a release exists.
- Data source of truth: `src/i18n/releaseNotes.json`. The app derives the current shipped version from the newest released entry — no separate version file.

**Versioning + release CI** (`.github/workflows/release.yml`)
- Versions are `YYYY.MM.DD.N`, resolved at manual dispatch from today's date + existing git tags.
- `scripts/release.ts` promotes the `upcoming` section to that version (dated today) and prepends a fresh empty `upcoming`. The workflow then commits/pushes to `main`, tags `vX`, builds, deploys, and creates a GitHub Release whose body deep-links to `/release-notes#<version>`.
- Version-resolution and JSON-rewrite logic lives in `src/lib/releaseVersioning.ts` and is unit-tested (`src/lib/__tests__/releaseVersioning.test.ts`).

**Agent / contributor docs**
- `docs/RELEASE_GUIDE.md` documents versioning, the release flow, and the major/minor/patch classification rules.
- `.github/copilot-instructions.md` and the PR template now instruct adding an `upcoming` entry (creating the section if missing) in both en and ja for user-visible changes.

**Initial content**
- The `upcoming` section is seeded from the ~199 commits since the last release run, curated and classified.

### Reviewer notes

- The release CI pushes a version-bump commit directly to `main` via `GITHUB_TOKEN` (`contents: write`). **If `main` is protected, the pushing identity needs bypass permission, or swap the workflow `token:` for a suitable PAT.**
- No release is cut by this PR; the first version is minted the next time the release workflow is dispatched.
- Verified locally: lint, typecheck, full test suite (499 + 8 new), production build, and end-to-end in the browser (splash link, direct load, en/ja toggle, `#version` anchor scroll, back navigation).

## CLA (Contributor License Agreement)

By submitting this pull request, I agree that my contributions
are licensed under the project's current license.

I also grant the maintainer(s) of this project the right to relicense
my contributions under any license, for use in future versions of the project.
This does not affect the license of any previously released versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)