### PR TITLE
feat(import-export): add the Import/Export tab with Keyboard Abyss sign-in

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,8 +50,11 @@ jobs:
         env:
           VITE_BASE: /
           VITE_GOOGLE_ANALYTICS_ID: ${{ secrets.VITE_GOOGLE_ANALYTICS_ID }}
-          # Keyboard Abyss OAuth client. Unset -> the Import/Export tab is not
-          # registered at all.
+          # Keyboard Abyss OAuth client, registered on the production instance.
+          # Unset -> the Import/Export tab is not registered at all.
+          # VITE_ABYSS_BASE_URL is deliberately unset here so the build falls
+          # back to https://abyss.keyboard-hub.com; only dev/PR builds (test.yml)
+          # point at the staging deployment.
           VITE_ABYSS_CLIENT_ID: ${{ secrets.VITE_ABYSS_CLIENT_ID }}
 
       - name: Deploy to Cloudflare Pages

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,6 +50,9 @@ jobs:
         env:
           VITE_BASE: /
           VITE_GOOGLE_ANALYTICS_ID: ${{ secrets.VITE_GOOGLE_ANALYTICS_ID }}
+          # Keyboard Abyss OAuth client. Unset -> the Import/Export tab is not
+          # registered at all.
+          VITE_ABYSS_CLIENT_ID: ${{ secrets.VITE_ABYSS_CLIENT_ID }}
 
       - name: Deploy to Cloudflare Pages
         id: deploy

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,6 +33,11 @@ jobs:
           # deployment. The production release build (release.yml) leaves this
           # unset → no badge.
           VITE_BUILD_LABEL: ${{ github.event_name == 'pull_request' && 'PullRequest' || 'Dev' }}
+          # Keyboard Abyss OAuth client. Unset -> the Import/Export tab is not
+          # registered at all. Note that pull-request previews get a fresh
+          # origin per commit, so their redirect URI will not match a
+          # statically registered one unless the OAuth client allows a pattern.
+          VITE_ABYSS_CLIENT_ID: ${{ secrets.VITE_ABYSS_CLIENT_ID }}
       - name: Upload build artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,11 +33,20 @@ jobs:
           # deployment. The production release build (release.yml) leaves this
           # unset → no badge.
           VITE_BUILD_LABEL: ${{ github.event_name == 'pull_request' && 'PullRequest' || 'Dev' }}
+          # Dev and PR preview builds talk to the staging Abyss deployment, not
+          # production, so an experimental export never lands in the real
+          # catalog. The production release build (release.yml) leaves this
+          # unset and falls back to https://abyss.keyboard-hub.com.
+          VITE_ABYSS_BASE_URL: https://keyboard-abyss.cormoran707.workers.dev
           # Keyboard Abyss OAuth client. Unset -> the Import/Export tab is not
-          # registered at all. Note that pull-request previews get a fresh
-          # origin per commit, so their redirect URI will not match a
-          # statically registered one unless the OAuth client allows a pattern.
-          VITE_ABYSS_CLIENT_ID: ${{ secrets.VITE_ABYSS_CLIENT_ID }}
+          # registered at all. This must be a client registered on the *staging*
+          # instance above: OAuth clients live in that deployment's own
+          # database, so the production client id does not exist there.
+          #
+          # Note that pull-request previews get a fresh origin per commit, so
+          # their redirect URI will not match a statically registered one unless
+          # the OAuth client allows a pattern.
+          VITE_ABYSS_CLIENT_ID: ${{ secrets.VITE_ABYSS_CLIENT_ID_DEV }}
       - name: Upload build artifact
         uses: actions/upload-artifact@v4
         with:

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -34,6 +34,8 @@ const config: Config = {
     // @keyboard-hub/adapter-common and are covered by that repo's own test
     // suite; what DYA Studio tests here is its wiring around them.
     "^@keyboard-hub/adapter-zmk$": "<rootDir>/src/__mocks__/abyssAdapterZmk.ts",
+    "^@keyboard-hub/adapter-common$":
+      "<rootDir>/src/__mocks__/abyssAdapterCommon.ts",
     // viteEnv reads `import.meta.env`, which the CommonJS test runtime can't
     // parse; swap it for the stub in src/lib/__mocks__/viteEnv.ts. Matches any
     // relative specifier for it ("./viteEnv", "../viteEnv", "../lib/viteEnv"),

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -18,11 +18,22 @@ const config: Config = {
       "<rootDir>/node_modules/@cormoran/zmk-studio-react-hook/lib/testing/index.js",
     "^@cormoran/zmk-studio-react-hook$":
       "<rootDir>/node_modules/@cormoran/zmk-studio-react-hook/lib/index.js",
+    // Collapse the adapter's copy of the ZMK Studio client onto the fork this
+    // app uses, so `call_rpc` has a single module-level mutex per connection.
+    // Mirrored in vite.config.ts and tsconfig.app.json.
+    "^@keyboard-hub/zmk-studio-ts-client$":
+      "<rootDir>/node_modules/@zmkfirmware/zmk-studio-ts-client/lib/index.js",
+    "^@keyboard-hub/zmk-studio-ts-client/(.*)$":
+      "<rootDir>/node_modules/@zmkfirmware/zmk-studio-ts-client/lib/$1.js",
     // @keyboard-hub/abyss-client publishes untranspiled ESM TypeScript and
     // declares only the "types" and "import" export conditions, so the
     // CommonJS test runtime can neither resolve nor execute it. Swap it for a
     // stub; the real SDK is exercised by the Vite build and in the browser.
     "^@keyboard-hub/abyss-client$": "<rootDir>/src/__mocks__/abyssClientSdk.ts",
+    // Same story for the ZMK adapter. Its diff/compare helpers live in
+    // @keyboard-hub/adapter-common and are covered by that repo's own test
+    // suite; what DYA Studio tests here is its wiring around them.
+    "^@keyboard-hub/adapter-zmk$": "<rootDir>/src/__mocks__/abyssAdapterZmk.ts",
     // viteEnv reads `import.meta.env`, which the CommonJS test runtime can't
     // parse; swap it for the stub in src/lib/__mocks__/viteEnv.ts. Matches any
     // relative specifier for it ("./viteEnv", "../viteEnv", "../lib/viteEnv"),

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -18,11 +18,22 @@ const config: Config = {
       "<rootDir>/node_modules/@cormoran/zmk-studio-react-hook/lib/testing/index.js",
     "^@cormoran/zmk-studio-react-hook$":
       "<rootDir>/node_modules/@cormoran/zmk-studio-react-hook/lib/index.js",
+    // @keyboard-hub/abyss-client publishes untranspiled ESM TypeScript and
+    // declares only the "types" and "import" export conditions, so the
+    // CommonJS test runtime can neither resolve nor execute it. Swap it for a
+    // stub; the real SDK is exercised by the Vite build and in the browser.
+    "^@keyboard-hub/abyss-client$": "<rootDir>/src/__mocks__/abyssClientSdk.ts",
     // viteEnv reads `import.meta.env`, which the CommonJS test runtime can't
-    // parse; swap it for the stub in src/lib/__mocks__/viteEnv.ts.
-    "^\\./viteEnv$": "<rootDir>/src/lib/__mocks__/viteEnv.ts",
+    // parse; swap it for the stub in src/lib/__mocks__/viteEnv.ts. Matches any
+    // relative specifier for it ("./viteEnv", "../viteEnv", "../lib/viteEnv"),
+    // not just the one shape used from inside src/lib.
+    "(?:^|/)viteEnv$": "<rootDir>/src/lib/__mocks__/viteEnv.ts",
     // Mock CSS imports
     "\\.(css|less|scss|sass)$": "identity-obj-proxy",
+    // vite-plugin-svgr imports (`*.svg?react`) are React components, not URLs,
+    // so they need a component stub rather than the plain string one. Must come
+    // before the generic asset rule.
+    "\\.svg\\?react$": "<rootDir>/src/__mocks__/svgComponentMock.tsx",
     "\\.(jpg|jpeg|png|gif|svg)$": "<rootDir>/src/__mocks__/fileMock.ts",
   },
   collectCoverageFrom: [
@@ -31,7 +42,11 @@ const config: Config = {
     "!src/main.tsx",
     "!src/vite-env.d.ts",
   ],
-  transformIgnorePatterns: ["node_modules/(?!(@cormoran|@zmkfirmware)/)"],
+  // @keyboard-hub packages ship untranspiled ESM TypeScript sources, so they
+  // have to go through the transform like the ZMK client packages do.
+  transformIgnorePatterns: [
+    "node_modules/(?!(@cormoran|@zmkfirmware|@keyboard-hub)/)",
+  ],
   transform: {
     "^.+\\.(js|jsx|ts|tsx)$": [
       "ts-jest",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@keyboard-hub/adapter-common": "^0.0.1",
         "@keyboard-hub/adapter-zmk": "^0.0.1",
         "@radix-ui/react-dialog": "^1.1.15",
+        "@radix-ui/react-popover": "^1.1.23",
         "@radix-ui/react-switch": "^1.2.6",
         "@radix-ui/react-tabs": "^1.1.13",
         "@radix-ui/react-tooltip": "^1.2.8",
@@ -2946,6 +2947,417 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@radix-ui/react-popover": {
+      "version": "1.1.23",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-popover/-/react-popover-1.1.23.tgz",
+      "integrity": "sha512-mw58MrBlyHWFisTOYignD0vf/3gdcgAR+9of1s9G/38CbFiUwH1nCDkc0AUM9IrXFgN5Ue8n45j9WCgyM1sbiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-dismissable-layer": "1.1.19",
+        "@radix-ui/react-focus-guards": "1.1.6",
+        "@radix-ui/react-focus-scope": "1.1.16",
+        "@radix-ui/react-id": "1.1.4",
+        "@radix-ui/react-popper": "1.3.7",
+        "@radix-ui/react-portal": "1.1.17",
+        "@radix-ui/react-presence": "1.1.10",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-slot": "1.3.3",
+        "@radix-ui/react-use-controllable-state": "1.2.6",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.7.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/primitive": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.7.tgz",
+      "integrity": "sha512-rqWnm76nYT8HoNNqEjpgJ7Pw/DrBj5iBTrmEPo6HTX5+VJyBNOqTdv4g89G63HuR5g0AaENoAcH7Is5fF2kZ8Q==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-arrow": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.1.15.tgz",
+      "integrity": "sha512-v4zggRcjadnI+ClKDuijlQEW4tw3NoaeHc/PwpKnLoLLKNUG4InLegkstooLcRIUWCs+8L22dGURCVuFfOKfnA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.5.tgz",
+      "integrity": "sha512-+48PbAAbq3didjJxa+OaWY2ZwgAKsNiRGyeHKszblZMQ+kcpd9pAaT11cMkGEie0vsOi3QdeTE6d5Fe3Gn61kA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-context": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.2.2.tgz",
+      "integrity": "sha512-RHCUGwKHDr0hDGg4X7ma4JG4/+12qxw8rkh5QKdDldlCvtja6nUx1Ef/8HVrJze81lEsgLQlqjzjGNHantgnQA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-dismissable-layer": {
+      "version": "1.1.19",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.19.tgz",
+      "integrity": "sha512-8g4pfOL9HoKKLWGiypT+dphVqjFfmcXO5GBnhsG6zI+lxAx/8feQpr+1LSN8Re3hiZ+XkLNS4O9ztK11/LzQ6w==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-use-callback-ref": "1.1.4",
+        "@radix-ui/react-use-effect-event": "0.0.5"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-focus-guards": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.6.tgz",
+      "integrity": "sha512-RNOJjfZMTyBM6xYmV3IVGXkPjIhcBAuv48POevAXwrGJhkWZ9p1rFoIS1JFooPuT193AZmRsCPhpoVJxx6OPoQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-focus-scope": {
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.16.tgz",
+      "integrity": "sha512-wmRZ2WWLvmt6KHy2rNPOdPUjwq5xOHY02+m+udwJTn0aNIox/rkskAvJTyTLGhPK6KgrUjlJUJpgmx/+wFiFIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-use-callback-ref": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-id": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.4.tgz",
+      "integrity": "sha512-TMQp2llA+RYn7JcjnrMnz7wN4pcVttPZnRZo52PLQsoLVKzNlVwUeHmfePgTgRluXFvlD3GD5g5MOVVTJCO0qA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-popper": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.3.7.tgz",
+      "integrity": "sha512-UsJrrd7w4wuKKTdvd/DNERVlwSlUcyXzjhyDwBk+3aPOsCjOY6ZSbxuw8E6lZTjjfP8Cpd0J8VVkrYUWyGYXyg==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react-dom": "^2.0.0",
+        "@radix-ui/react-arrow": "1.1.15",
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-use-callback-ref": "1.1.4",
+        "@radix-ui/react-use-layout-effect": "1.1.4",
+        "@radix-ui/react-use-rect": "1.1.4",
+        "@radix-ui/react-use-size": "1.1.4",
+        "@radix-ui/rect": "1.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-portal": {
+      "version": "1.1.17",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.17.tgz",
+      "integrity": "sha512-vKQLcWypUnwZVvfV7UkGahH2g6ySe8M8R+zYBwPrv5byZ9QAW6cQVvNKo7GgmD+p8aYb6D9JBuvy8/WhOno2wQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-use-layout-effect": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-presence": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.10.tgz",
+      "integrity": "sha512-3wyzCQ6+ubRA+D4uv9m95JYLXxmOHp05qjrkjeA7uKHHtjpPggQzc6DAb0URl7j67oR0K2foO4ip27TiX037Bw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.10",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.10.tgz",
+      "integrity": "sha512-MucOnzh6hR5mid6VpkbglRAMYMjKLqRnGBbjXkzjK52fuQDd1qbkx78a5P40mkcnVXJdEVxm26E9OPAiUq7nBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.3.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-slot": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.3.3.tgz",
+      "integrity": "sha512-qx7oqnYbxnK9kYI9m317qmFmEgo6ywqWvbTogdj7cL9p3/yx4M48p7Rnw5z3H890cL/ow/EeWJsuTykeZVXP5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.5"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-use-callback-ref": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.4.tgz",
+      "integrity": "sha512-R6OUY2e2fA6Yn6s+VSx5KBV6Nx8LQEhu+cz7LCej18rQ1HLyg9PSC9jP/ZNx0o6FAIK9c0F1kHylzSxKsdlkrQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-use-controllable-state": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.6.tgz",
+      "integrity": "sha512-uEQJGT97ZA/TgP/Hydw47lHu+/vQj6z/0jA+WeTbK1o9Rx45GImjpD0tc3W5ad3D6XTSR6e1yEO0FvGq6WQfVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-use-effect-event": "0.0.5",
+        "@radix-ui/react-use-layout-effect": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-use-effect-event": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.5.tgz",
+      "integrity": "sha512-7cshFL8HGS/7HEiHH+9kL9HBwp2sa9yX18Knwek6KYWmXwM7pegMgta2AXMQKI+rq3JnfSj9x8wYqFMTdG1Jgg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.4.tgz",
+      "integrity": "sha512-K20DkRkUwDnxEYMBPcg3Y6voLkEy5p5QQmszZgLngKKiC7dzBR/aEuK3w1qlx2JWDUNH6FluahYdgR3BP+QbYw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-use-rect": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-rect/-/react-use-rect-1.1.4.tgz",
+      "integrity": "sha512-cSOCh6JlkmfjLyNcLiu2nB4v+nm+dkZ+Q5KHWk/soo4U7ZLiEQFKHK9/YmtBHjfCEaU43IBKQOc4/uJmCaiCTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/rect": "1.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-use-size": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-1.1.4.tgz",
+      "integrity": "sha512-D3anSY15EJoxrihpsXI6SMrmmonnQtR2ni7arO+Lfdg3O95b9hNXxONk8jA5C8ANdF/h5HMAxejgs8PWJ6rlhw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/rect": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/rect/-/rect-1.1.3.tgz",
+      "integrity": "sha512-JtyZR+mqgBibTo8xea3B6ZRmzZiM/YeVBtUkas6zMuXjAlfIFIW2FgqeM9eLyvEaYX66vr6DJMK+4U6LV0KhNw==",
+      "license": "MIT"
     },
     "node_modules/@radix-ui/react-popper": {
       "version": "1.2.8",

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,8 +19,10 @@
         "@tabler/icons-react": "^3.36.1",
         "@zmkfirmware/zmk-studio-ts-client": "github:cormoran/zmk-studio-ts-client#custom-studio-protocol+bluefy",
         "clsx": "^2.1.1",
+        "diff": "^9.0.0",
         "framer-motion": "^12.29.0",
         "react": "^19.2.0",
+        "react-diff-view": "^3.3.3",
         "react-dom": "^19.2.0"
       },
       "devDependencies": {
@@ -5445,6 +5447,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/classnames": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
+      "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==",
+      "license": "MIT"
+    },
     "node_modules/cli-cursor": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
@@ -5855,14 +5863,19 @@
       "license": "MIT"
     },
     "node_modules/diff": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
-      "integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
-      "dev": true,
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-9.0.0.tgz",
+      "integrity": "sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw==",
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
       }
+    },
+    "node_modules/diff-match-patch": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/diff-match-patch/-/diff-match-patch-1.0.5.tgz",
+      "integrity": "sha512-IayShXAgj/QMXgB0IWmKx+rOPuGMhqm5w6jvFxmVenXKIzRqTAAsbBPT3kWQeGANj3jGgvcvv4yK6SxqYmikgw==",
+      "license": "Apache-2.0"
     },
     "node_modules/diff-sequences": {
       "version": "29.6.3",
@@ -6529,6 +6542,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/gitdiff-parser": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/gitdiff-parser/-/gitdiff-parser-0.3.1.tgz",
+      "integrity": "sha512-YQJnY8aew65id8okGxKCksH3efDCJ9HzV7M9rsvd65habf39Pkh4cgYJ27AaoDMqo1X98pgNJhNMrm/kpV7UVQ==",
+      "license": "MIT"
     },
     "node_modules/glob": {
       "version": "7.2.3",
@@ -8901,7 +8920,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -9467,6 +9485,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "license": "MIT"
+    },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
@@ -9607,6 +9631,18 @@
       "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
       "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
       "license": "Apache-2.0"
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
     },
     "node_modules/lower-case": {
       "version": "2.0.2",
@@ -10377,6 +10413,23 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-diff-view": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/react-diff-view/-/react-diff-view-3.3.3.tgz",
+      "integrity": "sha512-CPveApk6n7ZbkW7T6PoptR7LWAvD9hohTHZ7WnKnu3GZkTfUB5rvg486apPo94iYVi4fZd3Nt+rtBZ5877exoQ==",
+      "license": "MIT",
+      "dependencies": {
+        "classnames": "^2.3.2",
+        "diff-match-patch": "^1.0.5",
+        "gitdiff-parser": "^0.3.1",
+        "lodash": "^4.17.21",
+        "shallow-equal": "^3.1.0",
+        "warning": "^4.0.3"
+      },
+      "peerDependencies": {
+        "react": ">=16.14.0"
+      }
+    },
     "node_modules/react-dom": {
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
@@ -10710,6 +10763,12 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/shallow-equal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/shallow-equal/-/shallow-equal-3.1.0.tgz",
+      "integrity": "sha512-pfVOw8QZIXpMbhBWvzBISicvToTiM5WBF1EeAUZDDSb5Dt29yl4AYbyywbJFSEsRUMr7gJaxqCdr4L3tQf9wVg==",
+      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -11269,6 +11328,16 @@
         }
       }
     },
+    "node_modules/ts-node/node_modules/diff": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
+      "integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
     "node_modules/ts-poet": {
       "version": "6.12.0",
       "resolved": "https://registry.npmjs.org/ts-poet/-/ts-poet-6.12.0.tgz",
@@ -11624,6 +11693,15 @@
       "license": "Apache-2.0",
       "dependencies": {
         "makeerror": "1.0.12"
+      }
+    },
+    "node_modules/warning": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
+      "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.0.0"
       }
     },
     "node_modules/webidl-conversions": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,8 @@
       "dependencies": {
         "@cormoran/zmk-studio-react-hook": "github:cormoran/react-zmk-studio",
         "@keyboard-hub/abyss-client": "^0.0.1",
+        "@keyboard-hub/adapter-common": "^0.0.1",
+        "@keyboard-hub/adapter-zmk": "^0.0.1",
         "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-switch": "^1.2.6",
         "@radix-ui/react-tabs": "^1.1.13",
@@ -132,7 +134,6 @@
       "integrity": "sha512-H3mcG6ZDLTlYfaSNi0iOKkigqMFvkTKlGUYlD8GW7nNOYRrevuA46iTypPyv+06V3fEmvvazfntkBU34L0azAw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.28.6",
         "@babel/generator": "^7.28.6",
@@ -966,7 +967,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -990,7 +990,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2555,11 +2554,50 @@
         "@keyboard-hub/abyss-api-schema": "0.0.1"
       }
     },
+    "node_modules/@keyboard-hub/adapter-common": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@keyboard-hub/adapter-common/-/adapter-common-0.0.1.tgz",
+      "integrity": "sha512-+MQQiMeq+LfPW1z3ZSCTO9/ZJqG3RYA8WCLqG8cCUxunexPe5/hjBoE7BKlp/R91a2/fTHFo6Ti8P0I5WQ4yTg==",
+      "license": "MIT",
+      "dependencies": {
+        "@keyboard-hub/abyss-api-schema": "0.0.1",
+        "@keyboard-hub/schema": "0.0.1"
+      }
+    },
+    "node_modules/@keyboard-hub/adapter-zmk": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@keyboard-hub/adapter-zmk/-/adapter-zmk-0.0.1.tgz",
+      "integrity": "sha512-ePjOltww0dE6ib7x0/Cp2rl9qMCF4fb97VRkVpI8bIcjS+dmlbEFy8rQHUA5Fn9yN/acYn/VHRvFlTODykcJMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@bufbuild/protobuf": "^2.12.0",
+        "@keyboard-hub/abyss-api-schema": "0.0.1",
+        "@keyboard-hub/adapter-common": "0.0.1",
+        "@keyboard-hub/keycode-preview-zmk": "0.0.1",
+        "@keyboard-hub/schema": "0.0.1",
+        "@keyboard-hub/zmk-studio-ts-client": "0.0.18"
+      }
+    },
+    "node_modules/@keyboard-hub/adapter-zmk/node_modules/@bufbuild/protobuf": {
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.13.0.tgz",
+      "integrity": "sha512-acq7c49vxfm1ggJ95P70TX7ABDM0vxr1SYD3BB0o0jnBLB4OAqeHyKuN+cD3w80gXEDQ2zxHpR6CUeA+O/aU9g==",
+      "license": "(Apache-2.0 AND BSD-3-Clause)"
+    },
     "node_modules/@keyboard-hub/keycode-preview": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/@keyboard-hub/keycode-preview/-/keycode-preview-0.0.1.tgz",
       "integrity": "sha512-xVr4FV9FzJ1jGcG7u/6QwWzQD6Y0Cc7iekSQZhl9rfay/Yl4Ti2HdaDC5xDEsMg7EuF7SUdVSLplWFa8PNPQyQ==",
       "license": "MIT"
+    },
+    "node_modules/@keyboard-hub/keycode-preview-zmk": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@keyboard-hub/keycode-preview-zmk/-/keycode-preview-zmk-0.0.1.tgz",
+      "integrity": "sha512-W0DHfmNAhWBOxxgkJbFDVXaq5SpCcT+wBaitr0Ma/Ezma8Dnvz357MRf3qwwQOiNgzoLUzgfrFV8p6cS5P77GA==",
+      "license": "MIT",
+      "dependencies": {
+        "@keyboard-hub/keycode-preview": "0.0.1"
+      }
     },
     "node_modules/@keyboard-hub/schema": {
       "version": "0.0.1",
@@ -2568,6 +2606,21 @@
       "license": "MIT",
       "dependencies": {
         "zod": "^4.4.3"
+      }
+    },
+    "node_modules/@keyboard-hub/zmk-studio-ts-client": {
+      "version": "0.0.18",
+      "resolved": "https://registry.npmjs.org/@keyboard-hub/zmk-studio-ts-client/-/zmk-studio-ts-client-0.0.18.tgz",
+      "integrity": "sha512-z9NFuRsK8srdp/fc1YBimVNF1X8FAHfl1h6BquDyCeoGdH1ghsflUVg447KRNCw64b0bPXXGGzBd91dkOq3Gjg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/w3c-web-serial": "^1.0.6",
+        "@types/web-bluetooth": "^0.0.20",
+        "async-mutex": "^0.5.0",
+        "protobufjs": "^7.3.2"
+      },
+      "engines": {
+        "node": ">=12.0"
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
@@ -3766,7 +3819,6 @@
       "integrity": "sha512-8QqtOQT5ACVlmsvKOJNEaWmRPmcojMOzCz4Hs2BGG/toAp/K38LcsMRyLp349glq5AzJbCEeimEoxaX6v/fLrA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/core": "^7.21.3",
         "@svgr/babel-preset": "8.1.0",
@@ -4269,7 +4321,8 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -4457,7 +4510,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.9.tgz",
       "integrity": "sha512-ne4A0IpG3+2ETuREInjPNhUGis1SFjv1d5asp8MzEAGtOZeTeHVDOYqOgqfhvseqg/iXty2hjBf1zAOb7RNiNw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -4468,7 +4520,6 @@
       "integrity": "sha512-Lpo8kgb/igvMIPeNV2rsYKTgaORYdO1XGVZ4Qz3akwOj0ySGYMPlQWa8BaLn0G63D1aSaAQ5ldR06wCpChQCjA==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -4479,7 +4530,6 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -4496,6 +4546,18 @@
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
       "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/w3c-web-serial": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/w3c-web-serial/-/w3c-web-serial-1.0.8.tgz",
+      "integrity": "sha512-QQOT+bxQJhRGXoZDZGLs3ksLud1dMNnMiSQtBA0w8KXvLpXX4oM4TZb6J0GgJ8UbCaHo5s9/4VQT8uXy9JER2A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/web-bluetooth": {
+      "version": "0.0.20",
+      "resolved": "https://registry.npmjs.org/@types/web-bluetooth/-/web-bluetooth-0.0.20.tgz",
+      "integrity": "sha512-g9gZnnXVq7gM7v3tJCWV/qw7w+KeOlSHAhgF9RytFyifW6AF61hdT2ucrYhPq9hLs5JIryeupHV3qGk95dH9ow==",
       "license": "MIT"
     },
     "node_modules/@types/yargs": {
@@ -4560,7 +4622,6 @@
       "integrity": "sha512-nm3cvFN9SqZGXjmw5bZ6cGmvJSyJPn0wU9gHAZZHDnZl2wF9PhHv78Xf06E0MaNk4zLVHL8hb2/c32XvyJOLQg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.53.1",
         "@typescript-eslint/types": "8.53.1",
@@ -4838,7 +4899,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5234,7 +5294,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -5820,7 +5879,8 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dot-case": {
       "version": "3.0.4",
@@ -5962,7 +6022,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -6974,7 +7033,6 @@
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -8865,7 +8923,6 @@
       "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssstyle": "^4.2.1",
         "data-urls": "^5.0.0",
@@ -9577,6 +9634,7 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -10173,7 +10231,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -10222,6 +10279,7 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -10237,6 +10295,7 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -10314,7 +10373,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -10324,7 +10382,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -10337,7 +10394,8 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-refresh": {
       "version": "0.18.0",
@@ -11173,7 +11231,6 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -11296,7 +11353,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -11462,7 +11518,6 @@
       "integrity": "sha512-u09tdk/huMiN8xwoiBbig197jKdCamQTtOruSalOzbqGje3jdHiV0njQlAW0YvzoahkirFePNQ4RYlfnRQpXZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@oxc-project/runtime": "0.97.0",
         "fdir": "^6.5.0",
@@ -11820,7 +11875,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@cormoran/zmk-studio-react-hook": "github:cormoran/react-zmk-studio",
+        "@keyboard-hub/abyss-client": "^0.0.1",
         "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-switch": "^1.2.6",
         "@radix-ui/react-tabs": "^1.1.13",
@@ -2532,6 +2533,41 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@keyboard-hub/abyss-api-schema": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@keyboard-hub/abyss-api-schema/-/abyss-api-schema-0.0.1.tgz",
+      "integrity": "sha512-8045azAsMBfq1vJBeaFHHABDoGK7u/obH1bfcWn3y/2xi11fan3WFrUD0Xc0QeXWaWi15tjOam4VYb/hvHTfhA==",
+      "license": "MIT",
+      "dependencies": {
+        "@keyboard-hub/keycode-preview": "0.0.1",
+        "@keyboard-hub/schema": "0.0.1",
+        "zod": "^4.4.3"
+      }
+    },
+    "node_modules/@keyboard-hub/abyss-client": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@keyboard-hub/abyss-client/-/abyss-client-0.0.1.tgz",
+      "integrity": "sha512-IY8aAE0dk6Ide5GWszA99ywKr7lmFMHCSj683QVnAnociZ3jRSGUtpfaA4LVWcYX7sBVnQCK+qbZCYDeAomdzA==",
+      "license": "MIT",
+      "dependencies": {
+        "@keyboard-hub/abyss-api-schema": "0.0.1"
+      }
+    },
+    "node_modules/@keyboard-hub/keycode-preview": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@keyboard-hub/keycode-preview/-/keycode-preview-0.0.1.tgz",
+      "integrity": "sha512-xVr4FV9FzJ1jGcG7u/6QwWzQD6Y0Cc7iekSQZhl9rfay/Yl4Ti2HdaDC5xDEsMg7EuF7SUdVSLplWFa8PNPQyQ==",
+      "license": "MIT"
+    },
+    "node_modules/@keyboard-hub/schema": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@keyboard-hub/schema/-/schema-0.0.1.tgz",
+      "integrity": "sha512-NBfykTZutC5XVgBdLqVvDpOEkh7p5YfggCxyk788xT3Y0Y56jetzB82C5g6po4LwBmUelJJS8zV+SJrVEilt5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "zod": "^4.4.3"
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
@@ -11780,10 +11816,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "4.3.5",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.5.tgz",
-      "integrity": "sha512-k7Nwx6vuWx1IJ9Bjuf4Zt1PEllcwe7cls3VNzm4CQ1/hgtFUK2bRNG3rvnpPUhFjmqJKAKtjV576KnUkHocg/g==",
-      "dev": true,
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
       "peer": true,
       "funding": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@keyboard-hub/adapter-common": "^0.0.1",
     "@keyboard-hub/adapter-zmk": "^0.0.1",
     "@radix-ui/react-dialog": "^1.1.15",
+    "@radix-ui/react-popover": "^1.1.23",
     "@radix-ui/react-switch": "^1.2.6",
     "@radix-ui/react-tabs": "^1.1.13",
     "@radix-ui/react-tooltip": "^1.2.8",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,8 @@
   "dependencies": {
     "@cormoran/zmk-studio-react-hook": "github:cormoran/react-zmk-studio",
     "@keyboard-hub/abyss-client": "^0.0.1",
+    "@keyboard-hub/adapter-common": "^0.0.1",
+    "@keyboard-hub/adapter-zmk": "^0.0.1",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-switch": "^1.2.6",
     "@radix-ui/react-tabs": "^1.1.13",

--- a/package.json
+++ b/package.json
@@ -28,8 +28,10 @@
     "@tabler/icons-react": "^3.36.1",
     "@zmkfirmware/zmk-studio-ts-client": "github:cormoran/zmk-studio-ts-client#custom-studio-protocol+bluefy",
     "clsx": "^2.1.1",
+    "diff": "^9.0.0",
     "framer-motion": "^12.29.0",
     "react": "^19.2.0",
+    "react-diff-view": "^3.3.3",
     "react-dom": "^19.2.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "dependencies": {
     "@cormoran/zmk-studio-react-hook": "github:cormoran/react-zmk-studio",
+    "@keyboard-hub/abyss-client": "^0.0.1",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-switch": "^1.2.6",
     "@radix-ui/react-tabs": "^1.1.13",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import { useContext, useCallback, useEffect, useState } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import {
+  IconCloudUpload,
   IconHome,
   IconKeyboard,
   IconPlugConnected,
@@ -33,6 +34,13 @@ import { MacroComboPage } from "./pages/MacroComboPage";
 import { SettingsPage } from "./pages/SettingsPage";
 import { CustomSubsystemsPage } from "./pages/CustomSubsystemsPage";
 import { TroubleshootingPage } from "./pages/TroubleshootingPage";
+import {
+  ImportExportPage,
+  IMPORT_EXPORT_TAB_ID,
+} from "./pages/ImportExportPage";
+import { AbyssCallbackPage } from "./pages/AbyssCallbackPage";
+import { isAbyssConfigured } from "./lib/abyss/abyssConfig";
+import { OAUTH_CALLBACK_PATH } from "./lib/abyss/abyssOAuth";
 import { useLanguage } from "./hooks/useLanguage";
 import { useUrlTab, pathnameFromTabId } from "./hooks/useUrlTab";
 import { useDevtool } from "./hooks/useDevtool";
@@ -89,6 +97,18 @@ function getTabs(t: (key: string) => string): TabItem[] {
       icon: <IconPuzzle size={18} />,
       content: <CustomSubsystemsPage />,
     },
+    // Hidden entirely when the build has no Abyss OAuth client id — the tab's
+    // only entry point is a sign-in that could not succeed.
+    ...(isAbyssConfigured()
+      ? [
+          {
+            id: IMPORT_EXPORT_TAB_ID,
+            label: t("Import/Export"),
+            icon: <IconCloudUpload size={18} />,
+            content: <ImportExportPage />,
+          },
+        ]
+      : []),
   ];
 }
 
@@ -132,19 +152,29 @@ function AppContent() {
     // Notify both this route state and useUrlTab's own popstate listener.
     window.dispatchEvent(new PopStateEvent("popstate"));
   }, []);
+  // Same as navigatePath but without a history entry, so Back never returns to
+  // a URL carrying a spent OAuth authorization code.
+  const replacePath = useCallback((path: string) => {
+    window.history.replaceState(null, "", path);
+    window.dispatchEvent(new PopStateEvent("popstate"));
+  }, []);
   const onReleaseNotes = pathname === RELEASE_NOTES_PATH;
+  const onOauthCallback = pathname === OAUTH_CALLBACK_PATH;
 
   useEffect(() => {
     // Canonicalize unknown paths (e.g. a stale/typo'd link) to the home tab,
-    // but leave the standalone release notes route alone.
+    // but leave the standalone routes alone. The OAuth callback especially:
+    // rewriting it to "/" would discard the ?code=&state= query string before
+    // AbyssCallbackPage ever gets to read it.
     if (
       !onReleaseNotes &&
+      !onOauthCallback &&
       urlTab !== activeTab &&
       window.location.pathname !== "/"
     ) {
       window.history.replaceState(null, "", "/");
     }
-  }, [urlTab, activeTab, onReleaseNotes]);
+  }, [urlTab, activeTab, onReleaseNotes, onOauthCallback]);
 
   const setActiveTabWithTracking = useCallback(
     (tabId: string) => {
@@ -159,6 +189,13 @@ function AppContent() {
     },
     [navigateToTab, tabs],
   );
+
+  // Both standalone routes return before the connection gate: the user lands on
+  // the OAuth callback with no keyboard connected whenever the popup was
+  // blocked and the whole page navigated to Abyss.
+  if (onOauthCallback) {
+    return <AbyssCallbackPage onDone={replacePath} />;
+  }
 
   if (onReleaseNotes) {
     return <ReleaseNotesPage onBack={() => navigatePath("/")} />;

--- a/src/__mocks__/abyssAdapterCommon.ts
+++ b/src/__mocks__/abyssAdapterCommon.ts
@@ -1,0 +1,25 @@
+/**
+ * Jest stand-in for `@keyboard-hub/adapter-common`.
+ *
+ * The package publishes untranspiled ESM TypeScript with only `types` and
+ * `import` export conditions, so the CommonJS test runtime can neither resolve
+ * nor execute it. Wired in via `moduleNameMapper`.
+ *
+ * Only `compareKeyboardHubKeymaps` is consumed from it — the diff filtering,
+ * counting and grouping live in `src/lib/abyss/abyssDiff.ts` precisely so they
+ * can be tested for real. The comparison algorithm itself is covered by
+ * `packages/adapter-common/tests/keyboard-hub-diff.test.ts` upstream, so tests
+ * that need a specific diff mock this rather than reimplementing it.
+ */
+
+const EMPTY_DIFF = {
+  bindingChanges: [],
+  comboChanges: [],
+  macroChanges: [],
+  moduleChanges: [],
+  layerNameChanges: [],
+};
+
+export function compareKeyboardHubKeymaps() {
+  return EMPTY_DIFF;
+}

--- a/src/__mocks__/abyssAdapterZmk.ts
+++ b/src/__mocks__/abyssAdapterZmk.ts
@@ -1,0 +1,35 @@
+/**
+ * Jest stand-in for `@keyboard-hub/adapter-zmk`.
+ *
+ * Like `@keyboard-hub/abyss-client`, the package publishes untranspiled ESM
+ * TypeScript with only `types` and `import` export conditions, so the CommonJS
+ * test runtime can neither resolve nor execute it. Wired in via
+ * `moduleNameMapper`; the real module runs in the Vite build and the browser.
+ *
+ * Nothing here is worth asserting against — `loadZmkConnection` and
+ * `writeZmkKeymapDiff` only do anything with a live keyboard. Tests that need
+ * them supply their own behaviour with `jest.mock(..., factory)`; this stub
+ * exists so importing the module does not explode, and so a test that forgets
+ * to mock fails loudly instead of silently doing nothing.
+ */
+
+function notMocked(name: string): never {
+  throw new Error(
+    `@keyboard-hub/adapter-zmk.${name} was called in a test without being mocked. ` +
+      `It requires a live ZMK Studio connection; mock it with jest.mock().`,
+  );
+}
+
+export function loadZmkConnection(): never {
+  return notMocked("loadZmkConnection");
+}
+
+export function loadZmkPreview(): never {
+  return notMocked("loadZmkPreview");
+}
+
+export function writeZmkKeymapDiff(): never {
+  return notMocked("writeZmkKeymapDiff");
+}
+
+export const zmkAdapterLabel = "ZMK Studio";

--- a/src/__mocks__/abyssClientSdk.ts
+++ b/src/__mocks__/abyssClientSdk.ts
@@ -1,0 +1,54 @@
+/**
+ * Jest stand-in for `@keyboard-hub/abyss-client`.
+ *
+ * The real package publishes untranspiled ESM TypeScript and declares only the
+ * `types` and `import` export conditions, so the CommonJS test runtime cannot
+ * load it at all. It is wired in via `moduleNameMapper` so every test gets this
+ * stub without per-file boilerplate; the real SDK is only ever executed by the
+ * Vite build and in the browser.
+ *
+ * Only the surface DYA Studio actually uses is stubbed. Tests that need client
+ * behaviour inject their own fake through `getAbyssClient`.
+ */
+
+/** Mirrors the real error's `status` field, which the error mapping reads. */
+export class AbyssApiError extends Error {
+  readonly status: number;
+  readonly code?: string;
+
+  constructor(status = 500, code?: string) {
+    super(`AbyssApiError ${status}`);
+    this.name = "AbyssApiError";
+    this.status = status;
+    this.code = code;
+  }
+}
+
+export class AbyssOAuthError extends Error {
+  readonly code?: string;
+
+  constructor(message = "AbyssOAuthError", code?: string) {
+    super(message);
+    this.name = "AbyssOAuthError";
+    this.code = code;
+  }
+}
+
+export class AbyssClient {}
+
+// Plain functions rather than jest.fn(): this file is part of the `src`
+// TypeScript project, which has no jest globals. Tests that need client
+// behaviour inject a fake through `getAbyssClient` instead of asserting on
+// these.
+export function createAbyssClient(): AbyssClient {
+  return new AbyssClient();
+}
+
+export function createMemoryStorage() {
+  const values = new Map<string, string>();
+  return {
+    getItem: (key: string) => values.get(key) ?? null,
+    setItem: (key: string, value: string) => void values.set(key, value),
+    removeItem: (key: string) => void values.delete(key),
+  };
+}

--- a/src/__mocks__/svgComponentMock.tsx
+++ b/src/__mocks__/svgComponentMock.tsx
@@ -1,0 +1,12 @@
+/**
+ * Jest stub for `*.svg?react` imports.
+ *
+ * vite-plugin-svgr turns those into React components, so the plain string stub
+ * used for other assets ({@link ./fileMock.ts}) is not enough — React would try
+ * to render a string as a component type.
+ */
+import type { SVGProps } from "react";
+
+export default function SvgMock(props: SVGProps<SVGSVGElement>) {
+  return <svg data-testid="svg-mock" {...props} />;
+}

--- a/src/__tests__/App.test.tsx
+++ b/src/__tests__/App.test.tsx
@@ -1,0 +1,77 @@
+/**
+ * Routing tests for the App shell.
+ *
+ * The reason this file exists: `AppContent` canonicalizes any pathname that
+ * does not correspond to a tab back to "/". The OAuth callback is such a
+ * pathname, and rewriting it would throw away the `?code=&state=` query string
+ * before the callback page could read it — a failure that only shows up as
+ * "login silently does nothing". These tests pin that down.
+ */
+import { render, screen, waitFor } from "@testing-library/react";
+import App from "../App";
+import { OAUTH_CALLBACK_PATH } from "../lib/abyss/abyssOAuth";
+import { RELEASE_NOTES_PATH } from "../pages/ReleaseNotesPage";
+
+// The standalone pages are rendered by App directly; stub them so these tests
+// stay about routing rather than page internals.
+jest.mock("../pages/AbyssCallbackPage", () => ({
+  AbyssCallbackPage: () => <div data-testid="abyss-callback" />,
+}));
+jest.mock("../pages/ReleaseNotesPage", () => ({
+  RELEASE_NOTES_PATH: "/release-notes",
+  ReleaseNotesPage: () => <div data-testid="release-notes" />,
+}));
+// Stubbed so routing tests do not pull the Abyss SDK into the module graph.
+jest.mock("../pages/ImportExportPage", () => ({
+  IMPORT_EXPORT_TAB_ID: "import-export",
+  ImportExportPage: () => <div data-testid="import-export" />,
+}));
+
+function goTo(url: string) {
+  window.history.replaceState(null, "", url);
+}
+
+describe("App routing", () => {
+  let replaceStateSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    goTo("/");
+    replaceStateSpy = jest.spyOn(window.history, "replaceState");
+  });
+
+  afterEach(() => {
+    replaceStateSpy.mockRestore();
+  });
+
+  it("renders the OAuth callback page and keeps the query string", async () => {
+    goTo(`${OAUTH_CALLBACK_PATH}?code=test-code&state=test-state`);
+    replaceStateSpy.mockClear();
+
+    render(<App />);
+
+    expect(await screen.findByTestId("abyss-callback")).toBeInTheDocument();
+    // The authorization code must survive: the callback page reads it from
+    // window.location, and it is single-use.
+    expect(window.location.pathname).toBe(OAUTH_CALLBACK_PATH);
+    expect(window.location.search).toBe("?code=test-code&state=test-state");
+    expect(replaceStateSpy).not.toHaveBeenCalledWith(null, "", "/");
+  });
+
+  it("still renders the standalone release notes route", async () => {
+    goTo(RELEASE_NOTES_PATH);
+    replaceStateSpy.mockClear();
+
+    render(<App />);
+
+    expect(await screen.findByTestId("release-notes")).toBeInTheDocument();
+    expect(window.location.pathname).toBe(RELEASE_NOTES_PATH);
+  });
+
+  it("canonicalizes an unknown path back to the home tab", async () => {
+    goTo("/not-a-real-tab");
+
+    render(<App />);
+
+    await waitFor(() => expect(window.location.pathname).toBe("/"));
+  });
+});

--- a/src/components/TabNavigation.tsx
+++ b/src/components/TabNavigation.tsx
@@ -49,9 +49,26 @@ export function TabNavigation({
             className="h-full outline-none data-[state=inactive]:hidden"
             forceMount
           >
-            <PageTransition transitionKey={activeTab === tab.id ? tab.id : ""}>
-              {activeTab === tab.id ? tab.content : null}
-            </PageTransition>
+            {/*
+              Mount the transition only while the tab is active.
+
+              Previously this rendered a PageTransition for every tab, flipping
+              its key between "" and the tab id. `AnimatePresence mode="wait"`
+              holds the outgoing child until its exit animation finishes — and
+              inside a `display: none` panel that never happens, so the incoming
+              child never mounted. The tab looked blank until a reload, and the
+              stale subtree left behind still rendered DOM whose event handlers
+              updated a fiber React had discarded: clicks fired but setState did
+              nothing.
+
+              Rendering nothing when inactive means each tab's AnimatePresence
+              only ever holds one key, with no exit to wait on.
+            */}
+            {activeTab === tab.id && (
+              <PageTransition transitionKey={tab.id}>
+                {tab.content}
+              </PageTransition>
+            )}
           </Tabs.Content>
         ))}
       </div>

--- a/src/components/importExport/AbyssAccountCard.tsx
+++ b/src/components/importExport/AbyssAccountCard.tsx
@@ -8,6 +8,7 @@ import { IconCloud, IconLoader2, IconLogout } from "@tabler/icons-react";
 import { useLanguage } from "../../hooks/useLanguage";
 import { SectionError } from "../troubleshooting/SectionCard";
 import type { UseAbyssAuthReturn } from "../../hooks/useAbyssAuth";
+import { abyssHost } from "../../lib/abyss/abyssConfig";
 
 export function AbyssAccountCard({ auth }: { auth: UseAbyssAuthReturn }) {
   const { t } = useLanguage();
@@ -78,7 +79,8 @@ export function AbyssAccountCard({ auth }: { auth: UseAbyssAuthReturn }) {
       {!isAuthenticated && (
         <p className="mt-4 text-xs text-[var(--color-text-muted)]">
           {t(
-            "A sign-in window opens at abyss.keyboard-hub.com. Your session lasts until this tab is closed.",
+            "A sign-in window opens at {{host}}. Your session lasts until this tab is closed.",
+            { host: abyssHost() },
           )}
         </p>
       )}

--- a/src/components/importExport/AbyssAccountCard.tsx
+++ b/src/components/importExport/AbyssAccountCard.tsx
@@ -1,0 +1,87 @@
+/**
+ * Keyboard Abyss sign-in card at the top of the Import/Export tab.
+ *
+ * Everything else on the tab is gated on this, so it is the one section that is
+ * always expanded and always visible.
+ */
+import { IconCloud, IconLoader2, IconLogout } from "@tabler/icons-react";
+import { useLanguage } from "../../hooks/useLanguage";
+import { SectionError } from "../troubleshooting/SectionCard";
+import type { UseAbyssAuthReturn } from "../../hooks/useAbyssAuth";
+
+export function AbyssAccountCard({ auth }: { auth: UseAbyssAuthReturn }) {
+  const { t } = useLanguage();
+  const { isAuthenticated, user, isLoading, error, login, logout } = auth;
+
+  return (
+    <div className="glass-card p-6">
+      <div className="flex flex-col tablet:flex-row tablet:items-center gap-4">
+        <div className="flex items-center gap-3 min-w-0">
+          {user?.avatarUrl ? (
+            <img
+              src={user.avatarUrl}
+              alt=""
+              className="w-9 h-9 rounded-full flex-shrink-0 object-cover"
+            />
+          ) : (
+            <div className="p-2 rounded-lg bg-[var(--color-electric)]/10 border border-[var(--color-electric)]/20 flex-shrink-0">
+              <IconCloud size={20} className="text-[var(--color-electric)]" />
+            </div>
+          )}
+          <div className="min-w-0">
+            <h3 className="text-sm font-medium text-[var(--color-text)] truncate">
+              {isAuthenticated
+                ? (user?.displayName ?? user?.username ?? t("Keyboard Abyss"))
+                : t("Keyboard Abyss")}
+            </h3>
+            <p className="text-xs text-[var(--color-text-muted)] truncate">
+              {isAuthenticated
+                ? `@${user?.username ?? ""}`
+                : t("Sign in to import and export keymaps.")}
+            </p>
+          </div>
+        </div>
+
+        <div className="tablet:ml-auto flex-shrink-0">
+          {isAuthenticated ? (
+            <button
+              className="btn-ghost border border-[var(--color-border)] flex items-center gap-2 text-sm"
+              onClick={() => void logout()}
+              disabled={isLoading}
+            >
+              <IconLogout size={16} />
+              {t("Sign out")}
+            </button>
+          ) : (
+            <button
+              className="btn-electric flex items-center gap-2 text-sm"
+              onClick={() => void login()}
+              disabled={isLoading}
+            >
+              {isLoading ? (
+                <IconLoader2 size={16} className="animate-spin" />
+              ) : (
+                <IconCloud size={16} />
+              )}
+              {t("Sign in with Abyss")}
+            </button>
+          )}
+        </div>
+      </div>
+
+      {error && (
+        <div className="mt-4">
+          <SectionError message={error} />
+        </div>
+      )}
+
+      {!isAuthenticated && (
+        <p className="mt-4 text-xs text-[var(--color-text-muted)]">
+          {t(
+            "A sign-in window opens at abyss.keyboard-hub.com. Your session lasts until this tab is closed.",
+          )}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/components/importExport/ComboMacroDiff.tsx
+++ b/src/components/importExport/ComboMacroDiff.tsx
@@ -1,0 +1,159 @@
+/**
+ * Human-readable rendering of combo and macro changes, with the raw JSON kept
+ * underneath.
+ *
+ * `{"positions":[12,13],"binding":{"type":"key","usage":43}}` is precise and
+ * unreadable. The summary line says what it does; the JSON stays one click away
+ * because it is the only thing that is unambiguous when the summary does not
+ * cover a case.
+ */
+import { useLanguage } from "../../hooks/useLanguage";
+import { bindingLabel, type CollectionChange } from "../../lib/abyss/abyssDiff";
+
+/** A combo as KeyboardHub stores it. */
+type ComboShape = {
+  positions?: number[];
+  binding?: unknown;
+};
+
+/** A macro as KeyboardHub stores it. */
+type MacroShape = {
+  name?: string;
+  bindings?: MacroStep[];
+};
+
+type MacroStep = {
+  action?: string;
+  binding?: unknown;
+  wait?: number;
+  tap?: number;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+/** `keys 12 + 13 → SPACE` */
+function ComboSummary({ value }: { value: unknown }) {
+  const { t } = useLanguage();
+  if (!isRecord(value)) return null;
+  const combo = value as ComboShape;
+  const positions = combo.positions ?? [];
+
+  return (
+    <span className="text-[var(--color-text)]">
+      {positions.length > 0 ? (
+        <>
+          {t("Keys")}{" "}
+          <span className="tabular-nums">{positions.join(" + ")}</span>
+        </>
+      ) : (
+        t("No keys")
+      )}
+      {" → "}
+      <span className="text-[var(--color-neon)]">
+        {bindingLabel(combo.binding)}
+      </span>
+    </span>
+  );
+}
+
+/** Macro name plus its steps as chips, in order. */
+function MacroSummary({ value }: { value: unknown }) {
+  const { t } = useLanguage();
+  if (!isRecord(value)) return null;
+  const macro = value as MacroShape;
+  const steps = macro.bindings ?? [];
+
+  return (
+    <div>
+      <span className="text-[var(--color-text)]">
+        {macro.name || t("Unnamed macro")}
+      </span>
+      <div className="mt-1 flex flex-wrap gap-1">
+        {steps.length === 0 && (
+          <span className="text-xs text-[var(--color-text-muted)]">
+            {t("No steps")}
+          </span>
+        )}
+        {steps.map((step, index) => (
+          <span
+            key={index}
+            className="px-1.5 py-0.5 rounded bg-[var(--color-border)] text-[10px] text-[var(--color-text-muted)]"
+          >
+            {step.wait !== undefined
+              ? t("wait {{ms}}ms", { ms: step.wait })
+              : step.tap !== undefined
+                ? t("tap {{ms}}ms", { ms: step.tap })
+                : `${step.action ?? "tap"} ${bindingLabel(step.binding)}`}
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function ChangeRow({
+  change,
+  kind,
+}: {
+  change: CollectionChange;
+  kind: "combo" | "macro";
+}) {
+  const { t } = useLanguage();
+  const Summary = kind === "combo" ? ComboSummary : MacroSummary;
+  // A missing `to` means the entry goes away; a missing `from` means it is new.
+  const verb =
+    change.to === undefined
+      ? t("Removed")
+      : change.from === undefined
+        ? t("Added")
+        : t("Changed");
+
+  return (
+    <div className="py-2 border-t border-[var(--color-border)] first:border-t-0">
+      <p className="text-[10px] uppercase tracking-wide text-[var(--color-text-muted)] mb-1">
+        {change.label} · {verb}
+      </p>
+      {change.from !== undefined && change.to !== undefined && (
+        <div className="text-xs opacity-60 mb-1">
+          <Summary value={change.from} />
+        </div>
+      )}
+      <div className="text-xs">
+        <Summary value={change.to ?? change.from} />
+      </div>
+      <details className="mt-1">
+        <summary className="cursor-pointer text-[10px] text-[var(--color-text-muted)]">
+          {t("Raw")}
+        </summary>
+        <pre className="mt-1 p-2 rounded bg-[var(--color-border)] overflow-x-auto text-[10px] text-[var(--color-text-muted)]">
+          {JSON.stringify(change.to ?? change.from, null, 2)}
+        </pre>
+      </details>
+    </div>
+  );
+}
+
+export function ComboMacroDiff({
+  title,
+  kind,
+  changes,
+}: {
+  title: string;
+  kind: "combo" | "macro";
+  changes: CollectionChange[];
+}) {
+  if (changes.length === 0) return null;
+
+  return (
+    <div className="glass-card p-4">
+      <h4 className="text-sm font-medium text-[var(--color-text)] mb-2">
+        {title}
+      </h4>
+      {changes.map((change) => (
+        <ChangeRow key={change.index} change={change} kind={kind} />
+      ))}
+    </div>
+  );
+}

--- a/src/components/importExport/DataSectionSelector.tsx
+++ b/src/components/importExport/DataSectionSelector.tsx
@@ -1,0 +1,71 @@
+/**
+ * Checkboxes for which parts of the keymap an export or import covers.
+ *
+ * Mirrors the section selection Keyboard Abyss offers in its own writeback UI,
+ * so the same keymap moves the same way from either direction.
+ */
+import { useLanguage } from "../../hooks/useLanguage";
+import {
+  SECTION_IDS,
+  type AbyssSectionId,
+  type AbyssSectionSelection,
+} from "../../lib/abyss/abyssExportPayload";
+
+const SECTION_LABELS: Record<AbyssSectionId, string> = {
+  keymap: "Keymap (layers & key bindings)",
+  combos: "Combos",
+  macros: "Macros",
+  modules: "Module settings",
+};
+
+export function DataSectionSelector({
+  selection,
+  onChange,
+  /** Section ids that cannot be toggled, with the reason shown as a hint. */
+  disabled = {},
+  /** Sections forced on regardless of `selection`, e.g. keymap for a new keymap. */
+  forced = [],
+}: {
+  selection: AbyssSectionSelection;
+  onChange: (selection: AbyssSectionSelection) => void;
+  disabled?: Partial<Record<AbyssSectionId, string>>;
+  forced?: AbyssSectionId[];
+}) {
+  const { t } = useLanguage();
+
+  return (
+    <fieldset className="mb-4">
+      <legend className="text-xs text-[var(--color-text-muted)] mb-2">
+        {t("Include")}
+      </legend>
+      <div className="flex flex-wrap gap-x-5 gap-y-2">
+        {SECTION_IDS.map((id) => {
+          const isForced = forced.includes(id);
+          const disabledReason = disabled[id];
+          return (
+            <label
+              key={id}
+              className={`flex items-center gap-2 text-sm ${
+                disabledReason
+                  ? "text-[var(--color-text-muted)] cursor-not-allowed"
+                  : "text-[var(--color-text)] cursor-pointer"
+              }`}
+              title={disabledReason ? t(disabledReason) : undefined}
+            >
+              <input
+                type="checkbox"
+                className="accent-[var(--color-electric)]"
+                checked={isForced || (selection[id] && !disabledReason)}
+                disabled={isForced || Boolean(disabledReason)}
+                onChange={(event) =>
+                  onChange({ ...selection, [id]: event.target.checked })
+                }
+              />
+              {t(SECTION_LABELS[id])}
+            </label>
+          );
+        })}
+      </div>
+    </fieldset>
+  );
+}

--- a/src/components/importExport/DeviceSnapshotCard.tsx
+++ b/src/components/importExport/DeviceSnapshotCard.tsx
@@ -6,10 +6,34 @@
  * rather than automatic because it goes through the official ZMK protocol —
  * one `getBehaviorDetails` round trip per behavior — which is slow over BLE.
  */
-import { IconDeviceUsb, IconLoader2, IconRefresh } from "@tabler/icons-react";
+import {
+  IconDeviceUsb,
+  IconExternalLink,
+  IconLoader2,
+  IconRefresh,
+} from "@tabler/icons-react";
 import { useLanguage } from "../../hooks/useLanguage";
 import { SectionError } from "../troubleshooting/SectionCard";
 import type { UseAbyssDeviceReturn } from "../../hooks/useAbyssDevice";
+import {
+  abyssKeyboardUrl,
+  abyssRegisterUrl,
+} from "../../lib/abyss/abyssConfig";
+
+/** Every Abyss link leaves the app, so they all open in a new tab. */
+function AbyssLink({ href, children }: { href: string; children: string }) {
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="inline-flex items-center gap-1 underline"
+    >
+      {children}
+      <IconExternalLink size={14} />
+    </a>
+  );
+}
 
 function Stat({ label, value }: { label: string; value: number | string }) {
   return (
@@ -54,16 +78,31 @@ function LayoutVerdict({ device }: { device: UseAbyssDeviceReturn }) {
             "This layout is not registered on Abyss yet. Exporting will add it.",
           )
         : t(
-            "This keyboard is not registered on Abyss yet. Exporting will create it under your account.",
-          )}
+            "This keyboard is not registered on Abyss yet. Register it on Abyss first so exports land in the catalog.",
+          )}{" "}
+      {!resolved.keyboardExists && (
+        <AbyssLink href={abyssRegisterUrl()}>
+          {t("Register on Abyss")}
+        </AbyssLink>
+      )}
     </p>
   );
 }
 
 export function DeviceSnapshotCard({
   device,
+  keyboardSlug,
 }: {
   device: UseAbyssDeviceReturn;
+  /**
+   * Catalog slug for the connected keyboard, when known.
+   *
+   * `resolveLayout` only reports whether the keyboard exists, not which one it
+   * is, so this comes from the keymaps listed for it — the slug on the device
+   * snapshot is derived from the ZMK device name and does not identify the
+   * catalog entry.
+   */
+  keyboardSlug?: string;
 }) {
   const { t } = useLanguage();
   const { loaded, phase, isReading, error, read } = device;
@@ -134,6 +173,13 @@ export function DeviceSnapshotCard({
             />
           </div>
           <LayoutVerdict device={device} />
+          {keyboardSlug && (
+            <p className="mt-2 text-sm text-[var(--color-text-muted)]">
+              <AbyssLink href={abyssKeyboardUrl(keyboardSlug)}>
+                {t("Open this keyboard on Abyss")}
+              </AbyssLink>
+            </p>
+          )}
         </>
       )}
     </div>

--- a/src/components/importExport/DeviceSnapshotCard.tsx
+++ b/src/components/importExport/DeviceSnapshotCard.tsx
@@ -1,0 +1,141 @@
+/**
+ * Reads the connected keyboard into KeyboardHub JSON and shows what was found.
+ *
+ * Both the export and import sections work from this snapshot, so it is the
+ * first thing the user does after signing in. The read is an explicit button
+ * rather than automatic because it goes through the official ZMK protocol —
+ * one `getBehaviorDetails` round trip per behavior — which is slow over BLE.
+ */
+import { IconDeviceUsb, IconLoader2, IconRefresh } from "@tabler/icons-react";
+import { useLanguage } from "../../hooks/useLanguage";
+import { SectionError } from "../troubleshooting/SectionCard";
+import type { UseAbyssDeviceReturn } from "../../hooks/useAbyssDevice";
+
+function Stat({ label, value }: { label: string; value: number | string }) {
+  return (
+    <div className="rounded-lg border border-[var(--color-border)] p-3">
+      <p className="text-xs text-[var(--color-text-muted)]">{label}</p>
+      <p className="text-sm font-medium text-[var(--color-text)] tabular-nums">
+        {value}
+      </p>
+    </div>
+  );
+}
+
+/** How the connected layout matched the Abyss catalog, and what that implies. */
+function LayoutVerdict({ device }: { device: UseAbyssDeviceReturn }) {
+  const { t } = useLanguage();
+  const { resolved } = device;
+  if (!resolved) return null;
+
+  if (resolved.layout) {
+    return (
+      <p className="text-sm text-[var(--color-neon)]">
+        {t("Matched the Abyss layout {{layout}}.", {
+          layout: resolved.layout.name,
+        })}
+      </p>
+    );
+  }
+  if (resolved.compatibleLayout) {
+    return (
+      <p className="text-sm text-amber-400">
+        {t(
+          "No exact layout match. Exporting will add a new variation of {{layout}}.",
+          { layout: resolved.compatibleLayout.name },
+        )}
+      </p>
+    );
+  }
+  return (
+    <p className="text-sm text-amber-400">
+      {resolved.keyboardExists
+        ? t(
+            "This layout is not registered on Abyss yet. Exporting will add it.",
+          )
+        : t(
+            "This keyboard is not registered on Abyss yet. Exporting will create it under your account.",
+          )}
+    </p>
+  );
+}
+
+export function DeviceSnapshotCard({
+  device,
+}: {
+  device: UseAbyssDeviceReturn;
+}) {
+  const { t } = useLanguage();
+  const { loaded, phase, isReading, error, read } = device;
+  const keymap = loaded?.state.currentKeymap;
+
+  return (
+    <div className="glass-card p-6">
+      <div className="flex flex-col tablet:flex-row tablet:items-center gap-4 mb-4">
+        <div className="flex items-center gap-3 min-w-0">
+          <div className="p-2 rounded-lg bg-[var(--color-electric)]/10 border border-[var(--color-electric)]/20 flex-shrink-0">
+            <IconDeviceUsb size={20} className="text-[var(--color-electric)]" />
+          </div>
+          <div className="min-w-0">
+            <h3 className="text-sm font-medium text-[var(--color-text)]">
+              {t("Keyboard snapshot")}
+            </h3>
+            <p className="text-xs text-[var(--color-text-muted)] truncate">
+              {loaded
+                ? (loaded.deviceName ?? t("Connected keyboard"))
+                : t("Read the keyboard before exporting or importing.")}
+            </p>
+          </div>
+        </div>
+        <div className="tablet:ml-auto flex-shrink-0">
+          <button
+            className="btn-electric flex items-center gap-2 text-sm"
+            onClick={() => void read()}
+            disabled={isReading}
+          >
+            {isReading ? (
+              <IconLoader2 size={16} className="animate-spin" />
+            ) : (
+              <IconRefresh size={16} />
+            )}
+            {loaded ? t("Read again") : t("Read keyboard")}
+          </button>
+        </div>
+      </div>
+
+      {isReading && (
+        <p className="text-sm text-[var(--color-text-muted)] mb-4">
+          {phase === "resolving"
+            ? t("Matching the layout on Abyss...")
+            : t(
+                "Reading the keyboard. This is slower over Bluetooth than USB.",
+              )}
+        </p>
+      )}
+
+      {error && <SectionError message={error} />}
+
+      {keymap && !isReading && (
+        <>
+          <div className="grid grid-cols-2 tablet:grid-cols-5 gap-3 mb-4">
+            <Stat label={t("Layers")} value={keymap.layers.length} />
+            <Stat
+              label={t("Keys")}
+              value={Math.max(
+                0,
+                ...keymap.layers.map((layer) => layer.bindings.length),
+              )}
+            />
+            <Stat label={t("Combos")} value={keymap.combos?.length ?? 0} />
+            <Stat label={t("Macros")} value={keymap.macros?.length ?? 0} />
+            <Stat
+              label={t("Modules")}
+              value={loaded.state.detectedModules.length}
+            />
+          </div>
+          <LayoutVerdict device={device} />
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/components/importExport/ExportSection.tsx
+++ b/src/components/importExport/ExportSection.tsx
@@ -14,9 +14,7 @@ import { SectionError } from "../troubleshooting/SectionCard";
 import { DataSectionSelector } from "./DataSectionSelector";
 import type { UseAbyssDeviceReturn } from "../../hooks/useAbyssDevice";
 import type { UseAbyssExportReturn } from "../../hooks/useAbyssExport";
-import { ABYSS_BASE_URL } from "../../lib/abyss/abyssConfig";
-
-const DEFAULT_ABYSS_URL = "https://abyss.keyboard-hub.com";
+import { abyssBaseUrl, abyssHost } from "../../lib/abyss/abyssConfig";
 
 export function ExportSection({
   device,
@@ -64,9 +62,9 @@ export function ExportSection({
         {t("Export")}
       </h3>
       <p className="text-xs text-[var(--color-text-muted)] mb-4">
-        {t(
-          "Exporting uploads this keymap to abyss.keyboard-hub.com under your account.",
-        )}
+        {t("Exporting uploads this keymap to {{host}} under your account.", {
+          host: abyssHost(),
+        })}
       </p>
 
       <label className="block mb-4">
@@ -143,7 +141,7 @@ export function ExportSection({
             })}
             <a
               className="inline-flex items-center gap-1 underline"
-              href={`${ABYSS_BASE_URL || DEFAULT_ABYSS_URL}/keymaps/${result.id}`}
+              href={`${abyssBaseUrl()}/keymaps/${result.id}`}
               target="_blank"
               rel="noopener noreferrer"
             >

--- a/src/components/importExport/ExportSection.tsx
+++ b/src/components/importExport/ExportSection.tsx
@@ -1,0 +1,171 @@
+/**
+ * Uploads the connected keyboard's keymap to Keyboard Abyss.
+ *
+ * Nothing here writes to the keyboard, and Abyss keeps version history, so this
+ * side of the tab is safe to retry.
+ */
+import {
+  IconCloudUpload,
+  IconExternalLink,
+  IconLoader2,
+} from "@tabler/icons-react";
+import { useLanguage } from "../../hooks/useLanguage";
+import { SectionError } from "../troubleshooting/SectionCard";
+import { DataSectionSelector } from "./DataSectionSelector";
+import type { UseAbyssDeviceReturn } from "../../hooks/useAbyssDevice";
+import type { UseAbyssExportReturn } from "../../hooks/useAbyssExport";
+import { ABYSS_BASE_URL } from "../../lib/abyss/abyssConfig";
+
+const DEFAULT_ABYSS_URL = "https://abyss.keyboard-hub.com";
+
+export function ExportSection({
+  device,
+  exporter,
+}: {
+  device: UseAbyssDeviceReturn;
+  exporter: UseAbyssExportReturn;
+}) {
+  const { t } = useLanguage();
+  const { loaded } = device;
+  const {
+    mode,
+    setMode,
+    keymaps,
+    isLoadingKeymaps,
+    selectedKeymapId,
+    setSelectedKeymapId,
+    name,
+    setName,
+    selection,
+    setSelection,
+    isExporting,
+    error,
+    result,
+    canExport,
+    exportNow,
+  } = exporter;
+
+  if (!loaded) {
+    return (
+      <div className="glass-card p-6">
+        <h3 className="text-sm font-medium text-[var(--color-text)] mb-2">
+          {t("Export")}
+        </h3>
+        <p className="text-sm text-[var(--color-text-muted)]">
+          {t("Read the keyboard first to enable exporting.")}
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="glass-card p-6">
+      <h3 className="text-sm font-medium text-[var(--color-text)] mb-1">
+        {t("Export")}
+      </h3>
+      <p className="text-xs text-[var(--color-text-muted)] mb-4">
+        {t(
+          "Exporting uploads this keymap to abyss.keyboard-hub.com under your account.",
+        )}
+      </p>
+
+      <label className="block mb-4">
+        <span className="block text-xs text-[var(--color-text-muted)] mb-1">
+          {t("Destination")}
+        </span>
+        <select
+          className="input-field w-full tablet:w-80"
+          value={mode}
+          onChange={(event) => setMode(event.target.value as typeof mode)}
+        >
+          <option value="new">{t("Export as a new keymap")}</option>
+          <option value="update">{t("Update an existing keymap")}</option>
+        </select>
+      </label>
+
+      {mode === "new" ? (
+        <label className="block mb-4">
+          <span className="block text-xs text-[var(--color-text-muted)] mb-1">
+            {t("Keymap name")}
+          </span>
+          <input
+            className="input-field w-full tablet:w-80"
+            value={name}
+            onChange={(event) => setName(event.target.value)}
+            placeholder={t("Keymap name")}
+          />
+        </label>
+      ) : (
+        <label className="block mb-4">
+          <span className="block text-xs text-[var(--color-text-muted)] mb-1">
+            {t("Keymap to update")}
+          </span>
+          <select
+            className="input-field w-full tablet:w-80"
+            value={selectedKeymapId ?? ""}
+            disabled={isLoadingKeymaps || keymaps.length === 0}
+            onChange={(event) =>
+              setSelectedKeymapId(event.target.value || null)
+            }
+          >
+            <option value="">
+              {isLoadingKeymaps
+                ? t("Loading your keymaps...")
+                : keymaps.length === 0
+                  ? t("No keymaps found for this keyboard")
+                  : t("Select a keymap")}
+            </option>
+            {keymaps.map((keymap) => (
+              <option key={keymap.id} value={keymap.id}>
+                {keymap.name}
+                {keymap.version ? ` (v${keymap.version})` : ""}
+              </option>
+            ))}
+          </select>
+        </label>
+      )}
+
+      <DataSectionSelector
+        selection={selection}
+        onChange={setSelection}
+        // A keymap with no layers is meaningless, so a new one always carries
+        // its key bindings.
+        forced={mode === "new" ? ["keymap"] : []}
+      />
+
+      {error && <SectionError message={error} />}
+
+      {result && (
+        <div className="mb-4 p-3 rounded-lg bg-[var(--color-neon)]/10 border border-[var(--color-neon)]/20">
+          <p className="text-sm text-[var(--color-neon)] flex items-center gap-2 flex-wrap">
+            {t("Saved to Abyss as version {{version}}.", {
+              version: result.version,
+            })}
+            <a
+              className="inline-flex items-center gap-1 underline"
+              href={`${ABYSS_BASE_URL || DEFAULT_ABYSS_URL}/keymaps/${result.id}`}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              {t("Open on Abyss")}
+              <IconExternalLink size={14} />
+            </a>
+          </p>
+        </div>
+      )}
+
+      <button
+        className="btn-electric flex items-center gap-2 text-sm"
+        onClick={() => void exportNow()}
+        disabled={!canExport}
+      >
+        {isExporting ? (
+          <IconLoader2 size={16} className="animate-spin" />
+        ) : (
+          <IconCloudUpload size={16} />
+        )}
+        {mode === "new" ? t("Export as new keymap") : t("Update keymap")}
+      </button>
+    </div>
+  );
+}

--- a/src/components/importExport/ExportSection.tsx
+++ b/src/components/importExport/ExportSection.tsx
@@ -12,6 +12,7 @@ import {
 import { useLanguage } from "../../hooks/useLanguage";
 import { SectionError } from "../troubleshooting/SectionCard";
 import { DataSectionSelector } from "./DataSectionSelector";
+import { JsonPreview } from "./JsonPreview";
 import type { UseAbyssDeviceReturn } from "../../hooks/useAbyssDevice";
 import type { UseAbyssExportReturn } from "../../hooks/useAbyssExport";
 import { abyssBaseUrl, abyssHost } from "../../lib/abyss/abyssConfig";
@@ -34,6 +35,8 @@ export function ExportSection({
     setSelectedKeymapId,
     name,
     setName,
+    visibility,
+    setVisibility,
     selection,
     setSelection,
     isExporting,
@@ -41,6 +44,7 @@ export function ExportSection({
     result,
     canExport,
     exportNow,
+    preview,
   } = exporter;
 
   if (!loaded) {
@@ -82,17 +86,34 @@ export function ExportSection({
       </label>
 
       {mode === "new" ? (
-        <label className="block mb-4">
-          <span className="block text-xs text-[var(--color-text-muted)] mb-1">
-            {t("Keymap name")}
-          </span>
-          <input
-            className="input-field w-full tablet:w-80"
-            value={name}
-            onChange={(event) => setName(event.target.value)}
-            placeholder={t("Keymap name")}
-          />
-        </label>
+        <>
+          <label className="block mb-4">
+            <span className="block text-xs text-[var(--color-text-muted)] mb-1">
+              {t("Keymap name")}
+            </span>
+            <input
+              className="input-field w-full tablet:w-80"
+              value={name}
+              onChange={(event) => setName(event.target.value)}
+              placeholder={t("Keymap name")}
+            />
+          </label>
+          <label className="block mb-4">
+            <span className="block text-xs text-[var(--color-text-muted)] mb-1">
+              {t("Visibility")}
+            </span>
+            <select
+              className="input-field w-full tablet:w-80"
+              value={visibility}
+              onChange={(event) =>
+                setVisibility(event.target.value as typeof visibility)
+              }
+            >
+              <option value="private">{t("Private — only you")}</option>
+              <option value="public">{t("Public — anyone can find it")}</option>
+            </select>
+          </label>
+        </>
       ) : (
         <label className="block mb-4">
           <span className="block text-xs text-[var(--color-text-muted)] mb-1">
@@ -141,7 +162,9 @@ export function ExportSection({
             })}
             <a
               className="inline-flex items-center gap-1 underline"
-              href={`${abyssBaseUrl()}/keymaps/${result.id}`}
+              // Abyss routes a single keymap at /keymap/:id; /keymaps is the list
+              // page and /keymaps/:id matches no route at all.
+              href={`${abyssBaseUrl()}/keymap/${result.id}`}
               target="_blank"
               rel="noopener noreferrer"
             >
@@ -149,6 +172,19 @@ export function ExportSection({
               <IconExternalLink size={14} />
             </a>
           </p>
+        </div>
+      )}
+
+      {preview && (
+        <div className="mb-4 space-y-2">
+          <JsonPreview
+            title={t("Keymap JSON to upload")}
+            value={preview.keymap}
+          />
+          <JsonPreview
+            title={t("Layout JSON to upload")}
+            value={preview.layout}
+          />
         </div>
       )}
 

--- a/src/components/importExport/ExportSection.tsx
+++ b/src/components/importExport/ExportSection.tsx
@@ -16,8 +16,13 @@ import { SectionError } from "../troubleshooting/SectionCard";
 import { DataSectionSelector } from "./DataSectionSelector";
 import { JsonPreview } from "./JsonPreview";
 import { JsonDiffModal } from "./JsonDiffModal";
+import { KeymapDiffPreview } from "./KeymapDiffPreview";
+import { ComboMacroDiff } from "./ComboMacroDiff";
+import { countDiff } from "../../lib/abyss/abyssDiff";
 import type { UseAbyssDeviceReturn } from "../../hooks/useAbyssDevice";
 import type { UseAbyssExportReturn } from "../../hooks/useAbyssExport";
+import type { PreviewPosition } from "./KeymapLayerPreview";
+import type { PreviewLayer } from "./KeymapDiffPreview";
 import { abyssBaseUrl, abyssHost } from "../../lib/abyss/abyssConfig";
 
 export function ExportSection({
@@ -50,6 +55,7 @@ export function ExportSection({
     canExport,
     exportNow,
     preview,
+    diff,
   } = exporter;
 
   const selectedExisting = keymaps.find(
@@ -60,22 +66,14 @@ export function ExportSection({
 
   if (!loaded) {
     return (
-      <div className="glass-card p-6">
-        <h3 className="text-sm font-medium text-[var(--color-text)] mb-2">
-          {t("Export")}
-        </h3>
-        <p className="text-sm text-[var(--color-text-muted)]">
-          {t("Read the keyboard first to enable exporting.")}
-        </p>
-      </div>
+      <p className="text-sm text-[var(--color-text-muted)]">
+        {t("Read the keyboard first to enable exporting.")}
+      </p>
     );
   }
 
   return (
-    <div className="glass-card p-6">
-      <h3 className="text-sm font-medium text-[var(--color-text)] mb-1">
-        {t("Export")}
-      </h3>
+    <div>
       <p className="text-xs text-[var(--color-text-muted)] mb-4">
         {t("Exporting uploads this keymap to {{host}} under your account.", {
           host: abyssHost(),
@@ -164,6 +162,35 @@ export function ExportSection({
         // its key bindings.
         forced={mode === "new" ? ["keymap"] : []}
       />
+
+      {mode === "update" && selectedKeymapId && countDiff(diff).total > 0 && (
+        <div className="mb-4 space-y-3">
+          <KeymapDiffPreview
+            positions={
+              (
+                loaded.state.detectedLayout as
+                  | { positions?: PreviewPosition[] }
+                  | undefined
+              )?.positions ?? []
+            }
+            layers={
+              ((preview?.keymap as { layers?: PreviewLayer[] } | undefined)
+                ?.layers ?? []) as PreviewLayer[]
+            }
+            diff={diff}
+          />
+          <ComboMacroDiff
+            title={t("Combos")}
+            kind="combo"
+            changes={diff.comboChanges}
+          />
+          <ComboMacroDiff
+            title={t("Macros")}
+            kind="macro"
+            changes={diff.macroChanges}
+          />
+        </div>
+      )}
 
       {mode === "update" && selectedKeymapId && Boolean(preview?.keymap) && (
         <button

--- a/src/components/importExport/ExportSection.tsx
+++ b/src/components/importExport/ExportSection.tsx
@@ -4,15 +4,18 @@
  * Nothing here writes to the keyboard, and Abyss keeps version history, so this
  * side of the tab is safe to retry.
  */
+import { useState } from "react";
 import {
   IconCloudUpload,
   IconExternalLink,
+  IconFileDiff,
   IconLoader2,
 } from "@tabler/icons-react";
 import { useLanguage } from "../../hooks/useLanguage";
 import { SectionError } from "../troubleshooting/SectionCard";
 import { DataSectionSelector } from "./DataSectionSelector";
 import { JsonPreview } from "./JsonPreview";
+import { JsonDiffModal } from "./JsonDiffModal";
 import type { UseAbyssDeviceReturn } from "../../hooks/useAbyssDevice";
 import type { UseAbyssExportReturn } from "../../hooks/useAbyssExport";
 import { abyssBaseUrl, abyssHost } from "../../lib/abyss/abyssConfig";
@@ -25,12 +28,14 @@ export function ExportSection({
   exporter: UseAbyssExportReturn;
 }) {
   const { t } = useLanguage();
+  const [showDiff, setShowDiff] = useState(false);
   const { loaded } = device;
   const {
     mode,
     setMode,
     keymaps,
     isLoadingKeymaps,
+    listError,
     selectedKeymapId,
     setSelectedKeymapId,
     name,
@@ -46,6 +51,12 @@ export function ExportSection({
     exportNow,
     preview,
   } = exporter;
+
+  const selectedExisting = keymaps.find(
+    (keymap) => keymap.id === selectedKeymapId,
+  );
+  const selectedExistingData =
+    selectedExisting?.data ?? selectedExisting?.latestVersion?.data ?? null;
 
   if (!loaded) {
     return (
@@ -144,6 +155,8 @@ export function ExportSection({
         </label>
       )}
 
+      {listError && <SectionError message={listError} />}
+
       <DataSectionSelector
         selection={selection}
         onChange={setSelection}
@@ -151,6 +164,16 @@ export function ExportSection({
         // its key bindings.
         forced={mode === "new" ? ["keymap"] : []}
       />
+
+      {mode === "update" && selectedKeymapId && Boolean(preview?.keymap) && (
+        <button
+          className="btn-ghost flex items-center gap-2 text-sm mb-4"
+          onClick={() => setShowDiff(true)}
+        >
+          <IconFileDiff size={16} />
+          {t("Review changes")}
+        </button>
+      )}
 
       {error && <SectionError message={error} />}
 
@@ -200,6 +223,17 @@ export function ExportSection({
         )}
         {mode === "new" ? t("Export as new keymap") : t("Update keymap")}
       </button>
+
+      <JsonDiffModal
+        open={showDiff}
+        onOpenChange={setShowDiff}
+        title={t("Changes to upload")}
+        description={t(
+          "Left: the keymap currently on Abyss. Right: what this export would save.",
+        )}
+        before={selectedExistingData}
+        after={preview?.keymap}
+      />
     </div>
   );
 }

--- a/src/components/importExport/ImportSection.tsx
+++ b/src/components/importExport/ImportSection.tsx
@@ -1,0 +1,203 @@
+/**
+ * Writes a Keyboard Abyss keymap onto the connected keyboard.
+ *
+ * The only destructive action in this tab, so the order is deliberate: pick a
+ * keymap, see exactly what changes, clear the pre-flight checks, then confirm.
+ */
+import { useState } from "react";
+import {
+  IconAlertTriangle,
+  IconCheck,
+  IconDownload,
+  IconLoader2,
+} from "@tabler/icons-react";
+import { useLanguage } from "../../hooks/useLanguage";
+import { SectionError } from "../troubleshooting/SectionCard";
+import { DataSectionSelector } from "./DataSectionSelector";
+import { KeymapDiffView } from "./KeymapDiffView";
+import { countDiff } from "../../lib/abyss/abyssDiff";
+import type { UseAbyssDeviceReturn } from "../../hooks/useAbyssDevice";
+import type { UseAbyssImportReturn } from "../../hooks/useAbyssImport";
+
+export function ImportSection({
+  device,
+  importer,
+}: {
+  device: UseAbyssDeviceReturn;
+  importer: UseAbyssImportReturn;
+}) {
+  const { t } = useLanguage();
+  const [confirming, setConfirming] = useState(false);
+  const {
+    keymaps,
+    isLoadingKeymaps,
+    selectedKeymapId,
+    selectKeymap,
+    isLoadingSelection,
+    selection,
+    setSelection,
+    diff,
+    isInSync,
+    preflight,
+    canWrite,
+    isWriting,
+    didWrite,
+    error,
+    write,
+  } = importer;
+
+  if (!device.loaded) {
+    return (
+      <div className="glass-card p-6">
+        <h3 className="text-sm font-medium text-[var(--color-text)] mb-2">
+          {t("Import")}
+        </h3>
+        <p className="text-sm text-[var(--color-text-muted)]">
+          {t("Read the keyboard first to enable importing.")}
+        </p>
+      </div>
+    );
+  }
+
+  const counts = countDiff(diff);
+
+  return (
+    <div className="glass-card p-6">
+      <h3 className="text-sm font-medium text-[var(--color-text)] mb-1">
+        {t("Import")}
+      </h3>
+      <p className="text-xs text-[var(--color-text-muted)] mb-4">
+        {t(
+          "Writing changes the keyboard. Review the changes before confirming.",
+        )}
+      </p>
+
+      <label className="block mb-4">
+        <span className="block text-xs text-[var(--color-text-muted)] mb-1">
+          {t("Keymap to write")}
+        </span>
+        <select
+          className="input-field w-full tablet:w-80"
+          value={selectedKeymapId ?? ""}
+          disabled={isLoadingKeymaps || keymaps.length === 0 || isWriting}
+          onChange={(event) => void selectKeymap(event.target.value || null)}
+        >
+          <option value="">
+            {isLoadingKeymaps
+              ? t("Loading your keymaps...")
+              : keymaps.length === 0
+                ? t("No compatible keymaps found for this keyboard")
+                : t("Select a keymap")}
+          </option>
+          {keymaps.map((keymap) => (
+            <option key={keymap.id} value={keymap.id}>
+              {keymap.name}
+              {keymap.version ? ` (v${keymap.version})` : ""}
+            </option>
+          ))}
+        </select>
+      </label>
+
+      {selectedKeymapId && (
+        <DataSectionSelector selection={selection} onChange={setSelection} />
+      )}
+
+      {isLoadingSelection && (
+        <p className="text-sm text-[var(--color-text-muted)] mb-4">
+          {t("Loading the keymap...")}
+        </p>
+      )}
+
+      {error && <SectionError message={error} />}
+
+      {preflight.map((check) => (
+        <div
+          key={check.id}
+          className={`mb-3 p-3 rounded-lg flex items-start gap-2 ${
+            check.level === "blocked"
+              ? "bg-red-500/10 border border-red-500/20"
+              : "bg-amber-500/10 border border-amber-500/20"
+          }`}
+        >
+          <IconAlertTriangle
+            size={16}
+            className={
+              check.level === "blocked"
+                ? "text-red-400 flex-shrink-0 mt-0.5"
+                : "text-amber-400 flex-shrink-0 mt-0.5"
+            }
+          />
+          <p
+            className={`text-sm ${
+              check.level === "blocked" ? "text-red-400" : "text-amber-400"
+            }`}
+          >
+            {t(check.message, check.params)}
+          </p>
+        </div>
+      ))}
+
+      {didWrite && (
+        <div className="mb-4 p-3 rounded-lg bg-[var(--color-neon)]/10 border border-[var(--color-neon)]/20">
+          <p className="text-sm text-[var(--color-neon)] flex items-center gap-2">
+            <IconCheck size={16} />
+            {t("Written to the keyboard and re-read to confirm.")}
+          </p>
+        </div>
+      )}
+
+      {isInSync && !didWrite && (
+        <p className="text-sm text-[var(--color-text-muted)] mb-4">
+          {t("The keyboard already matches this keymap.")}
+        </p>
+      )}
+
+      {!isInSync && counts.total > 0 && (
+        <div className="mb-4">
+          <KeymapDiffView diff={diff} />
+        </div>
+      )}
+
+      {confirming ? (
+        <div className="p-4 rounded-lg border border-[var(--color-border)]">
+          <p className="text-sm text-[var(--color-text)] mb-3">
+            {t(
+              "Write {{count}} changes to the keyboard? This replaces the current settings and cannot be undone.",
+              { count: counts.total },
+            )}
+          </p>
+          <div className="flex gap-2">
+            <button
+              className="px-4 py-2 rounded-lg text-sm font-medium text-red-400 border border-red-500/30 hover:bg-red-500/10 transition-colors"
+              onClick={() => {
+                setConfirming(false);
+                void write();
+              }}
+            >
+              {t("Write to keyboard")}
+            </button>
+            <button
+              className="btn-ghost text-sm"
+              onClick={() => setConfirming(false)}
+            >
+              {t("Cancel")}
+            </button>
+          </div>
+        </div>
+      ) : (
+        <button
+          className="btn-electric flex items-center gap-2 text-sm"
+          onClick={() => setConfirming(true)}
+          disabled={!canWrite}
+        >
+          {isWriting ? (
+            <IconLoader2 size={16} className="animate-spin" />
+          ) : (
+            <IconDownload size={16} />
+          )}
+          {t("Write to keyboard")}
+        </button>
+      )}
+    </div>
+  );
+}

--- a/src/components/importExport/ImportSection.tsx
+++ b/src/components/importExport/ImportSection.tsx
@@ -16,10 +16,14 @@ import { useLanguage } from "../../hooks/useLanguage";
 import { SectionError } from "../troubleshooting/SectionCard";
 import { DataSectionSelector } from "./DataSectionSelector";
 import { KeymapDiffView } from "./KeymapDiffView";
+import { KeymapDiffPreview } from "./KeymapDiffPreview";
+import { ComboMacroDiff } from "./ComboMacroDiff";
 import { JsonDiffModal } from "./JsonDiffModal";
 import { countDiff } from "../../lib/abyss/abyssDiff";
 import type { UseAbyssDeviceReturn } from "../../hooks/useAbyssDevice";
 import type { UseAbyssImportReturn } from "../../hooks/useAbyssImport";
+import type { PreviewPosition } from "./KeymapLayerPreview";
+import type { PreviewLayer } from "./KeymapDiffPreview";
 
 export function ImportSection({
   device,
@@ -53,24 +57,16 @@ export function ImportSection({
 
   if (!device.loaded) {
     return (
-      <div className="glass-card p-6">
-        <h3 className="text-sm font-medium text-[var(--color-text)] mb-2">
-          {t("Import")}
-        </h3>
-        <p className="text-sm text-[var(--color-text-muted)]">
-          {t("Read the keyboard first to enable importing.")}
-        </p>
-      </div>
+      <p className="text-sm text-[var(--color-text-muted)]">
+        {t("Read the keyboard first to enable importing.")}
+      </p>
     );
   }
 
   const counts = countDiff(diff);
 
   return (
-    <div className="glass-card p-6">
-      <h3 className="text-sm font-medium text-[var(--color-text)] mb-1">
-        {t("Import")}
-      </h3>
+    <div>
       <p className="text-xs text-[var(--color-text-muted)] mb-4">
         {t(
           "Writing changes the keyboard. Review the changes before confirming.",
@@ -160,8 +156,36 @@ export function ImportSection({
 
       {!isInSync && counts.total > 0 && (
         <div className="mb-4">
+          <KeymapDiffPreview
+            positions={
+              (
+                device.loaded.state.detectedLayout as
+                  | { positions?: PreviewPosition[] }
+                  | undefined
+              )?.positions ?? []
+            }
+            layers={
+              ((targetKeymap as { layers?: PreviewLayer[] } | null)?.layers ??
+                []) as PreviewLayer[]
+            }
+            diff={diff}
+          />
+
+          <div className="mt-3 space-y-3">
+            <ComboMacroDiff
+              title={t("Combos")}
+              kind="combo"
+              changes={diff.comboChanges}
+            />
+            <ComboMacroDiff
+              title={t("Macros")}
+              kind="macro"
+              changes={diff.macroChanges}
+            />
+          </div>
+
           <button
-            className="btn-ghost flex items-center gap-2 text-sm mb-3"
+            className="btn-ghost flex items-center gap-2 text-sm mt-3 mb-3"
             onClick={() => setShowDiff(true)}
           >
             <IconFileDiff size={16} />

--- a/src/components/importExport/ImportSection.tsx
+++ b/src/components/importExport/ImportSection.tsx
@@ -9,12 +9,14 @@ import {
   IconAlertTriangle,
   IconCheck,
   IconDownload,
+  IconFileDiff,
   IconLoader2,
 } from "@tabler/icons-react";
 import { useLanguage } from "../../hooks/useLanguage";
 import { SectionError } from "../troubleshooting/SectionCard";
 import { DataSectionSelector } from "./DataSectionSelector";
 import { KeymapDiffView } from "./KeymapDiffView";
+import { JsonDiffModal } from "./JsonDiffModal";
 import { countDiff } from "../../lib/abyss/abyssDiff";
 import type { UseAbyssDeviceReturn } from "../../hooks/useAbyssDevice";
 import type { UseAbyssImportReturn } from "../../hooks/useAbyssImport";
@@ -28,15 +30,18 @@ export function ImportSection({
 }) {
   const { t } = useLanguage();
   const [confirming, setConfirming] = useState(false);
+  const [showDiff, setShowDiff] = useState(false);
   const {
     keymaps,
     isLoadingKeymaps,
+    listError,
     selectedKeymapId,
     selectKeymap,
     isLoadingSelection,
     selection,
     setSelection,
     diff,
+    targetKeymap,
     isInSync,
     preflight,
     canWrite,
@@ -108,6 +113,7 @@ export function ImportSection({
         </p>
       )}
 
+      {listError && <SectionError message={listError} />}
       {error && <SectionError message={error} />}
 
       {preflight.map((check) => (
@@ -154,6 +160,13 @@ export function ImportSection({
 
       {!isInSync && counts.total > 0 && (
         <div className="mb-4">
+          <button
+            className="btn-ghost flex items-center gap-2 text-sm mb-3"
+            onClick={() => setShowDiff(true)}
+          >
+            <IconFileDiff size={16} />
+            {t("Review changes as JSON")}
+          </button>
           <KeymapDiffView diff={diff} />
         </div>
       )}
@@ -198,6 +211,17 @@ export function ImportSection({
           {t("Write to keyboard")}
         </button>
       )}
+
+      <JsonDiffModal
+        open={showDiff}
+        onOpenChange={setShowDiff}
+        title={t("Changes to write")}
+        description={t(
+          "Left: what is on the keyboard now. Right: the keymap from Abyss.",
+        )}
+        before={device.loaded?.state.currentKeymap}
+        after={targetKeymap}
+      />
     </div>
   );
 }

--- a/src/components/importExport/JsonDiffModal.tsx
+++ b/src/components/importExport/JsonDiffModal.tsx
@@ -111,7 +111,10 @@ export function JsonDiffModal({
     <Dialog.Root open={open} onOpenChange={onOpenChange}>
       <Dialog.Portal>
         <Dialog.Overlay className="fixed inset-0 bg-black/50 backdrop-blur-sm z-50" />
-        <Dialog.Content className="fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[95vw] h-[90vh] max-w-6xl z-50 flex flex-col glass-card p-0 overflow-hidden">
+        {/* Full-bleed on phones — a 95vw/90vh sheet wastes edges that matter
+            most where there are fewest of them, and a diff is the densest thing
+            in this app. From tablet up it becomes a centred dialog. */}
+        <Dialog.Content className="fixed inset-0 w-full h-full max-w-none rounded-none border-0 z-50 flex flex-col glass-card p-0 overflow-hidden tablet:inset-auto tablet:top-1/2 tablet:left-1/2 tablet:-translate-x-1/2 tablet:-translate-y-1/2 tablet:w-[95vw] tablet:h-[90vh] tablet:max-w-6xl tablet:rounded-xl tablet:border">
           <div className="flex items-start gap-3 p-4 border-b border-[var(--color-border)]">
             <div className="min-w-0 flex-1">
               <Dialog.Title className="text-sm font-medium text-[var(--color-text)]">

--- a/src/components/importExport/JsonDiffModal.tsx
+++ b/src/components/importExport/JsonDiffModal.tsx
@@ -1,0 +1,166 @@
+/**
+ * Full-screen JSON diff, opened before committing a keymap change.
+ *
+ * Mirrors Keyboard Abyss's diff editor so the same keymap reads the same way on
+ * both sides: inline or side-by-side, and either a few lines of context around
+ * each change or the whole document.
+ *
+ * Rendering is deferred until the dialog is actually open — a keymap is tens of
+ * thousands of characters, and diffing two of them on every parent render would
+ * be paid by everyone who never opens it.
+ */
+import { useMemo, useState } from "react";
+import * as Dialog from "@radix-ui/react-dialog";
+import { IconX } from "@tabler/icons-react";
+import { Diff, Hunk, type FileData } from "react-diff-view";
+import "react-diff-view/style/index.css";
+import { useLanguage } from "../../hooks/useLanguage";
+import {
+  buildJsonDiff,
+  toDiffJson,
+  type DiffViewMode,
+} from "../../lib/abyss/jsonDiff";
+
+function SegmentedControl<T extends string>({
+  value,
+  options,
+  onChange,
+}: {
+  value: T;
+  options: { value: T; label: string }[];
+  onChange: (value: T) => void;
+}) {
+  return (
+    <div className="inline-flex rounded-lg border border-[var(--color-border)] overflow-hidden">
+      {options.map((option) => (
+        <button
+          key={option.value}
+          type="button"
+          onClick={() => onChange(option.value)}
+          aria-pressed={value === option.value}
+          className={`px-3 py-1.5 text-xs transition-colors ${
+            value === option.value
+              ? "bg-[var(--color-electric)]/15 text-[var(--color-electric)]"
+              : "text-[var(--color-text-muted)] hover:text-[var(--color-text)]"
+          }`}
+        >
+          {option.label}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+function DiffBody({
+  files,
+  viewMode,
+}: {
+  files: FileData[];
+  viewMode: DiffViewMode;
+}) {
+  return (
+    <>
+      {files.map((file, index) => (
+        <Diff
+          key={file.newPath ?? index}
+          diffType={file.type}
+          hunks={file.hunks}
+          viewType={viewMode}
+        >
+          {(hunks) =>
+            hunks.map((hunk) => <Hunk hunk={hunk} key={hunk.content} />)
+          }
+        </Diff>
+      ))}
+    </>
+  );
+}
+
+export function JsonDiffModal({
+  open,
+  onOpenChange,
+  title,
+  description,
+  before,
+  after,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  title: string;
+  /** What the two sides mean, so nobody has to guess which is which. */
+  description: string;
+  before: unknown;
+  after: unknown;
+}) {
+  const { t } = useLanguage();
+  const [viewMode, setViewMode] = useState<DiffViewMode>("unified");
+  const [showEntireFile, setShowEntireFile] = useState(false);
+
+  const diff = useMemo(() => {
+    if (!open) return null;
+    return buildJsonDiff(toDiffJson(before), toDiffJson(after));
+  }, [open, before, after]);
+
+  const files = diff
+    ? showEntireFile
+      ? diff.expandedFiles
+      : diff.collapsedFiles
+    : [];
+
+  return (
+    <Dialog.Root open={open} onOpenChange={onOpenChange}>
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 bg-black/50 backdrop-blur-sm z-50" />
+        <Dialog.Content className="fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[95vw] h-[90vh] max-w-6xl z-50 flex flex-col glass-card p-0 overflow-hidden">
+          <div className="flex items-start gap-3 p-4 border-b border-[var(--color-border)]">
+            <div className="min-w-0 flex-1">
+              <Dialog.Title className="text-sm font-medium text-[var(--color-text)]">
+                {title}
+              </Dialog.Title>
+              <Dialog.Description className="text-xs text-[var(--color-text-muted)]">
+                {description}
+              </Dialog.Description>
+            </div>
+            <Dialog.Close
+              className="btn-ghost p-1.5 flex-shrink-0"
+              aria-label={t("Close")}
+            >
+              <IconX size={16} />
+            </Dialog.Close>
+          </div>
+
+          <div className="flex flex-wrap items-center gap-3 px-4 py-3 border-b border-[var(--color-border)]">
+            <SegmentedControl
+              value={viewMode}
+              onChange={setViewMode}
+              options={[
+                { value: "unified", label: t("Inline") },
+                { value: "split", label: t("Side by side") },
+              ]}
+            />
+            {diff?.hasHiddenContext && (
+              <SegmentedControl
+                value={showEntireFile ? "all" : "around"}
+                onChange={(value) => setShowEntireFile(value === "all")}
+                options={[
+                  { value: "around", label: t("Around changes") },
+                  { value: "all", label: t("Entire file") },
+                ]}
+              />
+            )}
+          </div>
+
+          <div className="flex-1 overflow-auto p-4 text-xs abyss-diff">
+            {diff && !diff.hasChanges ? (
+              <p className="text-sm text-[var(--color-text-muted)]">
+                {t("No differences.")}
+              </p>
+            ) : (
+              <DiffBody files={files} viewMode={viewMode} />
+            )}
+          </div>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}

--- a/src/components/importExport/JsonDiffModal.tsx
+++ b/src/components/importExport/JsonDiffModal.tsx
@@ -38,7 +38,7 @@ function SegmentedControl<T extends string>({
           type="button"
           onClick={() => onChange(option.value)}
           aria-pressed={value === option.value}
-          className={`px-3 py-1.5 text-xs transition-colors ${
+          className={`px-2.5 py-1 tablet:px-3 tablet:py-1.5 text-xs transition-colors ${
             value === option.value
               ? "bg-[var(--color-electric)]/15 text-[var(--color-electric)]"
               : "text-[var(--color-text-muted)] hover:text-[var(--color-text)]"
@@ -113,9 +113,15 @@ export function JsonDiffModal({
         <Dialog.Overlay className="fixed inset-0 bg-black/50 backdrop-blur-sm z-50" />
         {/* Full-bleed on phones — a 95vw/90vh sheet wastes edges that matter
             most where there are fewest of them, and a diff is the densest thing
-            in this app. From tablet up it becomes a centred dialog. */}
-        <Dialog.Content className="fixed inset-0 w-screen h-dvh max-w-none max-h-dvh rounded-none border-0 z-50 flex flex-col glass-card p-0 overflow-hidden tablet:inset-auto tablet:top-1/2 tablet:left-1/2 tablet:-translate-x-1/2 tablet:-translate-y-1/2 tablet:w-[95vw] tablet:h-[90vh] tablet:max-h-[90vh] tablet:max-w-6xl tablet:rounded-xl tablet:border">
-          <div className="shrink-0 flex items-start gap-3 p-4 border-b border-[var(--color-border)]">
+            in this app. From tablet up it becomes a centred dialog.
+            
+            Sized with `w-screen` rather than `inset-x-0`: a fixed element's
+            containing block is not always the layout viewport (an ancestor with
+            a filter or transform establishes one), and where they differ
+            `inset-x-0` stretched the sheet wider than the screen and pushed the
+            close button off it. `100vw` tracks the layout viewport. */}
+        <Dialog.Content className="diff-sheet fixed left-0 top-0 w-screen h-dvh max-w-none max-h-dvh z-50 flex flex-col glass-card p-0 overflow-hidden tablet:inset-auto tablet:top-1/2 tablet:left-1/2 tablet:-translate-x-1/2 tablet:-translate-y-1/2 tablet:w-[95vw] tablet:h-[90vh] tablet:max-h-[90vh] tablet:max-w-6xl tablet:rounded-xl tablet:border">
+          <div className="shrink-0 flex items-start gap-3 p-3 tablet:p-4 border-b border-[var(--color-border)]">
             <div className="min-w-0 flex-1">
               <Dialog.Title className="text-sm font-medium text-[var(--color-text)] break-words">
                 {title}
@@ -132,7 +138,7 @@ export function JsonDiffModal({
             </Dialog.Close>
           </div>
 
-          <div className="shrink-0 flex flex-wrap items-center gap-3 px-4 py-3 border-b border-[var(--color-border)]">
+          <div className="shrink-0 flex flex-wrap items-center gap-2 px-3 py-2 tablet:gap-3 tablet:px-4 tablet:py-3 border-b border-[var(--color-border)]">
             <SegmentedControl
               value={viewMode}
               onChange={setViewMode}
@@ -157,7 +163,7 @@ export function JsonDiffModal({
               `min-height: auto`, so without them a long diff refuses to shrink
               and pushes the dialog past the bottom of the screen instead of
               scrolling inside it. Same story horizontally for a wide table. */}
-          <div className="flex-1 min-h-0 min-w-0 overflow-auto p-4 text-xs abyss-diff">
+          <div className="flex-1 min-h-0 min-w-0 overflow-auto p-2 tablet:p-4 text-xs abyss-diff">
             {diff && !diff.hasChanges ? (
               <p className="text-sm text-[var(--color-text-muted)]">
                 {t("No differences.")}

--- a/src/components/importExport/JsonDiffModal.tsx
+++ b/src/components/importExport/JsonDiffModal.tsx
@@ -114,13 +114,13 @@ export function JsonDiffModal({
         {/* Full-bleed on phones — a 95vw/90vh sheet wastes edges that matter
             most where there are fewest of them, and a diff is the densest thing
             in this app. From tablet up it becomes a centred dialog. */}
-        <Dialog.Content className="fixed inset-0 w-full h-full max-w-none rounded-none border-0 z-50 flex flex-col glass-card p-0 overflow-hidden tablet:inset-auto tablet:top-1/2 tablet:left-1/2 tablet:-translate-x-1/2 tablet:-translate-y-1/2 tablet:w-[95vw] tablet:h-[90vh] tablet:max-w-6xl tablet:rounded-xl tablet:border">
-          <div className="flex items-start gap-3 p-4 border-b border-[var(--color-border)]">
+        <Dialog.Content className="fixed inset-0 w-screen h-dvh max-w-none max-h-dvh rounded-none border-0 z-50 flex flex-col glass-card p-0 overflow-hidden tablet:inset-auto tablet:top-1/2 tablet:left-1/2 tablet:-translate-x-1/2 tablet:-translate-y-1/2 tablet:w-[95vw] tablet:h-[90vh] tablet:max-h-[90vh] tablet:max-w-6xl tablet:rounded-xl tablet:border">
+          <div className="shrink-0 flex items-start gap-3 p-4 border-b border-[var(--color-border)]">
             <div className="min-w-0 flex-1">
-              <Dialog.Title className="text-sm font-medium text-[var(--color-text)]">
+              <Dialog.Title className="text-sm font-medium text-[var(--color-text)] break-words">
                 {title}
               </Dialog.Title>
-              <Dialog.Description className="text-xs text-[var(--color-text-muted)]">
+              <Dialog.Description className="text-xs text-[var(--color-text-muted)] break-words">
                 {description}
               </Dialog.Description>
             </div>
@@ -132,7 +132,7 @@ export function JsonDiffModal({
             </Dialog.Close>
           </div>
 
-          <div className="flex flex-wrap items-center gap-3 px-4 py-3 border-b border-[var(--color-border)]">
+          <div className="shrink-0 flex flex-wrap items-center gap-3 px-4 py-3 border-b border-[var(--color-border)]">
             <SegmentedControl
               value={viewMode}
               onChange={setViewMode}
@@ -153,7 +153,11 @@ export function JsonDiffModal({
             )}
           </div>
 
-          <div className="flex-1 overflow-auto p-4 text-xs abyss-diff">
+          {/* `min-h-0`/`min-w-0` are load-bearing: a flex child defaults to
+              `min-height: auto`, so without them a long diff refuses to shrink
+              and pushes the dialog past the bottom of the screen instead of
+              scrolling inside it. Same story horizontally for a wide table. */}
+          <div className="flex-1 min-h-0 min-w-0 overflow-auto p-4 text-xs abyss-diff">
             {diff && !diff.hasChanges ? (
               <p className="text-sm text-[var(--color-text-muted)]">
                 {t("No differences.")}

--- a/src/components/importExport/JsonPreview.tsx
+++ b/src/components/importExport/JsonPreview.tsx
@@ -1,0 +1,43 @@
+/**
+ * Collapsed view of a JSON document.
+ *
+ * Exporting sends a document the user never otherwise sees; being able to open
+ * it and read exactly what left the machine is the difference between trusting
+ * the feature and hoping. Collapsed by default because it is long.
+ *
+ * The body is always rendered and simply hidden by `<details>`, rather than
+ * mounted on toggle. Gating it on an `onToggle` state handler looked like a
+ * free optimisation but silently rendered an empty pane — the browser opened
+ * the element while React never mounted its contents. The stringify cost is
+ * paid once per payload instead, via `useMemo`.
+ */
+import { useMemo } from "react";
+import { useLanguage } from "../../hooks/useLanguage";
+
+export function JsonPreview({
+  title,
+  value,
+}: {
+  title: string;
+  value: unknown;
+}) {
+  const { t } = useLanguage();
+  const text = useMemo(
+    () =>
+      value === null || value === undefined
+        ? null
+        : JSON.stringify(value, null, 2),
+    [value],
+  );
+
+  return (
+    <details className="rounded-lg border border-[var(--color-border)] px-3 py-2">
+      <summary className="cursor-pointer text-xs text-[var(--color-text-muted)]">
+        {title}
+      </summary>
+      <pre className="mt-2 max-h-80 overflow-auto rounded bg-[var(--color-border)] p-2 text-[10px] leading-relaxed text-[var(--color-text-muted)]">
+        {text ?? t("Not available.")}
+      </pre>
+    </details>
+  );
+}

--- a/src/components/importExport/KeymapDiffPreview.tsx
+++ b/src/components/importExport/KeymapDiffPreview.tsx
@@ -1,0 +1,87 @@
+/**
+ * Layer-by-layer visual diff: tab per layer, physical preview of the selected
+ * one, changed keys highlighted and explained on hover.
+ *
+ * Shared by export and import — the two directions differ only in which side is
+ * "before" and which is "after", which the caller resolves before getting here.
+ */
+import { useMemo, useState } from "react";
+import { useLanguage } from "../../hooks/useLanguage";
+import { LayerTabs } from "./LayerTabs";
+import {
+  KeymapLayerPreview,
+  type PreviewChange,
+  type PreviewPosition,
+} from "./KeymapLayerPreview";
+import type { KeymapDiff } from "../../lib/abyss/abyssDiff";
+
+export interface PreviewLayer {
+  name?: string;
+  bindings: unknown[];
+}
+
+export function KeymapDiffPreview({
+  positions,
+  layers,
+  diff,
+}: {
+  /** Key geometry from the Abyss layout document. */
+  positions: PreviewPosition[];
+  /** Layers as they would be *after* the change, so the preview shows the result. */
+  layers: PreviewLayer[];
+  diff: KeymapDiff;
+}) {
+  const { t } = useLanguage();
+  const [activeIndex, setActiveIndex] = useState(0);
+
+  /** Changed keys per layer, so each layer's preview is a plain lookup. */
+  const changesByLayer = useMemo(() => {
+    const byLayer = new Map<number, Map<number, PreviewChange>>();
+    for (const change of diff.bindingChanges) {
+      const layer =
+        byLayer.get(change.layerIndex) ?? new Map<number, PreviewChange>();
+      layer.set(change.keyIndex, { from: change.from, to: change.to });
+      byLayer.set(change.layerIndex, layer);
+    }
+    return byLayer;
+  }, [diff.bindingChanges]);
+
+  const tabs = layers.map((layer, index) => ({
+    index,
+    name: layer.name ?? "",
+    changeCount: changesByLayer.get(index)?.size ?? 0,
+  }));
+
+  // Land on the first layer that actually changed rather than always layer 0,
+  // which is usually unchanged and makes the preview look like it is not working.
+  const firstChanged = tabs.find((tab) => tab.changeCount > 0)?.index ?? 0;
+  const [touched, setTouched] = useState(false);
+  const shownIndex = touched ? activeIndex : firstChanged;
+  const layer = layers[shownIndex];
+
+  if (layers.length === 0) return null;
+
+  return (
+    <div>
+      <LayerTabs
+        layers={tabs}
+        activeIndex={shownIndex}
+        onSelect={(index) => {
+          setTouched(true);
+          setActiveIndex(index);
+        }}
+      />
+      {layer ? (
+        <KeymapLayerPreview
+          positions={positions}
+          bindings={layer.bindings}
+          changes={changesByLayer.get(shownIndex) ?? new Map()}
+        />
+      ) : (
+        <p className="text-xs text-[var(--color-text-muted)]">
+          {t("This layer does not exist in the selected keymap.")}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/components/importExport/KeymapDiffView.tsx
+++ b/src/components/importExport/KeymapDiffView.tsx
@@ -1,0 +1,220 @@
+/**
+ * Shows exactly what a write would change.
+ *
+ * Designed for the large case: replacing a full keymap is several hundred
+ * binding rows, and a flat list of those is unreadable. Changes are grouped
+ * into one collapsible card per layer so a collapsed card still says how much
+ * it contains, and the row list is capped until the user asks for all of it.
+ */
+import { useState } from "react";
+import { useLanguage } from "../../hooks/useLanguage";
+import { SectionCard } from "../troubleshooting/SectionCard";
+import {
+  BINDING_ROW_LIMIT,
+  bindingLabel,
+  countDiff,
+  globalModuleChanges,
+  groupByLayer,
+  type CollectionChange,
+  type KeymapDiff,
+  type LayerDiff,
+} from "../../lib/abyss/abyssDiff";
+
+function Chip({ label, count }: { label: string; count: number }) {
+  if (count === 0) return null;
+  return (
+    <span className="px-2 py-0.5 rounded-full text-xs bg-[var(--color-border)] text-[var(--color-text-muted)] tabular-nums">
+      {count} {label}
+    </span>
+  );
+}
+
+/** `#12  ▽ → LT(2, 0x2c)` */
+function BindingRow({
+  keyIndex,
+  from,
+  to,
+}: {
+  keyIndex: number;
+  from?: unknown;
+  to?: unknown;
+}) {
+  return (
+    <div className="flex items-center gap-2 text-xs py-0.5">
+      <span className="w-10 flex-shrink-0 text-[var(--color-text-muted)] tabular-nums">
+        #{keyIndex}
+      </span>
+      <span className="text-[var(--color-text-muted)] line-through">
+        {bindingLabel(from)}
+      </span>
+      <span className="text-[var(--color-text-muted)]">→</span>
+      <span className="text-[var(--color-neon)]">{bindingLabel(to)}</span>
+    </div>
+  );
+}
+
+function LayerCard({ layer }: { layer: LayerDiff }) {
+  const { t } = useLanguage();
+  const [showAll, setShowAll] = useState(false);
+  const changeCount =
+    layer.bindingChanges.length +
+    layer.moduleChanges.length +
+    (layer.nameChange ? 1 : 0);
+  const visible = showAll
+    ? layer.bindingChanges
+    : layer.bindingChanges.slice(0, 50);
+
+  return (
+    <SectionCard
+      icon={
+        <span className="text-xs text-[var(--color-text-muted)] tabular-nums">
+          L{layer.layerIndex}
+        </span>
+      }
+      title={
+        layer.layerName || t("Layer {{index}}", { index: layer.layerIndex })
+      }
+      summary={
+        <span className="text-xs text-[var(--color-text-muted)] tabular-nums">
+          {t("{{count}} changes", { count: changeCount })}
+        </span>
+      }
+    >
+      {layer.nameChange && (
+        <p className="text-sm text-[var(--color-text)] mb-3">
+          {t("Rename")}:{" "}
+          <span className="text-[var(--color-text-muted)] line-through">
+            {layer.nameChange.from ?? "—"}
+          </span>{" "}
+          →{" "}
+          <span className="text-[var(--color-neon)]">
+            {layer.nameChange.to}
+          </span>
+        </p>
+      )}
+
+      {layer.bindingChanges.length > 0 && (
+        <div className="mb-3">
+          {visible.map((change) => (
+            <BindingRow
+              key={change.keyIndex}
+              keyIndex={change.keyIndex}
+              from={change.from}
+              to={change.to}
+            />
+          ))}
+          {!showAll && layer.bindingChanges.length > visible.length && (
+            <button
+              className="btn-ghost text-xs mt-2"
+              onClick={() => setShowAll(true)}
+            >
+              {t("Show all {{count}} keys", {
+                count: layer.bindingChanges.length,
+              })}
+            </button>
+          )}
+        </div>
+      )}
+
+      {layer.moduleChanges.map((change) => (
+        <p
+          key={change.moduleName}
+          className="text-xs text-[var(--color-text-muted)]"
+        >
+          {t("Module")}: {change.moduleName}
+        </p>
+      ))}
+    </SectionCard>
+  );
+}
+
+function CollectionList({
+  title,
+  changes,
+}: {
+  title: string;
+  changes: CollectionChange[];
+}) {
+  if (changes.length === 0) return null;
+  return (
+    <div className="glass-card p-6">
+      <h4 className="text-sm font-medium text-[var(--color-text)] mb-2">
+        {title}
+      </h4>
+      {changes.map((change) => (
+        <details key={change.index} className="text-xs mb-1">
+          <summary className="cursor-pointer text-[var(--color-text-muted)]">
+            {change.label}
+            {change.to === undefined ? " (removed)" : ""}
+          </summary>
+          <pre className="mt-1 p-2 rounded bg-[var(--color-border)] overflow-x-auto text-[10px] text-[var(--color-text-muted)]">
+            {JSON.stringify(change.to ?? change.from, null, 2)}
+          </pre>
+        </details>
+      ))}
+    </div>
+  );
+}
+
+export function KeymapDiffView({ diff }: { diff: KeymapDiff }) {
+  const { t } = useLanguage();
+  const [showLargeDiff, setShowLargeDiff] = useState(false);
+  const counts = countDiff(diff);
+  const layers = groupByLayer(diff);
+  const globals = globalModuleChanges(diff);
+  // A full keymap replacement is several hundred rows; rendering them all is
+  // slow and tells the user nothing they cannot get from the counts.
+  const isLarge = counts.bindings > BINDING_ROW_LIMIT && !showLargeDiff;
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-wrap items-center gap-2">
+        <Chip label={t("bindings")} count={counts.bindings} />
+        <Chip label={t("layer names")} count={counts.layerNames} />
+        <Chip label={t("combos")} count={counts.combos} />
+        <Chip label={t("macros")} count={counts.macros} />
+        <Chip label={t("modules")} count={counts.modules} />
+      </div>
+
+      {isLarge ? (
+        <div className="glass-card p-6">
+          <p className="text-sm text-[var(--color-text-muted)] mb-3">
+            {t(
+              "This replaces most of the keymap ({{count}} keys). The full list is long.",
+              { count: counts.bindings },
+            )}
+          </p>
+          <button
+            className="btn-ghost text-sm"
+            onClick={() => setShowLargeDiff(true)}
+          >
+            {t("Show the full list anyway")}
+          </button>
+        </div>
+      ) : (
+        layers.map((layer) => (
+          <LayerCard key={layer.layerIndex} layer={layer} />
+        ))
+      )}
+
+      <CollectionList title={t("Combos")} changes={diff.comboChanges} />
+      <CollectionList title={t("Macros")} changes={diff.macroChanges} />
+
+      {globals.length > 0 && (
+        <div className="glass-card p-6">
+          <h4 className="text-sm font-medium text-[var(--color-text)] mb-2">
+            {t("Module settings")}
+          </h4>
+          {globals.map((change) => (
+            <p
+              key={change.moduleName}
+              className="text-xs text-[var(--color-text-muted)]"
+            >
+              {change.moduleName}
+            </p>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/importExport/KeymapLayerPreview.tsx
+++ b/src/components/importExport/KeymapLayerPreview.tsx
@@ -12,10 +12,12 @@
  * here.
  */
 import { useEffect, useRef, useState } from "react";
+import * as Popover from "@radix-ui/react-popover";
 import * as Tooltip from "@radix-ui/react-tooltip";
 import { useLanguage } from "../../hooks/useLanguage";
 import { bindingLabel } from "../../lib/abyss/abyssDiff";
 import {
+  isCoarsePointer,
   normalizePositions,
   previewScale,
 } from "../../lib/abyss/previewLayout";
@@ -47,64 +49,97 @@ function KeyCap({
   index,
   binding,
   change,
+  touch,
 }: {
   position: PreviewPosition;
   index: number;
   binding: unknown;
   change?: PreviewChange;
+  /** True on touch screens, where the detail opens on tap rather than hover. */
+  touch: boolean;
 }) {
   const { t } = useLanguage();
   const width = (position.w ?? 1) * UNIT - GAP;
   const height = (position.h ?? 1) * UNIT - GAP;
   const rotation = (position.r ?? 0) / 100;
 
-  const cap = (
-    <div
-      className={`absolute flex items-center justify-center overflow-hidden rounded text-[9px] leading-none ${
-        change
-          ? "bg-[var(--color-neon)]/25 border border-[var(--color-neon)] text-[var(--color-text)]"
-          : "bg-[var(--color-border)] border border-[var(--color-border-hover)] text-[var(--color-text-muted)]"
-      }`}
-      style={{
-        left: position.x * UNIT,
-        top: position.y * UNIT,
-        width,
-        height,
-        transform: rotation ? `rotate(${rotation}deg)` : undefined,
-        transformOrigin:
-          position.rx !== undefined && position.ry !== undefined
-            ? `${(position.rx - position.x) * UNIT}px ${(position.ry - position.y) * UNIT}px`
-            : undefined,
-      }}
-    >
-      <span className="px-0.5 truncate">{bindingLabel(binding)}</span>
-    </div>
+  const shared = {
+    className: `absolute flex items-center justify-center overflow-hidden rounded text-[9px] leading-none ${
+      change
+        ? "bg-[var(--color-neon)]/25 border border-[var(--color-neon)] text-[var(--color-text)] cursor-pointer"
+        : "bg-[var(--color-border)] border border-[var(--color-border-hover)] text-[var(--color-text-muted)]"
+    }`,
+    style: {
+      left: position.x * UNIT,
+      top: position.y * UNIT,
+      width,
+      height,
+      transform: rotation ? `rotate(${rotation}deg)` : undefined,
+      transformOrigin:
+        position.rx !== undefined && position.ry !== undefined
+          ? `${(position.rx - position.x) * UNIT}px ${(position.ry - position.y) * UNIT}px`
+          : undefined,
+    },
+    children: <span className="px-0.5 truncate">{bindingLabel(binding)}</span>,
+  };
+
+  // Changed keys are buttons: a plain div is neither tappable as a Popover
+  // trigger nor reachable by keyboard, and the detail is the point of the view.
+  const cap = change ? (
+    <button
+      type="button"
+      aria-label={t("Key {{index}}", { index })}
+      {...shared}
+    />
+  ) : (
+    <div {...shared} />
   );
 
-  // Only changed keys get a tooltip; a tooltip on every key would make the
+  // Only changed keys are interactive; a tooltip on every key would make the
   // board unusable to move a pointer across.
   if (!change) return cap;
+
+  const detail = (
+    <>
+      <p className="text-[var(--color-text-muted)] mb-1">
+        {t("Key {{index}}", { index })}
+      </p>
+      <p className="text-[var(--color-text)]">
+        <span className="text-[var(--color-text-muted)] line-through">
+          {bindingLabel(change.from)}
+        </span>
+        {" → "}
+        <span className="text-[var(--color-neon)]">
+          {bindingLabel(change.to)}
+        </span>
+      </p>
+    </>
+  );
+  const panelClass =
+    "px-3 py-2 rounded bg-[var(--color-surface-elevated)] border border-[var(--color-border)] text-xs shadow-lg z-50 max-w-xs";
+
+  // A tap produces neither hover nor focus, so Tooltip never opens on a touch
+  // screen. Popover opens on click, which is the gesture that exists there.
+  if (touch) {
+    return (
+      <Popover.Root>
+        <Popover.Trigger asChild>{cap}</Popover.Trigger>
+        <Popover.Portal>
+          <Popover.Content className={panelClass} sideOffset={5}>
+            {detail}
+            <Popover.Arrow className="fill-[var(--color-surface-elevated)]" />
+          </Popover.Content>
+        </Popover.Portal>
+      </Popover.Root>
+    );
+  }
 
   return (
     <Tooltip.Root>
       <Tooltip.Trigger asChild>{cap}</Tooltip.Trigger>
       <Tooltip.Portal>
-        <Tooltip.Content
-          className="px-3 py-2 rounded bg-[var(--color-surface-elevated)] border border-[var(--color-border)] text-xs shadow-lg z-50 max-w-xs"
-          sideOffset={5}
-        >
-          <p className="text-[var(--color-text-muted)] mb-1">
-            {t("Key {{index}}", { index })}
-          </p>
-          <p className="text-[var(--color-text)]">
-            <span className="text-[var(--color-text-muted)] line-through">
-              {bindingLabel(change.from)}
-            </span>
-            {" → "}
-            <span className="text-[var(--color-neon)]">
-              {bindingLabel(change.to)}
-            </span>
-          </p>
+        <Tooltip.Content className={panelClass} sideOffset={5}>
+          {detail}
           <Tooltip.Arrow className="fill-[var(--color-surface-elevated)]" />
         </Tooltip.Content>
       </Tooltip.Portal>
@@ -126,6 +161,7 @@ export function KeymapLayerPreview({
   const { t } = useLanguage();
   // Geometry may arrive in key units or in ZMK's hundredths; normalize first.
   const keys = normalizePositions(positions);
+  const touch = isCoarsePointer();
   const containerRef = useRef<HTMLDivElement | null>(null);
   const [available, setAvailable] = useState(0);
 
@@ -183,6 +219,7 @@ export function KeymapLayerPreview({
                 position={position}
                 binding={bindings[index]}
                 change={changes.get(index)}
+                touch={touch}
               />
             ))}
           </div>

--- a/src/components/importExport/KeymapLayerPreview.tsx
+++ b/src/components/importExport/KeymapLayerPreview.tsx
@@ -11,9 +11,14 @@
  * "three keys changed" are indistinguishable in a list of 300 rows and obvious
  * here.
  */
+import { useEffect, useRef, useState } from "react";
 import * as Tooltip from "@radix-ui/react-tooltip";
 import { useLanguage } from "../../hooks/useLanguage";
 import { bindingLabel } from "../../lib/abyss/abyssDiff";
+import {
+  normalizePositions,
+  previewScale,
+} from "../../lib/abyss/previewLayout";
 
 /** Geometry for one key, in key units, as the Abyss layout document stores it. */
 export interface PreviewPosition {
@@ -33,7 +38,7 @@ export interface PreviewChange {
   to?: unknown;
 }
 
-/** Pixels per key unit. Small enough that a 60% board fits without scrolling. */
+/** Pixels per key unit at full size. The rendered board is then scaled to fit. */
 const UNIT = 34;
 const GAP = 2;
 
@@ -119,8 +124,27 @@ export function KeymapLayerPreview({
   changes: Map<number, PreviewChange>;
 }) {
   const { t } = useLanguage();
+  // Geometry may arrive in key units or in ZMK's hundredths; normalize first.
+  const keys = normalizePositions(positions);
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const [available, setAvailable] = useState(0);
 
-  if (positions.length === 0) {
+  // Track the container so the board shrinks with the panel — the tab is inside
+  // a card inside a page that reflows, and a fixed scale would overflow on
+  // narrow windows and waste space on wide ones.
+  useEffect(() => {
+    const element = containerRef.current;
+    if (!element) return;
+    setAvailable(element.clientWidth);
+    if (typeof ResizeObserver === "undefined") return;
+    const observer = new ResizeObserver(([entry]) => {
+      setAvailable(entry.contentRect.width);
+    });
+    observer.observe(element);
+    return () => observer.disconnect();
+  }, []);
+
+  if (keys.length === 0) {
     return (
       <p className="text-xs text-[var(--color-text-muted)]">
         {t("No layout geometry available for a preview.")}
@@ -128,22 +152,40 @@ export function KeymapLayerPreview({
     );
   }
 
-  const width = Math.max(...positions.map((p) => p.x + (p.w ?? 1))) * UNIT;
-  const height = Math.max(...positions.map((p) => p.y + (p.h ?? 1))) * UNIT;
+  const width = Math.max(...keys.map((p) => p.x + (p.w ?? 1))) * UNIT;
+  const height = Math.max(...keys.map((p) => p.y + (p.h ?? 1))) * UNIT;
+  const scale = previewScale(width, available);
 
   return (
     <Tooltip.Provider delayDuration={150} disableHoverableContent>
-      <div className="overflow-x-auto">
-        <div className="relative" style={{ width, height }}>
-          {positions.map((position, index) => (
-            <KeyCap
-              key={index}
-              index={index}
-              position={position}
-              binding={bindings[index]}
-              change={changes.get(index)}
-            />
-          ))}
+      {/* Measured separately from the scaled board: reading the width off the
+          board itself would feed its own scaled size back in. */}
+      <div ref={containerRef} className="overflow-x-auto">
+        <div
+          style={{
+            width: width * scale,
+            height: height * scale,
+          }}
+        >
+          <div
+            className="relative"
+            style={{
+              width,
+              height,
+              transform: scale === 1 ? undefined : `scale(${scale})`,
+              transformOrigin: "top left",
+            }}
+          >
+            {keys.map((position, index) => (
+              <KeyCap
+                key={index}
+                index={index}
+                position={position}
+                binding={bindings[index]}
+                change={changes.get(index)}
+              />
+            ))}
+          </div>
         </div>
       </div>
     </Tooltip.Provider>

--- a/src/components/importExport/KeymapLayerPreview.tsx
+++ b/src/components/importExport/KeymapLayerPreview.tsx
@@ -1,0 +1,151 @@
+/**
+ * Read-only physical preview of one layer, with changed keys highlighted.
+ *
+ * Purpose-built rather than reusing `KeyboardLayout`, which is wired to the ZMK
+ * editing types (device `Layer`, behaviour ids, edit callbacks). Here the
+ * geometry comes from the Abyss layout document and the bindings from
+ * KeyboardHub JSON, and nothing is editable — adapting the editor would have
+ * meant bending both sides to fit.
+ *
+ * The point of the physical view is scale: "the whole alpha block moved" and
+ * "three keys changed" are indistinguishable in a list of 300 rows and obvious
+ * here.
+ */
+import * as Tooltip from "@radix-ui/react-tooltip";
+import { useLanguage } from "../../hooks/useLanguage";
+import { bindingLabel } from "../../lib/abyss/abyssDiff";
+
+/** Geometry for one key, in key units, as the Abyss layout document stores it. */
+export interface PreviewPosition {
+  x: number;
+  y: number;
+  w?: number;
+  h?: number;
+  /** Rotation in centidegrees. */
+  r?: number;
+  rx?: number;
+  ry?: number;
+}
+
+/** What changed at one key position. */
+export interface PreviewChange {
+  from?: unknown;
+  to?: unknown;
+}
+
+/** Pixels per key unit. Small enough that a 60% board fits without scrolling. */
+const UNIT = 34;
+const GAP = 2;
+
+function KeyCap({
+  position,
+  index,
+  binding,
+  change,
+}: {
+  position: PreviewPosition;
+  index: number;
+  binding: unknown;
+  change?: PreviewChange;
+}) {
+  const { t } = useLanguage();
+  const width = (position.w ?? 1) * UNIT - GAP;
+  const height = (position.h ?? 1) * UNIT - GAP;
+  const rotation = (position.r ?? 0) / 100;
+
+  const cap = (
+    <div
+      className={`absolute flex items-center justify-center overflow-hidden rounded text-[9px] leading-none ${
+        change
+          ? "bg-[var(--color-neon)]/25 border border-[var(--color-neon)] text-[var(--color-text)]"
+          : "bg-[var(--color-border)] border border-[var(--color-border-hover)] text-[var(--color-text-muted)]"
+      }`}
+      style={{
+        left: position.x * UNIT,
+        top: position.y * UNIT,
+        width,
+        height,
+        transform: rotation ? `rotate(${rotation}deg)` : undefined,
+        transformOrigin:
+          position.rx !== undefined && position.ry !== undefined
+            ? `${(position.rx - position.x) * UNIT}px ${(position.ry - position.y) * UNIT}px`
+            : undefined,
+      }}
+    >
+      <span className="px-0.5 truncate">{bindingLabel(binding)}</span>
+    </div>
+  );
+
+  // Only changed keys get a tooltip; a tooltip on every key would make the
+  // board unusable to move a pointer across.
+  if (!change) return cap;
+
+  return (
+    <Tooltip.Root>
+      <Tooltip.Trigger asChild>{cap}</Tooltip.Trigger>
+      <Tooltip.Portal>
+        <Tooltip.Content
+          className="px-3 py-2 rounded bg-[var(--color-surface-elevated)] border border-[var(--color-border)] text-xs shadow-lg z-50 max-w-xs"
+          sideOffset={5}
+        >
+          <p className="text-[var(--color-text-muted)] mb-1">
+            {t("Key {{index}}", { index })}
+          </p>
+          <p className="text-[var(--color-text)]">
+            <span className="text-[var(--color-text-muted)] line-through">
+              {bindingLabel(change.from)}
+            </span>
+            {" → "}
+            <span className="text-[var(--color-neon)]">
+              {bindingLabel(change.to)}
+            </span>
+          </p>
+          <Tooltip.Arrow className="fill-[var(--color-surface-elevated)]" />
+        </Tooltip.Content>
+      </Tooltip.Portal>
+    </Tooltip.Root>
+  );
+}
+
+export function KeymapLayerPreview({
+  positions,
+  bindings,
+  changes,
+}: {
+  positions: PreviewPosition[];
+  /** Bindings for this layer, indexed by key position. */
+  bindings: unknown[];
+  /** Changed keys by position index. */
+  changes: Map<number, PreviewChange>;
+}) {
+  const { t } = useLanguage();
+
+  if (positions.length === 0) {
+    return (
+      <p className="text-xs text-[var(--color-text-muted)]">
+        {t("No layout geometry available for a preview.")}
+      </p>
+    );
+  }
+
+  const width = Math.max(...positions.map((p) => p.x + (p.w ?? 1))) * UNIT;
+  const height = Math.max(...positions.map((p) => p.y + (p.h ?? 1))) * UNIT;
+
+  return (
+    <Tooltip.Provider delayDuration={150} disableHoverableContent>
+      <div className="overflow-x-auto">
+        <div className="relative" style={{ width, height }}>
+          {positions.map((position, index) => (
+            <KeyCap
+              key={index}
+              index={index}
+              position={position}
+              binding={bindings[index]}
+              change={changes.get(index)}
+            />
+          ))}
+        </div>
+      </div>
+    </Tooltip.Provider>
+  );
+}

--- a/src/components/importExport/LayerTabs.tsx
+++ b/src/components/importExport/LayerTabs.tsx
@@ -1,0 +1,65 @@
+/**
+ * Tab-like layer picker for the diff previews.
+ *
+ * A change count rides on each tab so the layers worth looking at are obvious
+ * without opening them — with eight layers and changes in two, hunting through
+ * them one by one is the slow part.
+ */
+import { useLanguage } from "../../hooks/useLanguage";
+
+export interface LayerTabItem {
+  index: number;
+  name: string;
+  /** Changed keys in this layer, shown as a badge when non-zero. */
+  changeCount: number;
+}
+
+export function LayerTabs({
+  layers,
+  activeIndex,
+  onSelect,
+}: {
+  layers: LayerTabItem[];
+  activeIndex: number;
+  onSelect: (index: number) => void;
+}) {
+  const { t } = useLanguage();
+  if (layers.length === 0) return null;
+
+  return (
+    <div
+      role="tablist"
+      aria-label={t("Layers")}
+      className="flex flex-wrap gap-1 mb-3"
+    >
+      {layers.map((layer) => {
+        const active = layer.index === activeIndex;
+        return (
+          <button
+            key={layer.index}
+            role="tab"
+            aria-selected={active}
+            onClick={() => onSelect(layer.index)}
+            className={`px-3 py-1.5 rounded-lg text-xs transition-colors border ${
+              active
+                ? "border-[var(--color-electric)] bg-[var(--color-electric)]/15 text-[var(--color-electric)]"
+                : "border-[var(--color-border)] text-[var(--color-text-muted)] hover:text-[var(--color-text)]"
+            }`}
+          >
+            {layer.name || t("Layer {{index}}", { index: layer.index })}
+            {layer.changeCount > 0 && (
+              <span
+                className="ml-1.5 px-1.5 py-0.5 rounded-full bg-[var(--color-neon)]/20 text-[var(--color-neon)] tabular-nums"
+                aria-label={t("{{count}} changes", {
+                  count: layer.changeCount,
+                })}
+              >
+                {layer.changeCount}
+              </span>
+            )}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/importExport/__tests__/JsonDiffModal.test.tsx
+++ b/src/components/importExport/__tests__/JsonDiffModal.test.tsx
@@ -58,6 +58,19 @@ describe("JsonDiffModal", () => {
     expect(screen.queryByText("Changes to write")).not.toBeInTheDocument();
   });
 
+  it("fills the screen on phones and centres from tablet up", () => {
+    open();
+
+    // A 95vw/90vh sheet wastes edges that matter most where there are fewest of
+    // them, and a diff is the densest thing in this app.
+    const dialog = screen.getByRole("dialog");
+    expect(dialog.className).toContain("inset-0");
+    expect(dialog.className).toContain("w-full");
+    expect(dialog.className).toContain("h-full");
+    expect(dialog.className).toContain("tablet:w-[95vw]");
+    expect(dialog.className).toContain("tablet:h-[90vh]");
+  });
+
   it("shows the title and which side is which", () => {
     open();
 

--- a/src/components/importExport/__tests__/JsonDiffModal.test.tsx
+++ b/src/components/importExport/__tests__/JsonDiffModal.test.tsx
@@ -65,10 +65,24 @@ describe("JsonDiffModal", () => {
     // them, and a diff is the densest thing in this app.
     const dialog = screen.getByRole("dialog");
     expect(dialog.className).toContain("inset-0");
-    expect(dialog.className).toContain("w-full");
-    expect(dialog.className).toContain("h-full");
+    // dvh rather than vh: mobile browser chrome shrinks the visual viewport,
+    // and 100vh would extend behind it.
+    expect(dialog.className).toContain("h-dvh");
+    expect(dialog.className).toContain("max-h-dvh");
     expect(dialog.className).toContain("tablet:w-[95vw]");
     expect(dialog.className).toContain("tablet:h-[90vh]");
+  });
+
+  it("lets the diff scroll inside the dialog instead of growing it", () => {
+    // A flex child defaults to `min-height: auto`, so without min-h-0 a long
+    // diff refuses to shrink and pushes the dialog past the bottom of the
+    // screen. This is the whole reason the modal overflowed.
+    const { container } = open();
+
+    const scroller = container.ownerDocument.querySelector(".abyss-diff");
+    expect(scroller?.className).toContain("min-h-0");
+    expect(scroller?.className).toContain("min-w-0");
+    expect(scroller?.className).toContain("overflow-auto");
   });
 
   it("shows the title and which side is which", () => {

--- a/src/components/importExport/__tests__/JsonDiffModal.test.tsx
+++ b/src/components/importExport/__tests__/JsonDiffModal.test.tsx
@@ -1,0 +1,114 @@
+/**
+ * Tests for the JSON diff modal.
+ *
+ * Mirrors Keyboard Abyss's diff editor, so the controls under test are the two
+ * it offers: inline vs side-by-side, and context around changes vs the whole
+ * document.
+ */
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { JsonDiffModal } from "../JsonDiffModal";
+
+const before = {
+  keyboard: "dya2",
+  layers: Array.from({ length: 30 }, (_, index) => ({
+    name: index === 15 ? "Before" : `Layer ${index}`,
+    bindings: [index],
+  })),
+};
+const after = {
+  ...before,
+  layers: before.layers.map((layer, index) =>
+    index === 15 ? { ...layer, name: "After" } : layer,
+  ),
+};
+
+function open(props: Partial<Parameters<typeof JsonDiffModal>[0]> = {}) {
+  return render(
+    <JsonDiffModal
+      open
+      onOpenChange={() => {}}
+      title="Changes to write"
+      description="Left: device. Right: Abyss."
+      before={before}
+      after={after}
+      {...props}
+    />,
+  );
+}
+
+/** Rendered diff lines, however the current view mode lays them out. */
+function diffLines() {
+  return document.querySelectorAll(".diff-line");
+}
+
+describe("JsonDiffModal", () => {
+  it("renders nothing until opened", () => {
+    render(
+      <JsonDiffModal
+        open={false}
+        onOpenChange={() => {}}
+        title="Changes to write"
+        description="d"
+        before={before}
+        after={after}
+      />,
+    );
+
+    expect(screen.queryByText("Changes to write")).not.toBeInTheDocument();
+  });
+
+  it("shows the title and which side is which", () => {
+    open();
+
+    expect(screen.getByText("Changes to write")).toBeInTheDocument();
+    expect(screen.getByText("Left: device. Right: Abyss.")).toBeInTheDocument();
+  });
+
+  it("starts inline and switches to side by side", async () => {
+    open();
+
+    const inline = screen.getByRole("button", { name: "Inline" });
+    const split = screen.getByRole("button", { name: "Side by side" });
+    expect(inline).toHaveAttribute("aria-pressed", "true");
+
+    await userEvent.click(split);
+
+    expect(split).toHaveAttribute("aria-pressed", "true");
+    expect(inline).toHaveAttribute("aria-pressed", "false");
+  });
+
+  it("shows more lines when switched to the entire file", async () => {
+    open();
+    const collapsed = diffLines().length;
+
+    await userEvent.click(screen.getByRole("button", { name: "Entire file" }));
+
+    // The whole point of the toggle: a 30-layer document with one changed line
+    // should not render every line by default.
+    expect(diffLines().length).toBeGreaterThan(collapsed);
+  });
+
+  it("hides the context toggle when nothing is hidden anyway", () => {
+    // A control that does nothing when clicked is worse than no control.
+    open({ before: { a: 1 }, after: { a: 2 } });
+
+    expect(
+      screen.queryByRole("button", { name: "Entire file" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("says so when the two documents are identical", () => {
+    open({ before, after: before });
+
+    expect(screen.getByText("No differences.")).toBeInTheDocument();
+    expect(diffLines()).toHaveLength(0);
+  });
+
+  it("renders the changed values", () => {
+    open();
+
+    expect(screen.getByText(/"After"/)).toBeInTheDocument();
+    expect(screen.getByText(/"Before"/)).toBeInTheDocument();
+  });
+});

--- a/src/components/importExport/__tests__/JsonDiffModal.test.tsx
+++ b/src/components/importExport/__tests__/JsonDiffModal.test.tsx
@@ -64,7 +64,11 @@ describe("JsonDiffModal", () => {
     // A 95vw/90vh sheet wastes edges that matter most where there are fewest of
     // them, and a diff is the densest thing in this app.
     const dialog = screen.getByRole("dialog");
-    expect(dialog.className).toContain("inset-0");
+    // `w-screen` rather than `inset-x-0`: a fixed element's containing block is
+    // not always the layout viewport, and where they differ inset-x stretched
+    // the sheet past the screen and pushed the close button off it.
+    expect(dialog.className).toContain("w-screen");
+    expect(dialog.className).toContain("diff-sheet");
     // dvh rather than vh: mobile browser chrome shrinks the visual viewport,
     // and 100vh would extend behind it.
     expect(dialog.className).toContain("h-dvh");

--- a/src/components/importExport/__tests__/JsonPreview.test.tsx
+++ b/src/components/importExport/__tests__/JsonPreview.test.tsx
@@ -1,0 +1,43 @@
+/**
+ * Tests for the collapsed JSON preview.
+ *
+ * These pin a bug that only showed up in a browser: gating the body on an
+ * `onToggle` state handler meant the element opened while React never mounted
+ * its contents, so the pane expanded to nothing.
+ */
+import { render, screen } from "@testing-library/react";
+import { JsonPreview } from "../JsonPreview";
+
+describe("JsonPreview", () => {
+  it("starts collapsed", () => {
+    render(<JsonPreview title="Keymap JSON" value={{ a: 1 }} />);
+
+    const details = screen.getByText("Keymap JSON").closest("details");
+    expect(details).not.toHaveAttribute("open");
+  });
+
+  it("renders the JSON body even while collapsed", () => {
+    // The body must exist in the DOM regardless of open state — <details> does
+    // the hiding. Mounting it on toggle is what produced an empty pane.
+    render(<JsonPreview title="Keymap JSON" value={{ keyboard: "dya2" }} />);
+
+    expect(screen.getByText(/"keyboard": "dya2"/)).toBeInTheDocument();
+  });
+
+  it("pretty-prints so the document is readable", () => {
+    render(
+      <JsonPreview
+        title="Layout JSON"
+        value={{ name: "DYA2", positions: [] }}
+      />,
+    );
+
+    const body = screen.getByText(/"name": "DYA2"/);
+    expect(body.textContent).toContain("\n");
+  });
+
+  it("says so when there is nothing to show", () => {
+    render(<JsonPreview title="Layout JSON" value={null} />);
+    expect(screen.getByText("Not available.")).toBeInTheDocument();
+  });
+});

--- a/src/components/importExport/__tests__/KeymapDiffView.test.tsx
+++ b/src/components/importExport/__tests__/KeymapDiffView.test.tsx
@@ -1,0 +1,111 @@
+/**
+ * Tests for the writeback diff view.
+ *
+ * This is what the user reads before agreeing to change their keyboard, so the
+ * things worth pinning are that every change is reachable and that a huge diff
+ * degrades to counts rather than rendering hundreds of rows.
+ */
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { KeymapDiffView } from "../KeymapDiffView";
+import { EMPTY_DIFF, type KeymapDiff } from "../../../lib/abyss/abyssDiff";
+
+function bindingChanges(count: number, layerIndex = 0) {
+  return Array.from({ length: count }, (_, keyIndex) => ({
+    layerIndex,
+    layerName: `Layer ${layerIndex}`,
+    keyIndex,
+    from: { type: "trans" },
+    to: { type: "key", usage: 0x04 },
+  }));
+}
+
+describe("KeymapDiffView", () => {
+  it("summarises each category as a chip", () => {
+    const diff: KeymapDiff = {
+      ...EMPTY_DIFF,
+      bindingChanges: bindingChanges(2),
+      layerNameChanges: [{ layerIndex: 0, from: "Base", to: "Alpha" }],
+      comboChanges: [{ index: 0, label: "Combo 1", to: {} }],
+    };
+
+    render(<KeymapDiffView diff={diff} />);
+
+    expect(screen.getByText("2 bindings")).toBeInTheDocument();
+    expect(screen.getByText("1 layer names")).toBeInTheDocument();
+    expect(screen.getByText("1 combos")).toBeInTheDocument();
+    // Categories with nothing in them are omitted rather than shown as zero.
+    expect(screen.queryByText(/macros/)).not.toBeInTheDocument();
+  });
+
+  it("groups changes into one card per layer", () => {
+    const diff: KeymapDiff = {
+      ...EMPTY_DIFF,
+      bindingChanges: [...bindingChanges(1, 0), ...bindingChanges(2, 3)],
+    };
+
+    render(<KeymapDiffView diff={diff} />);
+
+    expect(screen.getByText("1 changes")).toBeInTheDocument();
+    expect(screen.getByText("2 changes")).toBeInTheDocument();
+  });
+
+  it("caps the row list until the user asks for the rest", async () => {
+    const diff: KeymapDiff = {
+      ...EMPTY_DIFF,
+      bindingChanges: bindingChanges(80),
+    };
+
+    render(<KeymapDiffView diff={diff} />);
+    // Layer cards start collapsed, so open it first.
+    await userEvent.click(screen.getByRole("button", { name: "Layer 0" }));
+
+    expect(screen.getByText("#0")).toBeInTheDocument();
+    expect(screen.queryByText("#60")).not.toBeInTheDocument();
+
+    await userEvent.click(screen.getByText("Show all 80 keys"));
+    expect(screen.getByText("#60")).toBeInTheDocument();
+  });
+
+  it("degrades to counts for a whole-keymap replacement", async () => {
+    // 300 rows is both slow to render and useless to read; the counts and an
+    // explicit opt-in are more honest than a wall of text.
+    const diff: KeymapDiff = {
+      ...EMPTY_DIFF,
+      bindingChanges: bindingChanges(300),
+    };
+
+    render(<KeymapDiffView diff={diff} />);
+
+    expect(
+      screen.getByText(/This replaces most of the keymap/),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Layer 0" }),
+    ).not.toBeInTheDocument();
+
+    await userEvent.click(screen.getByText("Show the full list anyway"));
+    expect(screen.getByRole("button", { name: "Layer 0" })).toBeInTheDocument();
+  });
+
+  it("separates global module changes from layer-scoped ones", () => {
+    const diff: KeymapDiff = {
+      ...EMPTY_DIFF,
+      moduleChanges: [
+        { scope: "global", moduleName: "trackball" },
+        { scope: "layer", layerIndex: 1, moduleName: "encoder" },
+      ],
+    };
+
+    render(<KeymapDiffView diff={diff} />);
+
+    // The global one sits outside any layer card.
+    expect(screen.getByText("trackball")).toBeInTheDocument();
+    expect(screen.getByText("1 changes")).toBeInTheDocument();
+  });
+
+  it("renders nothing alarming for an empty diff", () => {
+    render(<KeymapDiffView diff={EMPTY_DIFF} />);
+    expect(screen.queryByText(/bindings/)).not.toBeInTheDocument();
+  });
+});

--- a/src/components/importExport/__tests__/KeymapLayerPreview.test.tsx
+++ b/src/components/importExport/__tests__/KeymapLayerPreview.test.tsx
@@ -2,6 +2,7 @@
  * Tests for the layer preview's fit-to-width scaling.
  */
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { KeymapLayerPreview } from "../KeymapLayerPreview";
 import {
   normalizePositions,
@@ -99,6 +100,47 @@ describe("KeymapLayerPreview", () => {
     expect(screen.getByText("▽")).toBeInTheDocument();
     expect(screen.getByText("MO(2)")).toBeInTheDocument();
     expect(screen.getByText("✕")).toBeInTheDocument();
+  });
+
+  it("opens the detail on tap when the pointer cannot hover", async () => {
+    // A tap produces neither hover nor focus, so Radix's Tooltip never opens on
+    // a touch screen; the detail is the whole point of the highlight.
+    const matchMedia = window.matchMedia as unknown as jest.Mock;
+    matchMedia.mockImplementation((query: string) => ({
+      matches: query === "(pointer: coarse)",
+      media: query,
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+    }));
+
+    render(
+      <KeymapLayerPreview
+        positions={positions}
+        bindings={[{ type: "trans" }, { type: "trans" }, { type: "trans" }]}
+        changes={
+          new Map([
+            [1, { from: { type: "trans" }, to: { type: "mo", layer: 2 } }],
+          ])
+        }
+      />,
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: "Key 1" }));
+
+    expect(await screen.findByText("MO(2)")).toBeInTheDocument();
+  });
+
+  it("makes changed keys focusable buttons", () => {
+    render(
+      <KeymapLayerPreview
+        positions={positions}
+        bindings={[{ type: "trans" }, { type: "trans" }, { type: "trans" }]}
+        changes={new Map([[2, { from: undefined, to: { type: "none" } }]])}
+      />,
+    );
+
+    // Unchanged keys stay plain: a board of 87 buttons is unusable by keyboard.
+    expect(screen.getAllByRole("button")).toHaveLength(1);
   });
 
   it("marks only the changed keys", () => {

--- a/src/components/importExport/__tests__/KeymapLayerPreview.test.tsx
+++ b/src/components/importExport/__tests__/KeymapLayerPreview.test.tsx
@@ -1,0 +1,119 @@
+/**
+ * Tests for the layer preview's fit-to-width scaling.
+ */
+import { render, screen } from "@testing-library/react";
+import { KeymapLayerPreview } from "../KeymapLayerPreview";
+import {
+  normalizePositions,
+  previewScale,
+} from "../../../lib/abyss/previewLayout";
+
+describe("previewScale", () => {
+  it("shrinks a board that is wider than the space available", () => {
+    expect(previewScale(1000, 500)).toBe(0.5);
+  });
+
+  it("never enlarges a board that already fits", () => {
+    // Blowing a 40% keyboard up to fill a wide window would look broken.
+    expect(previewScale(400, 1200)).toBe(1);
+    expect(previewScale(400, 400)).toBe(1);
+  });
+
+  it("stops shrinking before the legends become unreadable", () => {
+    // Past this the board scrolls instead; illegible is worse than scrolled.
+    expect(previewScale(2000, 100)).toBe(0.45);
+  });
+
+  it("renders at full size when the width is not known yet", () => {
+    // The first paint happens before measurement, and in environments with no
+    // layout at all; collapsing to nothing there would be worse.
+    expect(previewScale(800, 0)).toBe(1);
+    expect(previewScale(0, 500)).toBe(1);
+  });
+});
+
+describe("normalizePositions", () => {
+  it("passes key units through untouched", () => {
+    const positions = [{ x: 0, y: 0, w: 1, h: 1 }];
+    expect(normalizePositions(positions)).toEqual(positions);
+  });
+
+  it("converts ZMK's hundredths to key units", () => {
+    // The KeyboardHub schema documents key units, but the ZMK adapter copies
+    // ZMK Studio's KeyPhysicalAttrs verbatim and those are hundredths — a 1u
+    // key is `width: 100`. Believing the schema drew the board 100x too large.
+    expect(
+      normalizePositions([
+        { x: 0, y: 0, w: 100, h: 100 },
+        { x: 1400, y: 300, w: 200, h: 100, rx: 1400, ry: 300, r: 1500 },
+      ]),
+    ).toEqual([
+      { x: 0, y: 0, w: 1, h: 1, r: undefined, rx: undefined, ry: undefined },
+      { x: 14, y: 3, w: 2, h: 1, rx: 14, ry: 3, r: 1500 },
+    ]);
+  });
+
+  it("leaves rotation in centidegrees, which both conventions share", () => {
+    const [key] = normalizePositions([
+      { x: 0, y: 0, w: 100, h: 100, r: 1500 },
+      { x: 5000, y: 0 },
+    ]);
+    expect(key.r).toBe(1500);
+  });
+
+  it("handles an empty layout", () => {
+    expect(normalizePositions([])).toEqual([]);
+  });
+});
+
+describe("KeymapLayerPreview", () => {
+  const positions = [
+    { x: 0, y: 0 },
+    { x: 1, y: 0 },
+    { x: 2, y: 0 },
+  ];
+
+  it("says so when there is no geometry to draw", () => {
+    render(
+      <KeymapLayerPreview positions={[]} bindings={[]} changes={new Map()} />,
+    );
+
+    expect(
+      screen.getByText("No layout geometry available for a preview."),
+    ).toBeInTheDocument();
+  });
+
+  it("labels every key from its binding", () => {
+    render(
+      <KeymapLayerPreview
+        positions={positions}
+        bindings={[
+          { type: "trans" },
+          { type: "mo", layer: 2 },
+          { type: "none" },
+        ]}
+        changes={new Map()}
+      />,
+    );
+
+    expect(screen.getByText("▽")).toBeInTheDocument();
+    expect(screen.getByText("MO(2)")).toBeInTheDocument();
+    expect(screen.getByText("✕")).toBeInTheDocument();
+  });
+
+  it("marks only the changed keys", () => {
+    const { container } = render(
+      <KeymapLayerPreview
+        positions={positions}
+        bindings={[{ type: "trans" }, { type: "trans" }, { type: "trans" }]}
+        changes={
+          new Map([[1, { from: { type: "trans" }, to: { type: "none" } }]])
+        }
+      />,
+    );
+
+    // The highlight is what makes "three keys changed" visible at a glance.
+    const highlighted = container.querySelectorAll("[class*='color-neon']");
+    expect(highlighted.length).toBeGreaterThan(0);
+  });
+});

--- a/src/hooks/__tests__/useAbyssAuth.test.tsx
+++ b/src/hooks/__tests__/useAbyssAuth.test.tsx
@@ -1,0 +1,157 @@
+/**
+ * Tests for the Abyss sign-in state hook.
+ */
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { useAbyssAuth } from "../useAbyssAuth";
+
+// The Abyss SDK is stubbed globally via moduleNameMapper (see jest.config.ts);
+// this is that stub's error class, used to simulate API failures.
+import { AbyssApiError } from "@keyboard-hub/abyss-client";
+
+jest.mock("../../lib/abyss/abyssClient");
+import { getAbyssClient, isAbyssConfigured } from "../../lib/abyss/abyssClient";
+const mockGetAbyssClient = getAbyssClient as jest.MockedFunction<
+  typeof getAbyssClient
+>;
+const mockIsAbyssConfigured = isAbyssConfigured as jest.MockedFunction<
+  typeof isAbyssConfigured
+>;
+
+jest.mock("../../lib/abyss/abyssOAuth", () => ({
+  ...jest.requireActual("../../lib/abyss/abyssOAuth"),
+  startAbyssLogin: jest.fn(),
+}));
+import { startAbyssLogin } from "../../lib/abyss/abyssOAuth";
+const mockStartAbyssLogin = startAbyssLogin as jest.MockedFunction<
+  typeof startAbyssLogin
+>;
+
+const PROFILE = { sub: "u1", username: "cormoran" };
+
+type FakeClient = {
+  getTokenSet: jest.Mock;
+  userinfo: jest.Mock;
+  clearTokenSet: jest.Mock;
+  revoke: jest.Mock;
+};
+
+function useFakeClient(overrides: Partial<FakeClient> = {}): FakeClient {
+  const client: FakeClient = {
+    getTokenSet: jest.fn().mockReturnValue({ accessToken: "t" }),
+    userinfo: jest.fn().mockResolvedValue(PROFILE),
+    clearTokenSet: jest.fn(),
+    revoke: jest.fn().mockResolvedValue(undefined),
+    ...overrides,
+  };
+  mockGetAbyssClient.mockReturnValue(
+    client as unknown as ReturnType<typeof getAbyssClient>,
+  );
+  return client;
+}
+
+describe("useAbyssAuth", () => {
+  beforeEach(() => {
+    mockGetAbyssClient.mockReset();
+    mockIsAbyssConfigured.mockReset();
+    mockStartAbyssLogin.mockReset();
+    mockIsAbyssConfigured.mockReturnValue(true);
+  });
+
+  it("reports unconfigured builds without touching the client", async () => {
+    mockIsAbyssConfigured.mockReturnValue(false);
+    mockGetAbyssClient.mockReturnValue(null);
+
+    const { result } = renderHook(() => useAbyssAuth());
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.isConfigured).toBe(false);
+    expect(result.current.isAuthenticated).toBe(false);
+  });
+
+  it("loads the profile when a token is already stored", async () => {
+    const client = useFakeClient();
+
+    const { result } = renderHook(() => useAbyssAuth());
+
+    await waitFor(() => expect(result.current.isAuthenticated).toBe(true));
+    expect(result.current.user).toEqual(PROFILE);
+    expect(client.userinfo).toHaveBeenCalledTimes(1);
+  });
+
+  it("stays signed out when no token is stored", async () => {
+    const client = useFakeClient({
+      getTokenSet: jest.fn().mockReturnValue(null),
+    });
+
+    const { result } = renderHook(() => useAbyssAuth());
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.isAuthenticated).toBe(false);
+    expect(client.userinfo).not.toHaveBeenCalled();
+  });
+
+  it("drops an unusable token on 401 so the UI offers a fresh sign-in", async () => {
+    const client = useFakeClient({
+      userinfo: jest.fn().mockRejectedValue(new AbyssApiError(401)),
+    });
+
+    const { result } = renderHook(() => useAbyssAuth());
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(client.clearTokenSet).toHaveBeenCalled();
+    expect(result.current.isAuthenticated).toBe(false);
+    expect(result.current.error).toBe(
+      "Your Abyss session expired. Please log in again.",
+    );
+  });
+
+  it("surfaces a cancelled login", async () => {
+    useFakeClient({ getTokenSet: jest.fn().mockReturnValue(null) });
+    mockStartAbyssLogin.mockResolvedValue({ status: "cancelled" });
+
+    const { result } = renderHook(() => useAbyssAuth());
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    await act(async () => {
+      await result.current.login();
+    });
+
+    expect(result.current.error).toBe("Abyss login was cancelled.");
+    expect(result.current.isAuthenticated).toBe(false);
+  });
+
+  it("reads the profile after a successful login", async () => {
+    const client = useFakeClient({
+      getTokenSet: jest.fn().mockReturnValueOnce(null).mockReturnValue({
+        accessToken: "t",
+      }),
+    });
+    mockStartAbyssLogin.mockResolvedValue({ status: "authorized" });
+
+    const { result } = renderHook(() => useAbyssAuth());
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    await act(async () => {
+      await result.current.login();
+    });
+
+    expect(result.current.isAuthenticated).toBe(true);
+    expect(client.userinfo).toHaveBeenCalled();
+  });
+
+  it("clears the token on sign out even when revoke fails", async () => {
+    const client = useFakeClient({
+      revoke: jest.fn().mockRejectedValue(new Error("offline")),
+    });
+
+    const { result } = renderHook(() => useAbyssAuth());
+    await waitFor(() => expect(result.current.isAuthenticated).toBe(true));
+
+    await act(async () => {
+      await result.current.logout();
+    });
+
+    expect(client.clearTokenSet).toHaveBeenCalled();
+    expect(result.current.isAuthenticated).toBe(false);
+  });
+});

--- a/src/hooks/__tests__/useAbyssExport.test.tsx
+++ b/src/hooks/__tests__/useAbyssExport.test.tsx
@@ -61,7 +61,7 @@ type FakeClient = {
 
 function setUpAbyssClient(overrides: Partial<FakeClient> = {}): FakeClient {
   const client: FakeClient = {
-    listMyKeymaps: jest.fn().mockResolvedValue({ items: [] }),
+    listMyKeymaps: jest.fn().mockResolvedValue({ items: [], pageCount: 1 }),
     getKeymap: jest.fn(),
     createKeymap: jest.fn().mockResolvedValue({ id: "k1", version: 1 }),
     updateKeymap: jest.fn().mockResolvedValue({ id: "k1", version: 2 }),
@@ -115,6 +115,7 @@ describe("useAbyssExport", () => {
   it("appends a version and preserves the existing keymap's name", async () => {
     const client = setUpAbyssClient({
       listMyKeymaps: jest.fn().mockResolvedValue({
+        pageCount: 1,
         items: [
           {
             id: "existing-1",

--- a/src/hooks/__tests__/useAbyssExport.test.tsx
+++ b/src/hooks/__tests__/useAbyssExport.test.tsx
@@ -1,0 +1,201 @@
+/**
+ * Tests for which Abyss API call an export makes.
+ *
+ * The choice depends on how the connected layout resolved, and getting it wrong
+ * either fails outright or quietly creates catalog records the user did not ask
+ * for — so each branch is pinned here.
+ */
+import { renderHook, act, waitFor } from "@testing-library/react";
+import type { AbyssLayoutResolveResult } from "@keyboard-hub/abyss-client";
+import type { ZmkLoadedConnection } from "@keyboard-hub/adapter-zmk";
+import { useAbyssExport } from "../useAbyssExport";
+
+jest.mock("../../lib/abyss/abyssClient");
+import { getAbyssClient } from "../../lib/abyss/abyssClient";
+const mockGetAbyssClient = getAbyssClient as jest.MockedFunction<
+  typeof getAbyssClient
+>;
+
+const deviceKeymap = {
+  keyboard: "dya2",
+  name: "DYA Keyboard (Demo)",
+  layers: [{ name: "Base", bindings: ["d0"] }],
+  combos: ["device-combo"],
+  macros: ["device-macro"],
+  modules: ["device-module"],
+};
+
+const loaded = {
+  deviceName: "DYA Keyboard (Demo)",
+  state: {
+    currentKeymap: deviceKeymap,
+    detectedLayout: { name: "default", positions: [] },
+  },
+} as unknown as ZmkLoadedConnection;
+
+const exactMatch = {
+  keyboardExists: true,
+  exists: true,
+  layout: {
+    id: "layout-1",
+    name: "Default",
+    variation: { id: "variation-1", positions: [] },
+    latestVersion: { id: "version-1" },
+  },
+} as unknown as AbyssLayoutResolveResult;
+
+const unregistered = {
+  keyboardExists: false,
+  exists: false,
+  layout: null,
+} as unknown as AbyssLayoutResolveResult;
+
+type FakeClient = {
+  listMyKeymaps: jest.Mock;
+  getKeymap: jest.Mock;
+  createKeymap: jest.Mock;
+  updateKeymap: jest.Mock;
+  importKeymap: jest.Mock;
+  clearTokenSet: jest.Mock;
+};
+
+function useFakeClient(overrides: Partial<FakeClient> = {}): FakeClient {
+  const client: FakeClient = {
+    listMyKeymaps: jest.fn().mockResolvedValue({ items: [] }),
+    getKeymap: jest.fn(),
+    createKeymap: jest.fn().mockResolvedValue({ id: "k1", version: 1 }),
+    updateKeymap: jest.fn().mockResolvedValue({ id: "k1", version: 2 }),
+    importKeymap: jest.fn().mockResolvedValue({ id: "k2", version: 1 }),
+    clearTokenSet: jest.fn(),
+    ...overrides,
+  };
+  mockGetAbyssClient.mockReturnValue(
+    client as unknown as ReturnType<typeof getAbyssClient>,
+  );
+  return client;
+}
+
+describe("useAbyssExport", () => {
+  beforeEach(() => {
+    mockGetAbyssClient.mockReset();
+  });
+
+  it("creates against the resolved variation when the layout matched exactly", async () => {
+    const client = useFakeClient();
+    const { result } = renderHook(() => useAbyssExport(loaded, exactMatch));
+    await waitFor(() => expect(result.current.canExport).toBe(true));
+
+    await act(async () => {
+      await result.current.exportNow();
+    });
+
+    expect(client.createKeymap).toHaveBeenCalledWith(
+      "variation-1",
+      expect.objectContaining({ visibility: "private" }),
+    );
+    expect(client.importKeymap).not.toHaveBeenCalled();
+    expect(result.current.result).toEqual({ id: "k1", version: 1 });
+  });
+
+  it("imports when the keyboard is not in the Abyss catalog", async () => {
+    // importKeymap is the only call that may create the catalog records, so an
+    // unregistered keyboard must not go through createKeymap.
+    const client = useFakeClient();
+    const { result } = renderHook(() => useAbyssExport(loaded, unregistered));
+    await waitFor(() => expect(result.current.canExport).toBe(true));
+
+    await act(async () => {
+      await result.current.exportNow();
+    });
+
+    expect(client.importKeymap).toHaveBeenCalled();
+    expect(client.createKeymap).not.toHaveBeenCalled();
+  });
+
+  it("appends a version and preserves the existing keymap's name", async () => {
+    const client = useFakeClient({
+      listMyKeymaps: jest.fn().mockResolvedValue({
+        items: [
+          {
+            id: "existing-1",
+            name: "My saved keymap",
+            data: {
+              keyboard: "dya2",
+              name: "My saved keymap",
+              description: "kept",
+              layers: [{ name: "Old", bindings: ["a0"] }],
+            },
+          },
+        ],
+      }),
+    });
+    const { result } = renderHook(() => useAbyssExport(loaded, exactMatch));
+    await waitFor(() => expect(result.current.keymaps).toHaveLength(1));
+
+    act(() => {
+      result.current.setMode("update");
+      result.current.setSelectedKeymapId("existing-1");
+    });
+    await act(async () => {
+      await result.current.exportNow();
+    });
+
+    expect(client.updateKeymap).toHaveBeenCalledWith(
+      "existing-1",
+      expect.objectContaining({
+        layoutVariationId: "variation-1",
+        layoutVersionId: "version-1",
+      }),
+    );
+    const [, input] = client.updateKeymap.mock.calls[0];
+    expect(input.data.name).toBe("My saved keymap");
+    expect(input.data.layers[0].bindings).toEqual(["d0"]);
+  });
+
+  it("omits deselected sections from a new keymap", async () => {
+    const client = useFakeClient();
+    const { result } = renderHook(() => useAbyssExport(loaded, exactMatch));
+    await waitFor(() => expect(result.current.canExport).toBe(true));
+
+    act(() => {
+      result.current.setSelection({
+        keymap: true,
+        combos: false,
+        macros: false,
+        modules: true,
+      });
+    });
+    await act(async () => {
+      await result.current.exportNow();
+    });
+
+    const [, input] = client.createKeymap.mock.calls[0];
+    expect(input.data).not.toHaveProperty("combos");
+    expect(input.data).not.toHaveProperty("macros");
+    expect(input.data.modules).toEqual(["device-module"]);
+  });
+
+  it("surfaces a failure without a result", async () => {
+    const client = useFakeClient({
+      createKeymap: jest.fn().mockRejectedValue(new TypeError("offline")),
+    });
+    const { result } = renderHook(() => useAbyssExport(loaded, exactMatch));
+    await waitFor(() => expect(result.current.canExport).toBe(true));
+
+    await act(async () => {
+      await result.current.exportNow();
+    });
+
+    expect(client.createKeymap).toHaveBeenCalled();
+    expect(result.current.result).toBeNull();
+    expect(result.current.error).toBe(
+      "Could not reach Abyss. Check your network connection.",
+    );
+  });
+
+  it("cannot export before a device has been read", () => {
+    useFakeClient();
+    const { result } = renderHook(() => useAbyssExport(null, null));
+    expect(result.current.canExport).toBe(false);
+  });
+});

--- a/src/hooks/__tests__/useAbyssExport.test.tsx
+++ b/src/hooks/__tests__/useAbyssExport.test.tsx
@@ -59,7 +59,7 @@ type FakeClient = {
   clearTokenSet: jest.Mock;
 };
 
-function useFakeClient(overrides: Partial<FakeClient> = {}): FakeClient {
+function setUpAbyssClient(overrides: Partial<FakeClient> = {}): FakeClient {
   const client: FakeClient = {
     listMyKeymaps: jest.fn().mockResolvedValue({ items: [] }),
     getKeymap: jest.fn(),
@@ -81,7 +81,7 @@ describe("useAbyssExport", () => {
   });
 
   it("creates against the resolved variation when the layout matched exactly", async () => {
-    const client = useFakeClient();
+    const client = setUpAbyssClient();
     const { result } = renderHook(() => useAbyssExport(loaded, exactMatch));
     await waitFor(() => expect(result.current.canExport).toBe(true));
 
@@ -100,7 +100,7 @@ describe("useAbyssExport", () => {
   it("imports when the keyboard is not in the Abyss catalog", async () => {
     // importKeymap is the only call that may create the catalog records, so an
     // unregistered keyboard must not go through createKeymap.
-    const client = useFakeClient();
+    const client = setUpAbyssClient();
     const { result } = renderHook(() => useAbyssExport(loaded, unregistered));
     await waitFor(() => expect(result.current.canExport).toBe(true));
 
@@ -113,7 +113,7 @@ describe("useAbyssExport", () => {
   });
 
   it("appends a version and preserves the existing keymap's name", async () => {
-    const client = useFakeClient({
+    const client = setUpAbyssClient({
       listMyKeymaps: jest.fn().mockResolvedValue({
         items: [
           {
@@ -153,7 +153,7 @@ describe("useAbyssExport", () => {
   });
 
   it("omits deselected sections from a new keymap", async () => {
-    const client = useFakeClient();
+    const client = setUpAbyssClient();
     const { result } = renderHook(() => useAbyssExport(loaded, exactMatch));
     await waitFor(() => expect(result.current.canExport).toBe(true));
 
@@ -176,7 +176,7 @@ describe("useAbyssExport", () => {
   });
 
   it("surfaces a failure without a result", async () => {
-    const client = useFakeClient({
+    const client = setUpAbyssClient({
       createKeymap: jest.fn().mockRejectedValue(new TypeError("offline")),
     });
     const { result } = renderHook(() => useAbyssExport(loaded, exactMatch));
@@ -194,7 +194,7 @@ describe("useAbyssExport", () => {
   });
 
   it("cannot export before a device has been read", () => {
-    useFakeClient();
+    setUpAbyssClient();
     const { result } = renderHook(() => useAbyssExport(null, null));
     expect(result.current.canExport).toBe(false);
   });

--- a/src/hooks/__tests__/useAbyssExport.test.tsx
+++ b/src/hooks/__tests__/useAbyssExport.test.tsx
@@ -83,6 +83,7 @@ describe("useAbyssExport", () => {
   it("creates against the resolved variation when the layout matched exactly", async () => {
     const client = setUpAbyssClient();
     const { result } = renderHook(() => useAbyssExport(loaded, exactMatch));
+    act(() => result.current.setMode("new"));
     await waitFor(() => expect(result.current.canExport).toBe(true));
 
     await act(async () => {
@@ -102,6 +103,7 @@ describe("useAbyssExport", () => {
     // unregistered keyboard must not go through createKeymap.
     const client = setUpAbyssClient();
     const { result } = renderHook(() => useAbyssExport(loaded, unregistered));
+    act(() => result.current.setMode("new"));
     await waitFor(() => expect(result.current.canExport).toBe(true));
 
     await act(async () => {
@@ -156,6 +158,7 @@ describe("useAbyssExport", () => {
   it("omits deselected sections from a new keymap", async () => {
     const client = setUpAbyssClient();
     const { result } = renderHook(() => useAbyssExport(loaded, exactMatch));
+    act(() => result.current.setMode("new"));
     await waitFor(() => expect(result.current.canExport).toBe(true));
 
     act(() => {
@@ -181,6 +184,7 @@ describe("useAbyssExport", () => {
       createKeymap: jest.fn().mockRejectedValue(new TypeError("offline")),
     });
     const { result } = renderHook(() => useAbyssExport(loaded, exactMatch));
+    act(() => result.current.setMode("new"));
     await waitFor(() => expect(result.current.canExport).toBe(true));
 
     await act(async () => {
@@ -192,6 +196,41 @@ describe("useAbyssExport", () => {
     expect(result.current.error).toBe(
       "Could not reach Abyss. Check your network connection.",
     );
+  });
+
+  it("defaults to updating the most recently updated keymap", async () => {
+    // Creating a new keymap on every save would litter the account with
+    // near-duplicates, so updating is the default — and it needs a target
+    // preselected or the primary action starts unavailable.
+    setUpAbyssClient({
+      listMyKeymaps: jest.fn().mockResolvedValue({
+        pageCount: 1,
+        items: [
+          { id: "older", name: "Older", updatedAt: "2026-01-01T00:00:00Z" },
+          { id: "newest", name: "Newest", updatedAt: "2026-07-01T00:00:00Z" },
+        ],
+      }),
+    });
+
+    const { result } = renderHook(() => useAbyssExport(loaded, exactMatch));
+
+    expect(result.current.mode).toBe("update");
+    await waitFor(() => expect(result.current.selectedKeymapId).toBe("newest"));
+  });
+
+  it("does not override a keymap the user already picked", async () => {
+    setUpAbyssClient({
+      listMyKeymaps: jest.fn().mockResolvedValue({
+        pageCount: 1,
+        items: [{ id: "newest", name: "Newest", updatedAt: "2026-07-01Z" }],
+      }),
+    });
+
+    const { result } = renderHook(() => useAbyssExport(loaded, exactMatch));
+    act(() => result.current.setSelectedKeymapId("chosen"));
+
+    await waitFor(() => expect(result.current.keymaps).toHaveLength(1));
+    expect(result.current.selectedKeymapId).toBe("chosen");
   });
 
   it("cannot export before a device has been read", () => {

--- a/src/hooks/__tests__/useAbyssImport.test.tsx
+++ b/src/hooks/__tests__/useAbyssImport.test.tsx
@@ -1,0 +1,225 @@
+/**
+ * Tests for the import/writeback flow.
+ *
+ * This is the only path that changes the keyboard, so what matters is when it
+ * refuses to: an empty diff, a blocking pre-flight failure, or a deselected
+ * section must all keep the write from happening.
+ */
+import { renderHook, act, waitFor } from "@testing-library/react";
+import type { ZmkLoadedConnection } from "@keyboard-hub/adapter-zmk";
+import { useAbyssImport } from "../useAbyssImport";
+import type { UseAbyssDeviceReturn } from "../useAbyssDevice";
+import type { KeymapDiff } from "../../lib/abyss/abyssDiff";
+
+jest.mock("../../lib/abyss/abyssClient");
+import { getAbyssClient } from "../../lib/abyss/abyssClient";
+const mockGetAbyssClient = getAbyssClient as jest.MockedFunction<
+  typeof getAbyssClient
+>;
+
+jest.mock("@keyboard-hub/adapter-common");
+import { compareKeyboardHubKeymaps } from "@keyboard-hub/adapter-common";
+const mockCompare = compareKeyboardHubKeymaps as jest.MockedFunction<
+  typeof compareKeyboardHubKeymaps
+>;
+
+jest.mock("@keyboard-hub/adapter-zmk");
+import { writeZmkKeymapDiff } from "@keyboard-hub/adapter-zmk";
+const mockWrite = writeZmkKeymapDiff as jest.MockedFunction<
+  typeof writeZmkKeymapDiff
+>;
+
+const currentKeymap = {
+  keyboard: "dya2",
+  layers: [
+    { name: "Base", bindings: new Array(87).fill({ type: "trans" }) },
+    { name: "Nav", bindings: new Array(87).fill({ type: "trans" }) },
+  ],
+};
+
+const abyssKeymap = {
+  keyboard: "dya2",
+  name: "Saved",
+  layers: [{ name: "Base", bindings: new Array(87).fill({ type: "none" }) }],
+};
+
+const diffWithChanges: KeymapDiff = {
+  bindingChanges: [
+    { layerIndex: 0, layerName: "Base", keyIndex: 1, to: { type: "none" } },
+  ],
+  layerNameChanges: [],
+  comboChanges: [{ index: 0, label: "Combo 1", to: {} }],
+  macroChanges: [],
+  moduleChanges: [],
+};
+
+const read = jest.fn().mockResolvedValue(undefined);
+
+function makeDevice(): UseAbyssDeviceReturn {
+  return {
+    loaded: {
+      deviceName: "DYA Keyboard (Demo)",
+      state: {
+        currentKeymap,
+        detectedLayout: { name: "DYA2 ANSI" },
+        detectedModules: [],
+      },
+    } as unknown as ZmkLoadedConnection,
+    resolved: null,
+    phase: "done",
+    isReading: false,
+    error: null,
+    read,
+  };
+}
+
+function setUpAbyssClient(
+  items: unknown[] = [{ id: "k1", name: "Saved", data: abyssKeymap }],
+) {
+  const client = {
+    listMyKeymaps: jest.fn().mockResolvedValue({ items }),
+    getKeymap: jest.fn().mockResolvedValue({ data: abyssKeymap }),
+    clearTokenSet: jest.fn(),
+  };
+  mockGetAbyssClient.mockReturnValue(
+    client as unknown as ReturnType<typeof getAbyssClient>,
+  );
+  return client;
+}
+
+/** Renders the hook with a keymap already selected and a diff computed. */
+async function renderSelected(diff: KeymapDiff = diffWithChanges) {
+  setUpAbyssClient();
+  mockCompare.mockReturnValue(diff as never);
+  const rendered = renderHook(() => useAbyssImport(makeDevice()));
+  await waitFor(() => expect(rendered.result.current.keymaps).toHaveLength(1));
+  await act(async () => {
+    await rendered.result.current.selectKeymap("k1");
+  });
+  return rendered;
+}
+
+describe("useAbyssImport", () => {
+  beforeEach(() => {
+    mockGetAbyssClient.mockReset();
+    mockCompare.mockReset();
+    mockWrite.mockReset();
+    read.mockClear();
+    mockWrite.mockResolvedValue(undefined as never);
+  });
+
+  it("writes the filtered diff and re-reads to confirm", async () => {
+    const { result } = await renderSelected();
+    expect(result.current.canWrite).toBe(true);
+
+    await act(async () => {
+      await result.current.write();
+    });
+
+    expect(mockWrite).toHaveBeenCalledTimes(1);
+    // The re-read is what proves the keyboard accepted the write, rather than
+    // trusting the diff we hoped to apply.
+    expect(read).toHaveBeenCalledTimes(1);
+    expect(result.current.didWrite).toBe(true);
+  });
+
+  it("only writes the sections the user kept ticked", async () => {
+    const { result } = await renderSelected();
+
+    act(() => {
+      result.current.setSelection({
+        keymap: true,
+        combos: false,
+        macros: false,
+        modules: false,
+      });
+    });
+    await act(async () => {
+      await result.current.write();
+    });
+
+    const [, written] = mockWrite.mock.calls[0] as unknown as [
+      unknown,
+      KeymapDiff,
+    ];
+    expect(written.bindingChanges).toHaveLength(1);
+    expect(written.comboChanges).toHaveLength(0);
+  });
+
+  it("refuses to write when the keymap already matches", async () => {
+    const { result } = await renderSelected({
+      bindingChanges: [],
+      layerNameChanges: [],
+      comboChanges: [],
+      macroChanges: [],
+      moduleChanges: [],
+    });
+
+    expect(result.current.isInSync).toBe(true);
+    expect(result.current.canWrite).toBe(false);
+  });
+
+  it("refuses to write when every section is deselected", async () => {
+    const { result } = await renderSelected();
+
+    act(() => {
+      result.current.setSelection({
+        keymap: false,
+        combos: false,
+        macros: false,
+        modules: false,
+      });
+    });
+
+    expect(result.current.canWrite).toBe(false);
+  });
+
+  it("blocks a keymap that is wider than the keyboard", async () => {
+    setUpAbyssClient([
+      {
+        id: "k1",
+        name: "Too wide",
+        data: {
+          keyboard: "dya2",
+          layers: [{ name: "Base", bindings: new Array(104).fill({}) }],
+        },
+      },
+    ]);
+    mockCompare.mockReturnValue(diffWithChanges as never);
+    const { result } = renderHook(() => useAbyssImport(makeDevice()));
+    await waitFor(() => expect(result.current.keymaps).toHaveLength(1));
+
+    await act(async () => {
+      await result.current.selectKeymap("k1");
+    });
+
+    expect(result.current.preflight.map((c) => c.id)).toContain("key-count");
+    expect(result.current.canWrite).toBe(false);
+  });
+
+  it("surfaces a locked keyboard with the shared unlock message", async () => {
+    const { result } = await renderSelected();
+    mockWrite.mockRejectedValue(
+      Object.assign(new Error("locked"), { name: "FirmwareLockedError" }),
+    );
+
+    await act(async () => {
+      await result.current.write();
+    });
+
+    expect(result.current.didWrite).toBe(false);
+    expect(result.current.error).toBe(
+      "The operation failed because the device is locked in ZMK Studio. Unlock the keyboard and try again.",
+    );
+  });
+
+  it("cannot write before a keymap is selected", async () => {
+    setUpAbyssClient();
+    mockCompare.mockReturnValue(diffWithChanges as never);
+    const { result } = renderHook(() => useAbyssImport(makeDevice()));
+    await waitFor(() => expect(result.current.keymaps).toHaveLength(1));
+
+    expect(result.current.canWrite).toBe(false);
+    expect(mockWrite).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/__tests__/useAbyssImport.test.tsx
+++ b/src/hooks/__tests__/useAbyssImport.test.tsx
@@ -85,7 +85,7 @@ function setUpAbyssClient(
   items: unknown[] = [{ id: "k1", name: "Saved", data: abyssKeymap }],
 ) {
   const client = {
-    listMyKeymaps: jest.fn().mockResolvedValue({ items }),
+    listMyKeymaps: jest.fn().mockResolvedValue({ items, pageCount: 1 }),
     getKeymap: jest.fn().mockResolvedValue({ data: abyssKeymap }),
     clearTokenSet: jest.fn(),
   };

--- a/src/hooks/__tests__/useAbyssImport.test.tsx
+++ b/src/hooks/__tests__/useAbyssImport.test.tsx
@@ -55,6 +55,14 @@ const diffWithChanges: KeymapDiff = {
 
 const read = jest.fn().mockResolvedValue(undefined);
 
+/**
+ * Returns a *fresh* object each call, on purpose.
+ *
+ * The hook must key its keymap-list effect on stable primitives rather than the
+ * device object; depending on the object made the effect re-run every render
+ * and cancel its own in-flight request, so the list never populated. Keep this
+ * unstable — it is what catches that regression.
+ */
 function makeDevice(): UseAbyssDeviceReturn {
   return {
     loaded: {

--- a/src/hooks/useAbyssAuth.ts
+++ b/src/hooks/useAbyssAuth.ts
@@ -1,0 +1,151 @@
+/**
+ * Keyboard Abyss login state for the Import/Export tab.
+ *
+ * The token itself lives in the shared client (`getAbyssClient`), which reads
+ * and writes `sessionStorage`; this hook only mirrors it into React state and
+ * owns the login/logout actions. Mount it once, at the page, and pass what the
+ * sections need down as props — a second instance would issue a second
+ * `userinfo()` request for no benefit.
+ */
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { AbyssUserInfo } from "@keyboard-hub/abyss-client";
+import { getAbyssClient, isAbyssConfigured } from "../lib/abyss/abyssClient";
+import {
+  IMPORT_EXPORT_PATH,
+  startAbyssLogin,
+  type AbyssLoginOutcome,
+} from "../lib/abyss/abyssOAuth";
+import {
+  abyssErrorMessageKey,
+  classifyAbyssError,
+  isAbyssUnauthorized,
+} from "../lib/abyss/abyssErrors";
+import { trackAbyssFailed, trackAbyssOperation } from "../lib/analytics";
+
+export interface UseAbyssAuthReturn {
+  /** Whether this build has an Abyss OAuth client id at all. */
+  isConfigured: boolean;
+  /** True once a token is stored and the profile has been read. */
+  isAuthenticated: boolean;
+  /** The signed-in Abyss profile, or `null`. */
+  user: AbyssUserInfo | null;
+  /** A login, logout, or profile fetch is in flight. */
+  isLoading: boolean;
+  /** English message key for the last failure, or `null`. */
+  error: string | null;
+  /** Opens the Abyss consent flow. Resolves once tokens are stored. */
+  login: () => Promise<void>;
+  /** Revokes and forgets the stored token. */
+  logout: () => Promise<void>;
+}
+
+export function useAbyssAuth(): UseAbyssAuthReturn {
+  const configured = isAbyssConfigured();
+  const [user, setUser] = useState<AbyssUserInfo | null>(null);
+  const [isLoading, setIsLoading] = useState(configured);
+  const [error, setError] = useState<string | null>(null);
+  const mountedRef = useRef(true);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  /** Reads the profile for a stored token. Clears the token on 401 so the UI
+   * offers a fresh login instead of failing every later call. */
+  const refreshProfile = useCallback(async () => {
+    const client = getAbyssClient();
+    if (!client || !client.getTokenSet()) {
+      if (mountedRef.current) {
+        setUser(null);
+        setIsLoading(false);
+      }
+      return;
+    }
+    try {
+      const profile = await client.userinfo();
+      if (mountedRef.current) {
+        setUser(profile);
+        setError(null);
+      }
+    } catch (caught) {
+      if (isAbyssUnauthorized(caught)) client.clearTokenSet();
+      if (mountedRef.current) {
+        setUser(null);
+        setError(abyssErrorMessageKey(caught));
+      }
+    } finally {
+      if (mountedRef.current) setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!configured) {
+      setIsLoading(false);
+      return;
+    }
+    void refreshProfile();
+  }, [configured, refreshProfile]);
+
+  const login = useCallback(async () => {
+    const client = getAbyssClient();
+    if (!client) return;
+    setIsLoading(true);
+    setError(null);
+    let outcome: AbyssLoginOutcome;
+    try {
+      outcome = await startAbyssLogin(client, IMPORT_EXPORT_PATH);
+    } catch (caught) {
+      trackAbyssFailed("login", classifyAbyssError(caught));
+      if (mountedRef.current) {
+        setError(abyssErrorMessageKey(caught));
+        setIsLoading(false);
+      }
+      return;
+    }
+    if (outcome.status === "redirecting") {
+      // The document is navigating away; leave the spinner up.
+      return;
+    }
+    if (outcome.status === "cancelled") {
+      trackAbyssFailed("login", "cancelled");
+      if (mountedRef.current) {
+        setError("Abyss login was cancelled.");
+        setIsLoading(false);
+      }
+      return;
+    }
+    trackAbyssOperation("login");
+    await refreshProfile();
+  }, [refreshProfile]);
+
+  const logout = useCallback(async () => {
+    const client = getAbyssClient();
+    if (!client) return;
+    setIsLoading(true);
+    try {
+      // Best effort: a failed revoke must not leave the token in storage.
+      await client.revoke();
+    } catch {
+      // Ignored on purpose.
+    }
+    client.clearTokenSet();
+    if (mountedRef.current) {
+      setUser(null);
+      setError(null);
+      setIsLoading(false);
+    }
+  }, []);
+
+  return {
+    isConfigured: configured,
+    isAuthenticated: user !== null,
+    user,
+    isLoading,
+    error,
+    login,
+    logout,
+  };
+}

--- a/src/hooks/useAbyssDevice.ts
+++ b/src/hooks/useAbyssDevice.ts
@@ -1,0 +1,133 @@
+/**
+ * Reads the connected keyboard into KeyboardHub JSON via the Abyss ZMK adapter,
+ * and resolves its layout against the Abyss catalog.
+ *
+ * Deliberately *not* automatic. The adapter loads through the official ZMK
+ * protocol — `getKeymap`, `listAllBehaviors`, then one `getBehaviorDetails` per
+ * behavior — which is precisely the slow path `useKeymapSource`'s fast-keymap
+ * route exists to avoid. Over BLE that is tens of seconds. So the read is an
+ * explicit user action with visible progress, never a fetch on mount.
+ *
+ * Mount this once at the page and share it: the export and import sections work
+ * from the same snapshot, and reading twice would double the cost for nothing.
+ */
+import { useCallback, useContext, useMemo, useRef, useState } from "react";
+import { ZMKAppContext } from "@cormoran/zmk-studio-react-hook";
+import {
+  loadZmkConnection,
+  type ZmkLoadedConnection,
+} from "@keyboard-hub/adapter-zmk";
+import type {
+  AbyssLayoutDefinition,
+  AbyssLayoutResolveResult,
+} from "@keyboard-hub/abyss-client";
+import { useStudioUnlock } from "./useStudioUnlock";
+import { getAbyssClient } from "../lib/abyss/abyssClient";
+import { createAbyssZmkConnection } from "../lib/abyss/zmkConnectionAdapter";
+import { createAbyssNotificationSource } from "../lib/abyss/abyssNotifications";
+import { abyssErrorMessageKey } from "../lib/abyss/abyssErrors";
+import { studioLockErrorText } from "../lib/studioUnlock";
+
+/** What the read is currently doing, for the progress label. */
+export type AbyssDevicePhase = "idle" | "reading" | "resolving" | "done";
+
+export interface UseAbyssDeviceReturn {
+  /** The device snapshot, or `null` before the first successful read. */
+  loaded: ZmkLoadedConnection | null;
+  /** How the connected keyboard's layout matched the Abyss catalog. */
+  resolved: AbyssLayoutResolveResult | null;
+  phase: AbyssDevicePhase;
+  isReading: boolean;
+  /** English message key for the last failure, or `null`. */
+  error: string | null;
+  /** Reads the keyboard and resolves its layout. Safe to call repeatedly. */
+  read: () => Promise<void>;
+}
+
+export function useAbyssDevice(): UseAbyssDeviceReturn {
+  const zmkApp = useContext(ZMKAppContext);
+  const { runWithUnlock } = useStudioUnlock();
+  const [loaded, setLoaded] = useState<ZmkLoadedConnection | null>(null);
+  const [resolved, setResolved] = useState<AbyssLayoutResolveResult | null>(
+    null,
+  );
+  const [phase, setPhase] = useState<AbyssDevicePhase>("idle");
+  const [error, setError] = useState<string | null>(null);
+  // Guards against a second read being started from the other section while one
+  // is already in flight; both share this hook.
+  const inFlight = useRef<Promise<void> | null>(null);
+
+  const subsystemIndexes = useMemo(
+    () =>
+      (zmkApp?.state.customSubsystems?.subsystems ?? []).map(
+        (subsystem) => subsystem.index,
+      ),
+    [zmkApp?.state.customSubsystems],
+  );
+
+  const read = useCallback(async () => {
+    if (inFlight.current) return inFlight.current;
+    const rpcConnection = zmkApp?.state.connection;
+    const client = getAbyssClient();
+    if (!rpcConnection || !client) return;
+
+    const run = (async () => {
+      setError(null);
+      setPhase("reading");
+      try {
+        const wrapped = createAbyssZmkConnection({
+          rpcConnection,
+          deviceName: zmkApp?.state.deviceInfo?.name,
+          // The connection context does not expose how the user connected, and
+          // the adapter only uses this for a display label it never surfaces to
+          // us, so the distinction does not matter here.
+          method: "serial",
+          notificationSource: zmkApp?.onNotification
+            ? createAbyssNotificationSource({
+                subsystemIndexes,
+                onNotification: zmkApp.onNotification,
+              })
+            : undefined,
+        });
+        // A locked device throws before any read, so the unlock gate can park
+        // the whole operation and retry it cleanly once the user unlocks.
+        const next = await runWithUnlock(() => loadZmkConnection(wrapped));
+        setLoaded(next);
+
+        setPhase("resolving");
+        const layout = next.state.detectedLayout;
+        setResolved(
+          layout
+            ? await client.resolveLayout({
+                keyboard: next.state.currentKeymap.keyboard,
+                // The adapter's layout type and the client's disagree on one
+                // field: `modules[].firmwareDialect` is `[key: string]: unknown`
+                // in @keyboard-hub/schema but `[key: string]: object` in
+                // abyss-api-schema, for the same JSON. The value is serialized
+                // and posted as-is, so this is a typing gap upstream rather than
+                // a real shape difference.
+                layout: layout as unknown as AbyssLayoutDefinition,
+              })
+            : null,
+        );
+        setPhase("done");
+      } catch (caught) {
+        setPhase("idle");
+        setError(studioLockErrorText(caught) ?? abyssErrorMessageKey(caught));
+      } finally {
+        inFlight.current = null;
+      }
+    })();
+    inFlight.current = run;
+    return run;
+  }, [zmkApp, runWithUnlock, subsystemIndexes]);
+
+  return {
+    loaded,
+    resolved,
+    phase,
+    isReading: phase === "reading" || phase === "resolving",
+    error,
+    read,
+  };
+}

--- a/src/hooks/useAbyssExport.ts
+++ b/src/hooks/useAbyssExport.ts
@@ -22,7 +22,9 @@ import type {
   AbyssLayoutResolveResult,
 } from "@keyboard-hub/abyss-client";
 import type { ZmkLoadedConnection } from "@keyboard-hub/adapter-zmk";
+import { compareKeyboardHubKeymaps } from "@keyboard-hub/adapter-common";
 import { getAbyssClient } from "../lib/abyss/abyssClient";
+import { EMPTY_DIFF, type KeymapDiff } from "../lib/abyss/abyssDiff";
 import { listCandidateKeymaps } from "../lib/abyss/abyssKeymapList";
 import {
   ALL_SECTIONS,
@@ -70,6 +72,19 @@ export interface UseAbyssExportReturn {
   exportNow: () => Promise<void>;
   /** The exact JSON that would be uploaded, for the preview panes. */
   preview: { keymap: unknown; layout: unknown } | null;
+  /** What the upload would change on Abyss, for the visual preview. */
+  diff: KeymapDiff;
+  /** The selected keymap's current document on Abyss. */
+  selectedExistingData: unknown;
+}
+
+/** Most recently updated keymap, or the first when timestamps are absent. */
+function latestKeymapId(items: AbyssKeymapSummary[]): string | null {
+  if (items.length === 0) return null;
+  const sorted = [...items].sort((left, right) =>
+    (right.updatedAt ?? "").localeCompare(left.updatedAt ?? ""),
+  );
+  return sorted[0].id;
 }
 
 /** `2026-07-26` — a stable default name suffix. */
@@ -81,7 +96,9 @@ export function useAbyssExport(
   loaded: ZmkLoadedConnection | null,
   resolved: AbyssLayoutResolveResult | null,
 ): UseAbyssExportReturn {
-  const [mode, setMode] = useState<AbyssExportMode>("new");
+  // Updating is the common case once a keymap exists on Abyss; creating a new
+  // one every save would litter the account with near-duplicates.
+  const [mode, setMode] = useState<AbyssExportMode>("update");
   const [keymaps, setKeymaps] = useState<AbyssKeymapSummary[]>([]);
   const [isLoadingKeymaps, setIsLoadingKeymaps] = useState(false);
   const [listError, setListError] = useState<string | null>(null);
@@ -117,7 +134,15 @@ export function useAbyssExport(
         const result = await listCandidateKeymaps(client, {
           layoutId: resolved?.layout?.id,
         });
-        if (!cancelled) setKeymaps(result.items);
+        if (!cancelled) {
+          setKeymaps(result.items);
+          // Preselect the most recently updated one: with "update" as the
+          // default mode, an empty picker would make the primary action
+          // unavailable until the user works out what to choose.
+          setSelectedKeymapId(
+            (current) => current ?? latestKeymapId(result.items),
+          );
+        }
       } catch (caught) {
         if (isAbyssUnauthorized(caught)) client.clearTokenSet();
         if (!cancelled) {
@@ -135,6 +160,14 @@ export function useAbyssExport(
     };
   }, [hasDevice, resolved?.layout?.id]);
 
+  /** The selected keymap's document on Abyss, i.e. the merge base. */
+  const selectedExistingData = useMemo(() => {
+    const existing = keymaps.find((keymap) => keymap.id === selectedKeymapId);
+    return (existing?.data ??
+      existing?.latestVersion?.data ??
+      null) as KeymapDocument | null;
+  }, [keymaps, selectedKeymapId]);
+
   /**
    * The document that `exportNow` would upload, built with the same functions
    * so the preview cannot drift from what is actually sent.
@@ -148,18 +181,32 @@ export function useAbyssExport(
     const device = loaded.state.currentKeymap as unknown as KeymapDocument;
     const layout = loaded.state.detectedLayout ?? null;
     if (mode === "update") {
-      const existing = keymaps.find((keymap) => keymap.id === selectedKeymapId);
-      const base = (existing?.data ?? existing?.latestVersion?.data) as
-        | KeymapDocument
-        | undefined;
-      if (!base) return { keymap: null, layout };
-      return { keymap: buildExportData(device, base, selection), layout };
+      if (!selectedExistingData) return { keymap: null, layout };
+      return {
+        keymap: buildExportData(device, selectedExistingData, selection),
+        layout,
+      };
     }
     return {
       keymap: buildNewExportData(device, selection, name.trim()),
       layout,
     };
-  }, [loaded, mode, keymaps, selectedKeymapId, selection, name]);
+  }, [loaded, mode, selectedExistingData, selection, name]);
+
+  /**
+   * What the upload would change on Abyss, for the visual preview.
+   *
+   * Argument order is (target, current): the payload is the target, the keymap
+   * already on Abyss is current, so `to` is the value that would be saved.
+   */
+  const diff = useMemo<KeymapDiff>(() => {
+    const base = selectedExistingData;
+    if (mode !== "update" || !base || !preview?.keymap) return EMPTY_DIFF;
+    return compareKeyboardHubKeymaps(
+      preview.keymap as never,
+      base as never,
+    ) as unknown as KeymapDiff;
+  }, [mode, preview, selectedExistingData]);
 
   const canExport = Boolean(
     loaded &&
@@ -273,5 +320,7 @@ export function useAbyssExport(
     canExport,
     exportNow,
     preview,
+    diff,
+    selectedExistingData,
   };
 }

--- a/src/hooks/useAbyssExport.ts
+++ b/src/hooks/useAbyssExport.ts
@@ -12,16 +12,18 @@
  * Exports are non-destructive on both sides: Abyss keeps version history, and
  * nothing is written to the keyboard.
  */
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import type {
   AbyssKeymapData,
   AbyssKeymapSummary,
+  AbyssKeymapVisibility,
   AbyssKeymapWriteResult,
   AbyssLayoutDefinition,
   AbyssLayoutResolveResult,
 } from "@keyboard-hub/abyss-client";
 import type { ZmkLoadedConnection } from "@keyboard-hub/adapter-zmk";
 import { getAbyssClient } from "../lib/abyss/abyssClient";
+import { listCandidateKeymaps } from "../lib/abyss/abyssKeymapList";
 import {
   ALL_SECTIONS,
   buildExportData,
@@ -51,6 +53,10 @@ export interface UseAbyssExportReturn {
   /** Name for a new keymap. Ignored when updating. */
   name: string;
   setName: (name: string) => void;
+  /** Who can see a new keymap on Abyss. Ignored when updating, since that
+   * appends a version rather than changing the record's metadata. */
+  visibility: AbyssKeymapVisibility;
+  setVisibility: (visibility: AbyssKeymapVisibility) => void;
   selection: AbyssSectionSelection;
   setSelection: (selection: AbyssSectionSelection) => void;
   isExporting: boolean;
@@ -60,6 +66,8 @@ export interface UseAbyssExportReturn {
   /** Whether the button should be enabled. */
   canExport: boolean;
   exportNow: () => Promise<void>;
+  /** The exact JSON that would be uploaded, for the preview panes. */
+  preview: { keymap: unknown; layout: unknown } | null;
 }
 
 /** `2026-07-26` — a stable default name suffix. */
@@ -76,6 +84,8 @@ export function useAbyssExport(
   const [isLoadingKeymaps, setIsLoadingKeymaps] = useState(false);
   const [selectedKeymapId, setSelectedKeymapId] = useState<string | null>(null);
   const [name, setName] = useState("");
+  const [visibility, setVisibility] =
+    useState<AbyssKeymapVisibility>("private");
   const [selection, setSelection] =
     useState<AbyssSectionSelection>(ALL_SECTIONS);
   const [isExporting, setIsExporting] = useState(false);
@@ -83,30 +93,28 @@ export function useAbyssExport(
   const [result, setResult] = useState<AbyssKeymapWriteResult | null>(null);
 
   const deviceName = loaded?.deviceName;
-  const keyboard = loaded?.state.currentKeymap.keyboard;
+  // A boolean, not `loaded` itself: the effect below must not re-run on every
+  // render just because a caller passed a fresh object.
+  const hasDevice = Boolean(loaded);
 
   // Seed the new-keymap name once a device has been read.
   useEffect(() => {
     if (deviceName) setName(`${deviceName} — ${today()}`);
   }, [deviceName]);
 
-  // Load the user's existing keymaps for this keyboard so "update" has options.
+  // Load the user's existing keymaps so "update" has options.
   useEffect(() => {
     const client = getAbyssClient();
-    if (!client || !keyboard) return;
+    if (!client || !hasDevice) return;
     let cancelled = false;
     setIsLoadingKeymaps(true);
     void (async () => {
       try {
-        const page = await client.listMyKeymaps({
-          visibility: "all",
-          keyboard,
+        const items = await listCandidateKeymaps(client, {
           layoutId: resolved?.layout?.id,
           layoutVariationId: resolved?.layout?.variation.id,
-          page: 1,
-          limit: 50,
         });
-        if (!cancelled) setKeymaps(page.items);
+        if (!cancelled) setKeymaps(items);
       } catch (caught) {
         if (isAbyssUnauthorized(caught)) client.clearTokenSet();
         if (!cancelled) setKeymaps([]);
@@ -117,7 +125,33 @@ export function useAbyssExport(
     return () => {
       cancelled = true;
     };
-  }, [keyboard, resolved?.layout?.id, resolved?.layout?.variation.id]);
+  }, [hasDevice, resolved?.layout?.id, resolved?.layout?.variation.id]);
+
+  /**
+   * The document that `exportNow` would upload, built with the same functions
+   * so the preview cannot drift from what is actually sent.
+   *
+   * For an update this needs the existing keymap's data as the merge base; list
+   * summaries usually carry it, and when they do not the preview falls back to
+   * the new-keymap shape rather than guessing at the merge.
+   */
+  const preview = useMemo(() => {
+    if (!loaded) return null;
+    const device = loaded.state.currentKeymap as unknown as KeymapDocument;
+    const layout = loaded.state.detectedLayout ?? null;
+    if (mode === "update") {
+      const existing = keymaps.find((keymap) => keymap.id === selectedKeymapId);
+      const base = (existing?.data ?? existing?.latestVersion?.data) as
+        | KeymapDocument
+        | undefined;
+      if (!base) return { keymap: null, layout };
+      return { keymap: buildExportData(device, base, selection), layout };
+    }
+    return {
+      keymap: buildNewExportData(device, selection, name.trim()),
+      layout,
+    };
+  }, [loaded, mode, keymaps, selectedKeymapId, selection, name]);
 
   const canExport = Boolean(
     loaded &&
@@ -169,7 +203,7 @@ export function useAbyssExport(
             name.trim(),
           ) as AbyssKeymapData,
           name: name.trim(),
-          visibility: "private",
+          visibility,
           layout,
           message: "Created from DYA Studio",
         });
@@ -183,7 +217,7 @@ export function useAbyssExport(
             name.trim(),
           ) as AbyssKeymapData,
           name: name.trim(),
-          visibility: "private",
+          visibility,
           layout,
           message: "Imported from DYA Studio",
         });
@@ -200,7 +234,16 @@ export function useAbyssExport(
     } finally {
       setIsExporting(false);
     }
-  }, [loaded, mode, keymaps, selectedKeymapId, selection, resolved, name]);
+  }, [
+    loaded,
+    mode,
+    keymaps,
+    selectedKeymapId,
+    selection,
+    resolved,
+    name,
+    visibility,
+  ]);
 
   return {
     mode,
@@ -211,6 +254,8 @@ export function useAbyssExport(
     setSelectedKeymapId,
     name,
     setName,
+    visibility,
+    setVisibility,
     selection,
     setSelection,
     isExporting,
@@ -218,5 +263,6 @@ export function useAbyssExport(
     result,
     canExport,
     exportNow,
+    preview,
   };
 }

--- a/src/hooks/useAbyssExport.ts
+++ b/src/hooks/useAbyssExport.ts
@@ -48,6 +48,8 @@ export interface UseAbyssExportReturn {
   /** Existing keymaps for this keyboard, for the "update" dropdown. */
   keymaps: AbyssKeymapSummary[];
   isLoadingKeymaps: boolean;
+  /** Why the keymap list is empty, when it failed rather than being empty. */
+  listError: string | null;
   selectedKeymapId: string | null;
   setSelectedKeymapId: (id: string | null) => void;
   /** Name for a new keymap. Ignored when updating. */
@@ -82,6 +84,7 @@ export function useAbyssExport(
   const [mode, setMode] = useState<AbyssExportMode>("new");
   const [keymaps, setKeymaps] = useState<AbyssKeymapSummary[]>([]);
   const [isLoadingKeymaps, setIsLoadingKeymaps] = useState(false);
+  const [listError, setListError] = useState<string | null>(null);
   const [selectedKeymapId, setSelectedKeymapId] = useState<string | null>(null);
   const [name, setName] = useState("");
   const [visibility, setVisibility] =
@@ -108,16 +111,22 @@ export function useAbyssExport(
     if (!client || !hasDevice) return;
     let cancelled = false;
     setIsLoadingKeymaps(true);
+    setListError(null);
     void (async () => {
       try {
-        const items = await listCandidateKeymaps(client, {
+        const result = await listCandidateKeymaps(client, {
           layoutId: resolved?.layout?.id,
           layoutVariationId: resolved?.layout?.variation.id,
         });
-        if (!cancelled) setKeymaps(items);
+        if (!cancelled) setKeymaps(result.items);
       } catch (caught) {
         if (isAbyssUnauthorized(caught)) client.clearTokenSet();
-        if (!cancelled) setKeymaps([]);
+        if (!cancelled) {
+          setKeymaps([]);
+          // Without this a failed request is indistinguishable from an empty
+          // account, which is exactly how the earlier slug bug hid itself.
+          setListError(abyssErrorMessageKey(caught));
+        }
       } finally {
         if (!cancelled) setIsLoadingKeymaps(false);
       }
@@ -250,6 +259,7 @@ export function useAbyssExport(
     setMode,
     keymaps,
     isLoadingKeymaps,
+    listError,
     selectedKeymapId,
     setSelectedKeymapId,
     name,

--- a/src/hooks/useAbyssExport.ts
+++ b/src/hooks/useAbyssExport.ts
@@ -116,7 +116,6 @@ export function useAbyssExport(
       try {
         const result = await listCandidateKeymaps(client, {
           layoutId: resolved?.layout?.id,
-          layoutVariationId: resolved?.layout?.variation.id,
         });
         if (!cancelled) setKeymaps(result.items);
       } catch (caught) {
@@ -134,7 +133,7 @@ export function useAbyssExport(
     return () => {
       cancelled = true;
     };
-  }, [hasDevice, resolved?.layout?.id, resolved?.layout?.variation.id]);
+  }, [hasDevice, resolved?.layout?.id]);
 
   /**
    * The document that `exportNow` would upload, built with the same functions

--- a/src/hooks/useAbyssExport.ts
+++ b/src/hooks/useAbyssExport.ts
@@ -1,0 +1,222 @@
+/**
+ * Uploads the device snapshot to Keyboard Abyss, either as a new keymap or as a
+ * new version of one the user already owns.
+ *
+ * Which API call is right depends on how the connected layout resolved against
+ * the Abyss catalog:
+ *
+ * - exact layout match → `createKeymap` / `updateKeymap` against that variation
+ * - compatible layout only, or an unregistered keyboard → `importKeymap`, which
+ *   is documented to create the catalog records it needs
+ *
+ * Exports are non-destructive on both sides: Abyss keeps version history, and
+ * nothing is written to the keyboard.
+ */
+import { useCallback, useEffect, useState } from "react";
+import type {
+  AbyssKeymapData,
+  AbyssKeymapSummary,
+  AbyssKeymapWriteResult,
+  AbyssLayoutDefinition,
+  AbyssLayoutResolveResult,
+} from "@keyboard-hub/abyss-client";
+import type { ZmkLoadedConnection } from "@keyboard-hub/adapter-zmk";
+import { getAbyssClient } from "../lib/abyss/abyssClient";
+import {
+  ALL_SECTIONS,
+  buildExportData,
+  buildNewExportData,
+  selectedSectionIds,
+  type AbyssSectionSelection,
+  type KeymapDocument,
+} from "../lib/abyss/abyssExportPayload";
+import {
+  abyssErrorMessageKey,
+  classifyAbyssError,
+  isAbyssUnauthorized,
+} from "../lib/abyss/abyssErrors";
+import { trackAbyssFailed, trackAbyssOperation } from "../lib/analytics";
+
+/** Whether the upload creates a keymap or appends a version to one. */
+export type AbyssExportMode = "new" | "update";
+
+export interface UseAbyssExportReturn {
+  mode: AbyssExportMode;
+  setMode: (mode: AbyssExportMode) => void;
+  /** Existing keymaps for this keyboard, for the "update" dropdown. */
+  keymaps: AbyssKeymapSummary[];
+  isLoadingKeymaps: boolean;
+  selectedKeymapId: string | null;
+  setSelectedKeymapId: (id: string | null) => void;
+  /** Name for a new keymap. Ignored when updating. */
+  name: string;
+  setName: (name: string) => void;
+  selection: AbyssSectionSelection;
+  setSelection: (selection: AbyssSectionSelection) => void;
+  isExporting: boolean;
+  error: string | null;
+  /** Set after a successful upload, so the UI can link to the result. */
+  result: AbyssKeymapWriteResult | null;
+  /** Whether the button should be enabled. */
+  canExport: boolean;
+  exportNow: () => Promise<void>;
+}
+
+/** `2026-07-26` — a stable default name suffix. */
+function today(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+export function useAbyssExport(
+  loaded: ZmkLoadedConnection | null,
+  resolved: AbyssLayoutResolveResult | null,
+): UseAbyssExportReturn {
+  const [mode, setMode] = useState<AbyssExportMode>("new");
+  const [keymaps, setKeymaps] = useState<AbyssKeymapSummary[]>([]);
+  const [isLoadingKeymaps, setIsLoadingKeymaps] = useState(false);
+  const [selectedKeymapId, setSelectedKeymapId] = useState<string | null>(null);
+  const [name, setName] = useState("");
+  const [selection, setSelection] =
+    useState<AbyssSectionSelection>(ALL_SECTIONS);
+  const [isExporting, setIsExporting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [result, setResult] = useState<AbyssKeymapWriteResult | null>(null);
+
+  const deviceName = loaded?.deviceName;
+  const keyboard = loaded?.state.currentKeymap.keyboard;
+
+  // Seed the new-keymap name once a device has been read.
+  useEffect(() => {
+    if (deviceName) setName(`${deviceName} — ${today()}`);
+  }, [deviceName]);
+
+  // Load the user's existing keymaps for this keyboard so "update" has options.
+  useEffect(() => {
+    const client = getAbyssClient();
+    if (!client || !keyboard) return;
+    let cancelled = false;
+    setIsLoadingKeymaps(true);
+    void (async () => {
+      try {
+        const page = await client.listMyKeymaps({
+          visibility: "all",
+          keyboard,
+          layoutId: resolved?.layout?.id,
+          layoutVariationId: resolved?.layout?.variation.id,
+          page: 1,
+          limit: 50,
+        });
+        if (!cancelled) setKeymaps(page.items);
+      } catch (caught) {
+        if (isAbyssUnauthorized(caught)) client.clearTokenSet();
+        if (!cancelled) setKeymaps([]);
+      } finally {
+        if (!cancelled) setIsLoadingKeymaps(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [keyboard, resolved?.layout?.id, resolved?.layout?.variation.id]);
+
+  const canExport = Boolean(
+    loaded &&
+    !isExporting &&
+    (mode === "new" ? name.trim().length > 0 : selectedKeymapId),
+  );
+
+  const exportNow = useCallback(async () => {
+    const client = getAbyssClient();
+    if (!client || !loaded) return;
+    setIsExporting(true);
+    setError(null);
+    setResult(null);
+
+    const device = loaded.state.currentKeymap as unknown as KeymapDocument;
+    // The layout the device reported, sent alongside the data so Abyss can
+    // create or match the variation. Typed differently by the two packages for
+    // the same JSON; see useAbyssDevice for why the cast is safe.
+    const layout = loaded.state.detectedLayout as unknown as
+      | AbyssLayoutDefinition
+      | undefined;
+
+    try {
+      let written: AbyssKeymapWriteResult;
+      if (mode === "update") {
+        const existing = keymaps.find(
+          (keymap) => keymap.id === selectedKeymapId,
+        );
+        const base = (existing?.data ??
+          existing?.latestVersion?.data ??
+          // A summary without data means we only know its metadata; fall back
+          // to fetching the full record rather than uploading a partial merge.
+          (await client.getKeymap(selectedKeymapId!)).data) as
+          | KeymapDocument
+          | undefined;
+        if (!base) throw new Error("Keymap data unavailable");
+        written = await client.updateKeymap(selectedKeymapId!, {
+          data: buildExportData(device, base, selection) as AbyssKeymapData,
+          layoutVariationId: resolved?.layout?.variation.id,
+          layoutVersionId: resolved?.layout?.latestVersion.id,
+          layout,
+          message: `Saved from DYA Studio (${selectedSectionIds(selection)})`,
+        });
+      } else if (resolved?.layout) {
+        written = await client.createKeymap(resolved.layout.variation.id, {
+          data: buildNewExportData(
+            device,
+            selection,
+            name.trim(),
+          ) as AbyssKeymapData,
+          name: name.trim(),
+          visibility: "private",
+          layout,
+          message: "Created from DYA Studio",
+        });
+      } else {
+        // No exact variation, or the keyboard is not in the catalog at all.
+        // importKeymap creates the records it needs.
+        written = await client.importKeymap({
+          data: buildNewExportData(
+            device,
+            selection,
+            name.trim(),
+          ) as AbyssKeymapData,
+          name: name.trim(),
+          visibility: "private",
+          layout,
+          message: "Imported from DYA Studio",
+        });
+      }
+      setResult(written);
+      trackAbyssOperation("export", {
+        mode,
+        sections: selectedSectionIds(selection),
+      });
+    } catch (caught) {
+      if (isAbyssUnauthorized(caught)) getAbyssClient()?.clearTokenSet();
+      trackAbyssFailed("export", classifyAbyssError(caught));
+      setError(abyssErrorMessageKey(caught));
+    } finally {
+      setIsExporting(false);
+    }
+  }, [loaded, mode, keymaps, selectedKeymapId, selection, resolved, name]);
+
+  return {
+    mode,
+    setMode,
+    keymaps,
+    isLoadingKeymaps,
+    selectedKeymapId,
+    setSelectedKeymapId,
+    name,
+    setName,
+    selection,
+    setSelection,
+    isExporting,
+    error,
+    result,
+    canExport,
+    exportNow,
+  };
+}

--- a/src/hooks/useAbyssImport.ts
+++ b/src/hooks/useAbyssImport.ts
@@ -102,7 +102,6 @@ export function useAbyssImport(
       try {
         const result = await listCandidateKeymaps(client, {
           layoutId: resolved?.layout?.id,
-          layoutVariationId: resolved?.layout?.variation.id,
         });
         if (!cancelled) setKeymaps(result.items);
       } catch (caught) {
@@ -120,7 +119,7 @@ export function useAbyssImport(
     return () => {
       cancelled = true;
     };
-  }, [hasDevice, resolved?.layout?.id, resolved?.layout?.variation.id]);
+  }, [hasDevice, resolved?.layout?.id]);
 
   const selectKeymap = useCallback(
     async (id: string | null) => {

--- a/src/hooks/useAbyssImport.ts
+++ b/src/hooks/useAbyssImport.ts
@@ -1,0 +1,221 @@
+/**
+ * Writes a Keyboard Abyss keymap onto the connected keyboard.
+ *
+ * This is the only part of the tab that changes the device, so it is
+ * deliberately stepwise: list → select → diff → pre-flight → explicit confirm.
+ * The adapter applies changes one RPC at a time and commits with `saveChanges`
+ * at the end, so a failure partway leaves the keyboard in a mixed state — which
+ * is why mismatches are caught before the write rather than during it.
+ */
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { compareKeyboardHubKeymaps } from "@keyboard-hub/adapter-common";
+import { writeZmkKeymapDiff } from "@keyboard-hub/adapter-zmk";
+import type { AbyssKeymapSummary } from "@keyboard-hub/abyss-client";
+import { getAbyssClient } from "../lib/abyss/abyssClient";
+import { useStudioUnlock } from "./useStudioUnlock";
+import {
+  EMPTY_DIFF,
+  filterDiff,
+  isEmptyDiff,
+  type KeymapDiff,
+} from "../lib/abyss/abyssDiff";
+import { runPreflight, isBlocked } from "../lib/abyss/abyssPreflight";
+import {
+  ALL_SECTIONS,
+  selectedSectionIds,
+  type AbyssSectionSelection,
+  type KeymapDocument,
+} from "../lib/abyss/abyssExportPayload";
+import {
+  abyssErrorMessageKey,
+  classifyAbyssError,
+  isAbyssUnauthorized,
+} from "../lib/abyss/abyssErrors";
+import { studioLockErrorText } from "../lib/studioUnlock";
+import { trackAbyssFailed, trackAbyssOperation } from "../lib/analytics";
+import type { UseAbyssDeviceReturn } from "./useAbyssDevice";
+
+/** Widest layer in a keymap, which is what "key count" means for compatibility. */
+function keyCountOf(keymap: KeymapDocument | undefined): number {
+  if (!keymap?.layers.length) return 0;
+  return Math.max(...keymap.layers.map((layer) => layer.bindings.length));
+}
+
+export interface UseAbyssImportReturn {
+  keymaps: AbyssKeymapSummary[];
+  isLoadingKeymaps: boolean;
+  selectedKeymapId: string | null;
+  /** Selecting fetches the keymap's data and recomputes the diff. */
+  selectKeymap: (id: string | null) => Promise<void>;
+  isLoadingSelection: boolean;
+  selection: AbyssSectionSelection;
+  setSelection: (selection: AbyssSectionSelection) => void;
+  /** The diff after the section filter, i.e. exactly what would be written. */
+  diff: KeymapDiff;
+  isInSync: boolean;
+  preflight: ReturnType<typeof runPreflight>;
+  canWrite: boolean;
+  isWriting: boolean;
+  /** True once a write finished and the re-read confirmed an empty diff. */
+  didWrite: boolean;
+  error: string | null;
+  write: () => Promise<void>;
+}
+
+export function useAbyssImport(
+  device: UseAbyssDeviceReturn,
+): UseAbyssImportReturn {
+  const { loaded, resolved, read } = device;
+  const { runWithUnlock } = useStudioUnlock();
+  const [keymaps, setKeymaps] = useState<AbyssKeymapSummary[]>([]);
+  const [isLoadingKeymaps, setIsLoadingKeymaps] = useState(false);
+  const [selectedKeymapId, setSelectedKeymapId] = useState<string | null>(null);
+  const [targetKeymap, setTargetKeymap] = useState<KeymapDocument | null>(null);
+  const [isLoadingSelection, setIsLoadingSelection] = useState(false);
+  const [selection, setSelection] =
+    useState<AbyssSectionSelection>(ALL_SECTIONS);
+  const [isWriting, setIsWriting] = useState(false);
+  const [didWrite, setDidWrite] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const currentKeymap = loaded?.state.currentKeymap as
+    | KeymapDocument
+    | undefined;
+  const keyboard = currentKeymap?.keyboard;
+
+  // Only keymaps for this keyboard and layout variation are candidates.
+  useEffect(() => {
+    const client = getAbyssClient();
+    if (!client || !keyboard) return;
+    let cancelled = false;
+    setIsLoadingKeymaps(true);
+    void (async () => {
+      try {
+        const page = await client.listMyKeymaps({
+          visibility: "all",
+          keyboard,
+          layoutId: resolved?.layout?.id,
+          layoutVariationId: resolved?.layout?.variation.id,
+          page: 1,
+          limit: 50,
+        });
+        if (!cancelled) setKeymaps(page.items);
+      } catch (caught) {
+        if (isAbyssUnauthorized(caught)) client.clearTokenSet();
+        if (!cancelled) setKeymaps([]);
+      } finally {
+        if (!cancelled) setIsLoadingKeymaps(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [keyboard, resolved?.layout?.id, resolved?.layout?.variation.id]);
+
+  const selectKeymap = useCallback(
+    async (id: string | null) => {
+      setSelectedKeymapId(id);
+      setTargetKeymap(null);
+      setDidWrite(false);
+      setError(null);
+      if (!id) return;
+      const client = getAbyssClient();
+      if (!client) return;
+      setIsLoadingSelection(true);
+      try {
+        const summary = keymaps.find((keymap) => keymap.id === id);
+        // List summaries may omit the payload; fetch the full record rather
+        // than diffing against a partial one.
+        const data =
+          summary?.data ??
+          summary?.latestVersion?.data ??
+          (await client.getKeymap(id)).data;
+        setTargetKeymap((data ?? null) as KeymapDocument | null);
+      } catch (caught) {
+        if (isAbyssUnauthorized(caught)) client.clearTokenSet();
+        setError(abyssErrorMessageKey(caught));
+      } finally {
+        setIsLoadingSelection(false);
+      }
+    },
+    [keymaps],
+  );
+
+  // Argument order is (target, current): what Abyss has versus what the device
+  // has, so `to` is the value that would be written.
+  const fullDiff = useMemo<KeymapDiff>(() => {
+    if (!targetKeymap || !currentKeymap) return EMPTY_DIFF;
+    return compareKeyboardHubKeymaps(
+      targetKeymap as never,
+      currentKeymap as never,
+    ) as unknown as KeymapDiff;
+  }, [targetKeymap, currentKeymap]);
+
+  const diff = useMemo(
+    () => filterDiff(fullDiff, selection),
+    [fullDiff, selection],
+  );
+
+  const preflight = useMemo(() => {
+    if (!targetKeymap || !currentKeymap) return [];
+    return runPreflight({
+      diff,
+      deviceKeyCount: keyCountOf(currentKeymap),
+      targetKeyCount: keyCountOf(targetKeymap),
+      deviceLayerCount: currentKeymap.layers.length,
+      deviceLayoutName: loaded?.state.detectedLayout?.name,
+      targetLayoutName: keymaps.find((keymap) => keymap.id === selectedKeymapId)
+        ?.layout?.name,
+    });
+  }, [diff, targetKeymap, currentKeymap, loaded, keymaps, selectedKeymapId]);
+
+  const isInSync = Boolean(targetKeymap) && isEmptyDiff(diff);
+  const canWrite = Boolean(
+    loaded &&
+    targetKeymap &&
+    !isEmptyDiff(diff) &&
+    !isBlocked(preflight) &&
+    !isWriting,
+  );
+
+  const write = useCallback(async () => {
+    if (!loaded) return;
+    setIsWriting(true);
+    setError(null);
+    try {
+      // A locked device throws before anything is written, so the unlock gate
+      // can park the whole write and retry it once the user unlocks.
+      await runWithUnlock(() => writeZmkKeymapDiff(loaded, diff as never));
+      trackAbyssOperation("import", {
+        sections: selectedSectionIds(selection),
+      });
+      // Re-read so the shown state is what the keyboard actually accepted, not
+      // what we hoped it would.
+      await read();
+      setDidWrite(true);
+    } catch (caught) {
+      trackAbyssFailed("import", classifyAbyssError(caught));
+      setError(studioLockErrorText(caught) ?? abyssErrorMessageKey(caught));
+    } finally {
+      setIsWriting(false);
+    }
+  }, [loaded, diff, selection, runWithUnlock, read]);
+
+  return {
+    keymaps,
+    isLoadingKeymaps,
+    selectedKeymapId,
+    selectKeymap,
+    isLoadingSelection,
+    selection,
+    setSelection,
+    diff,
+    isInSync,
+    preflight,
+    canWrite,
+    isWriting,
+    didWrite,
+    error,
+    write,
+  };
+}

--- a/src/hooks/useAbyssImport.ts
+++ b/src/hooks/useAbyssImport.ts
@@ -12,6 +12,7 @@ import { compareKeyboardHubKeymaps } from "@keyboard-hub/adapter-common";
 import { writeZmkKeymapDiff } from "@keyboard-hub/adapter-zmk";
 import type { AbyssKeymapSummary } from "@keyboard-hub/abyss-client";
 import { getAbyssClient } from "../lib/abyss/abyssClient";
+import { listCandidateKeymaps } from "../lib/abyss/abyssKeymapList";
 import { useStudioUnlock } from "./useStudioUnlock";
 import {
   EMPTY_DIFF,
@@ -81,25 +82,23 @@ export function useAbyssImport(
   const currentKeymap = loaded?.state.currentKeymap as
     | KeymapDocument
     | undefined;
-  const keyboard = currentKeymap?.keyboard;
+  // A boolean, not `loaded` itself: the effect below must not re-run on every
+  // render just because a caller passed a fresh object.
+  const hasDevice = Boolean(loaded);
 
-  // Only keymaps for this keyboard and layout variation are candidates.
+  // Candidates come from the resolved layout, not the device-derived slug.
   useEffect(() => {
     const client = getAbyssClient();
-    if (!client || !keyboard) return;
+    if (!client || !hasDevice) return;
     let cancelled = false;
     setIsLoadingKeymaps(true);
     void (async () => {
       try {
-        const page = await client.listMyKeymaps({
-          visibility: "all",
-          keyboard,
+        const items = await listCandidateKeymaps(client, {
           layoutId: resolved?.layout?.id,
           layoutVariationId: resolved?.layout?.variation.id,
-          page: 1,
-          limit: 50,
         });
-        if (!cancelled) setKeymaps(page.items);
+        if (!cancelled) setKeymaps(items);
       } catch (caught) {
         if (isAbyssUnauthorized(caught)) client.clearTokenSet();
         if (!cancelled) setKeymaps([]);
@@ -110,7 +109,7 @@ export function useAbyssImport(
     return () => {
       cancelled = true;
     };
-  }, [keyboard, resolved?.layout?.id, resolved?.layout?.variation.id]);
+  }, [hasDevice, resolved?.layout?.id, resolved?.layout?.variation.id]);
 
   const selectKeymap = useCallback(
     async (id: string | null) => {

--- a/src/hooks/useAbyssImport.ts
+++ b/src/hooks/useAbyssImport.ts
@@ -45,6 +45,8 @@ function keyCountOf(keymap: KeymapDocument | undefined): number {
 export interface UseAbyssImportReturn {
   keymaps: AbyssKeymapSummary[];
   isLoadingKeymaps: boolean;
+  /** Why the keymap list is empty, when it failed rather than being empty. */
+  listError: string | null;
   selectedKeymapId: string | null;
   /** Selecting fetches the keymap's data and recomputes the diff. */
   selectKeymap: (id: string | null) => Promise<void>;
@@ -53,6 +55,8 @@ export interface UseAbyssImportReturn {
   setSelection: (selection: AbyssSectionSelection) => void;
   /** The diff after the section filter, i.e. exactly what would be written. */
   diff: KeymapDiff;
+  /** The selected Abyss keymap's raw document, for the JSON diff view. */
+  targetKeymap: KeymapDocument | null;
   isInSync: boolean;
   preflight: ReturnType<typeof runPreflight>;
   canWrite: boolean;
@@ -70,6 +74,7 @@ export function useAbyssImport(
   const { runWithUnlock } = useStudioUnlock();
   const [keymaps, setKeymaps] = useState<AbyssKeymapSummary[]>([]);
   const [isLoadingKeymaps, setIsLoadingKeymaps] = useState(false);
+  const [listError, setListError] = useState<string | null>(null);
   const [selectedKeymapId, setSelectedKeymapId] = useState<string | null>(null);
   const [targetKeymap, setTargetKeymap] = useState<KeymapDocument | null>(null);
   const [isLoadingSelection, setIsLoadingSelection] = useState(false);
@@ -92,16 +97,22 @@ export function useAbyssImport(
     if (!client || !hasDevice) return;
     let cancelled = false;
     setIsLoadingKeymaps(true);
+    setListError(null);
     void (async () => {
       try {
-        const items = await listCandidateKeymaps(client, {
+        const result = await listCandidateKeymaps(client, {
           layoutId: resolved?.layout?.id,
           layoutVariationId: resolved?.layout?.variation.id,
         });
-        if (!cancelled) setKeymaps(items);
+        if (!cancelled) setKeymaps(result.items);
       } catch (caught) {
         if (isAbyssUnauthorized(caught)) client.clearTokenSet();
-        if (!cancelled) setKeymaps([]);
+        if (!cancelled) {
+          setKeymaps([]);
+          // Without this a failed request is indistinguishable from an empty
+          // account, which is exactly how the earlier slug bug hid itself.
+          setListError(abyssErrorMessageKey(caught));
+        }
       } finally {
         if (!cancelled) setIsLoadingKeymaps(false);
       }
@@ -203,12 +214,14 @@ export function useAbyssImport(
   return {
     keymaps,
     isLoadingKeymaps,
+    listError,
     selectedKeymapId,
     selectKeymap,
     isLoadingSelection,
     selection,
     setSelection,
     diff,
+    targetKeymap,
     isInSync,
     preflight,
     canWrite,

--- a/src/i18n/releaseNotes.json
+++ b/src/i18n/releaseNotes.json
@@ -57,8 +57,8 @@
             "ja": "fast-keymap モジュールによりキーマップ読み込みを高速化。レイヤーごとの逐次読み込みに対応し、非対応時は公式プロトコルにフォールバックします。"
           },
           {
-            "en": "New Import/Export tab: sign in to Keyboard Abyss to sync keymaps with your account.",
-            "ja": "インポート／エクスポートタブを追加。Keyboard Abyss にサインインしてアカウントとキーマップを同期できます。"
+            "en": "New Import/Export tab: sign in to Keyboard Abyss to upload your keymap, or write a saved keymap back to the keyboard after reviewing exactly what changes.",
+            "ja": "インポート／エクスポートタブを追加。Keyboard Abyss にサインインしてキーマップをアップロードしたり、保存済みキーマップの変更内容を確認したうえでキーボードに書き戻せます。"
           }
         ],
         "minor": [

--- a/src/i18n/releaseNotes.json
+++ b/src/i18n/releaseNotes.json
@@ -55,6 +55,10 @@
           {
             "en": "Faster keymap loading via the fast-keymap module with incremental per-layer loading and an official-protocol fallback.",
             "ja": "fast-keymap モジュールによりキーマップ読み込みを高速化。レイヤーごとの逐次読み込みに対応し、非対応時は公式プロトコルにフォールバックします。"
+          },
+          {
+            "en": "New Import/Export tab: sign in to Keyboard Abyss to sync keymaps with your account.",
+            "ja": "インポート／エクスポートタブを追加。Keyboard Abyss にサインインしてアカウントとキーマップを同期できます。"
           }
         ],
         "minor": [

--- a/src/i18n/translations.ts
+++ b/src/i18n/translations.ts
@@ -1181,6 +1181,23 @@ const ja: Record<string, string> = {
   "Layout JSON to upload": "アップロードする layout JSON",
   "Not available.": "利用できません。",
 
+  // Import/Export — visual diff preview
+  // "Layers" and "Keys" are already translated above.
+  "Key {{index}}": "キー {{index}}",
+  "No layout geometry available for a preview.":
+    "プレビュー用のレイアウト情報がありません。",
+  "This layer does not exist in the selected keymap.":
+    "選択したキーマップにこのレイヤーはありません。",
+  "No keys": "キーなし",
+  "Unnamed macro": "名前のないマクロ",
+  "No steps": "ステップなし",
+  "wait {{ms}}ms": "{{ms}}ms 待機",
+  "tap {{ms}}ms": "{{ms}}ms タップ",
+  Added: "追加",
+  Removed: "削除",
+  Changed: "変更",
+  Raw: "生データ",
+
   // Import/Export — JSON diff modal
   "Review changes": "変更内容を確認",
   "Review changes as JSON": "JSON で変更内容を確認",

--- a/src/i18n/translations.ts
+++ b/src/i18n/translations.ts
@@ -1181,6 +1181,28 @@ const ja: Record<string, string> = {
   "Layout JSON to upload": "アップロードする layout JSON",
   "Not available.": "利用できません。",
 
+  // Import/Export — JSON diff modal
+  "Review changes": "変更内容を確認",
+  "Review changes as JSON": "JSON で変更内容を確認",
+  "Changes to upload": "アップロードする変更",
+  "Changes to write": "書き込む変更",
+  "Left: the keymap currently on Abyss. Right: what this export would save.":
+    "左: 現在 Abyss にあるキーマップ。右: このエクスポートで保存される内容。",
+  "Left: what is on the keyboard now. Right: the keymap from Abyss.":
+    "左: 現在キーボードにある内容。右: Abyss のキーマップ。",
+  Inline: "インライン",
+  "Side by side": "左右に並べる",
+  "Around changes": "変更箇所のみ",
+  "Entire file": "ファイル全体",
+  "No differences.": "差分はありません。",
+  // "Close" is already translated near the top of this dictionary.
+
+  // Import/Export — Abyss links
+  "Open this keyboard on Abyss": "このキーボードを Abyss で開く",
+  "Register on Abyss": "Abyss で登録する",
+  "This keyboard is not registered on Abyss yet. Register it on Abyss first so exports land in the catalog.":
+    "このキーボードはまだ Abyss に登録されていません。エクスポートをカタログに反映させるには、先に Abyss で登録してください。",
+
   // Import/Export — import section
   "Read the keyboard first to enable importing.":
     "インポートするには、先にキーボードを読み取ってください。",

--- a/src/i18n/translations.ts
+++ b/src/i18n/translations.ts
@@ -1128,6 +1128,27 @@ const ja: Record<string, string> = {
   "Not available in this build yet — the Abyss keyboard adapter has not been released.":
     "このビルドではまだ利用できません（Abyss のキーボードアダプタが未リリースです）。",
 
+  // Import/Export — device snapshot
+  "Keyboard snapshot": "キーボードの読み取り",
+  "Read the keyboard before exporting or importing.":
+    "エクスポート／インポートの前にキーボードを読み取ってください。",
+  "Read keyboard": "キーボードを読み取る",
+  "Read again": "再読み取り",
+  "Connected keyboard": "接続中のキーボード",
+  "Reading the keyboard. This is slower over Bluetooth than USB.":
+    "キーボードを読み取っています。Bluetooth 接続では USB より時間がかかります。",
+  "Matching the layout on Abyss...": "Abyss 上のレイアウトと照合しています...",
+  Keys: "キー数",
+  Modules: "モジュール",
+  "Matched the Abyss layout {{layout}}.":
+    "Abyss のレイアウト {{layout}} と一致しました。",
+  "No exact layout match. Exporting will add a new variation of {{layout}}.":
+    "完全に一致するレイアウトがありません。エクスポートすると {{layout}} の新しいバリエーションが作成されます。",
+  "This layout is not registered on Abyss yet. Exporting will add it.":
+    "このレイアウトはまだ Abyss に登録されていません。エクスポート時に追加されます。",
+  "This keyboard is not registered on Abyss yet. Exporting will create it under your account.":
+    "このキーボードはまだ Abyss に登録されていません。エクスポート時にあなたのアカウントで作成されます。",
+
   // Import/Export — OAuth callback route
   "Completing Abyss sign-in...": "Abyss のサインインを完了しています...",
   "Signed in to Abyss": "Abyss にサインインしました",

--- a/src/i18n/translations.ts
+++ b/src/i18n/translations.ts
@@ -1174,6 +1174,13 @@ const ja: Record<string, string> = {
   // Macro & Combo tab.
   "Module settings": "モジュール設定",
 
+  Visibility: "公開設定",
+  "Private — only you": "非公開 — 自分のみ",
+  "Public — anyone can find it": "公開 — 誰でも閲覧できます",
+  "Keymap JSON to upload": "アップロードする keymap JSON",
+  "Layout JSON to upload": "アップロードする layout JSON",
+  "Not available.": "利用できません。",
+
   // Import/Export — import section
   "Read the keyboard first to enable importing.":
     "インポートするには、先にキーボードを読み取ってください。",

--- a/src/i18n/translations.ts
+++ b/src/i18n/translations.ts
@@ -1108,6 +1108,57 @@ const ja: Record<string, string> = {
   Note: "補足",
   "These values are read from and written to your keyboard's firmware. Change them in small steps.":
     "これらの値はキーボードのファームウェアから読み書きされます。少しずつ変更してください。",
+
+  // Import/Export (Keyboard Abyss)
+  "Import/Export": "インポート／エクスポート",
+  "Sync keymaps with Keyboard Abyss": "Keyboard Abyss とキーマップを同期します",
+  "Keyboard Abyss": "Keyboard Abyss",
+  "Sign in to import and export keymaps.":
+    "サインインするとキーマップのインポート／エクスポートができます。",
+  "Sign in with Abyss": "Abyss でサインイン",
+  "Sign out": "サインアウト",
+  "A sign-in window opens at abyss.keyboard-hub.com. Your session lasts until this tab is closed.":
+    "abyss.keyboard-hub.com のサインイン画面が開きます。セッションはこのタブを閉じるまで有効です。",
+  Export: "エクスポート",
+  Import: "インポート",
+  "Upload the connected keyboard's keymap to Abyss, either as a new keymap or as a new version of an existing one.":
+    "接続中のキーボードのキーマップを、新規キーマップまたは既存キーマップの新しいバージョンとして Abyss にアップロードします。",
+  "Pick a compatible keymap from Abyss, review what would change, and write it to the connected keyboard.":
+    "Abyss から互換性のあるキーマップを選び、変更内容を確認したうえで接続中のキーボードに書き込みます。",
+  "Not available in this build yet — the Abyss keyboard adapter has not been released.":
+    "このビルドではまだ利用できません（Abyss のキーボードアダプタが未リリースです）。",
+
+  // Import/Export — OAuth callback route
+  "Completing Abyss sign-in...": "Abyss のサインインを完了しています...",
+  "Signed in to Abyss": "Abyss にサインインしました",
+  "You can close this window.": "このウィンドウは閉じて構いません。",
+  "Abyss sign-in failed": "Abyss のサインインに失敗しました",
+  "Back to DYA Studio": "DYA Studio に戻る",
+
+  // Import/Export — error messages
+  "Your Abyss session expired. Please log in again.":
+    "Abyss のセッションが失効しました。もう一度サインインしてください。",
+  "Your Abyss account does not have permission for this action.":
+    "この操作を行う権限が Abyss アカウントにありません。",
+  "This keymap no longer exists on Abyss.":
+    "このキーマップは Abyss 上に存在しません。",
+  "Abyss rejected this keymap. It may not match the connected keyboard.":
+    "Abyss がこのキーマップを受け付けませんでした。接続中のキーボードと一致していない可能性があります。",
+  "Too many requests to Abyss. Please wait a moment and try again.":
+    "Abyss へのリクエストが多すぎます。しばらく待ってから再試行してください。",
+  "Abyss is having trouble right now. Please try again later.":
+    "現在 Abyss に問題が発生しています。時間をおいて再試行してください。",
+  "Could not reach Abyss. Check your network connection.":
+    "Abyss に接続できませんでした。ネットワーク接続を確認してください。",
+  "The keyboard is locked. Unlock it and try again.":
+    "キーボードがロックされています。ロックを解除して再試行してください。",
+  "Abyss login was cancelled.": "Abyss のサインインがキャンセルされました。",
+  "Abyss sign-in could not be completed. Please start again from the Import/Export tab.":
+    "Abyss のサインインを完了できませんでした。インポート／エクスポートタブからやり直してください。",
+  "Something went wrong talking to Abyss.":
+    "Abyss との通信で問題が発生しました。",
+  "Abyss is not configured for this build.":
+    "このビルドには Abyss の設定がありません。",
 };
 
 const dictionaries: Record<Language, Record<string, string>> = {

--- a/src/i18n/translations.ts
+++ b/src/i18n/translations.ts
@@ -1174,6 +1174,49 @@ const ja: Record<string, string> = {
   // Macro & Combo tab.
   "Module settings": "モジュール設定",
 
+  // Import/Export — import section
+  "Read the keyboard first to enable importing.":
+    "インポートするには、先にキーボードを読み取ってください。",
+  "Writing changes the keyboard. Review the changes before confirming.":
+    "書き込みはキーボードを変更します。確認する前に変更内容を確認してください。",
+  "Keymap to write": "書き込むキーマップ",
+  "No compatible keymaps found for this keyboard":
+    "このキーボードと互換性のあるキーマップが見つかりません",
+  "Loading the keymap...": "キーマップを読み込んでいます...",
+  "The keyboard already matches this keymap.":
+    "キーボードはすでにこのキーマップと一致しています。",
+  "Written to the keyboard and re-read to confirm.":
+    "キーボードに書き込み、再読み取りで確認しました。",
+  "Write to keyboard": "キーボードに書き込む",
+  "Write {{count}} changes to the keyboard? This replaces the current settings and cannot be undone.":
+    "{{count}} 件の変更をキーボードに書き込みますか？現在の設定を置き換え、元に戻せません。",
+  // "Cancel" is already translated near the top of this dictionary.
+
+  // Import/Export — diff view
+  "Layer {{index}}": "レイヤー {{index}}",
+  "{{count}} changes": "{{count}} 件の変更",
+  Rename: "名前の変更",
+  Module: "モジュール",
+  "Show all {{count}} keys": "{{count}} 件すべて表示",
+  "This replaces most of the keymap ({{count}} keys). The full list is long.":
+    "キーマップの大部分を置き換えます（{{count}} キー）。一覧は非常に長くなります。",
+  "Show the full list anyway": "それでも一覧を表示",
+  bindings: "キー割り当て",
+  "layer names": "レイヤー名",
+  combos: "コンボ",
+  macros: "マクロ",
+  modules: "モジュール",
+
+  // Import/Export — pre-flight checks
+  "This keymap has {{target}} keys per layer but the keyboard has {{device}}.":
+    "このキーマップは1レイヤーあたり {{target}} キーですが、キーボードは {{device}} キーです。",
+  "This keymap covers {{target}} of the keyboard's {{device}} keys. The rest are left unchanged.":
+    "このキーマップはキーボードの {{device}} キーのうち {{target}} キーを対象にしています。残りは変更されません。",
+  "Writing needs {{needed}} layers; the keyboard has {{device}}. The missing ones will be added.":
+    "書き込みには {{needed}} レイヤーが必要ですが、キーボードには {{device}} レイヤーあります。不足分は追加されます。",
+  "This keymap was made for the {{target}} layout; the keyboard reports {{device}}.":
+    "このキーマップは {{target}} レイアウト向けですが、キーボードは {{device}} と報告しています。",
+
   // Import/Export — OAuth callback route
   "Completing Abyss sign-in...": "Abyss のサインインを完了しています...",
   "Signed in to Abyss": "Abyss にサインインしました",

--- a/src/i18n/translations.ts
+++ b/src/i18n/translations.ts
@@ -1125,8 +1125,8 @@ const ja: Record<string, string> = {
     "接続中のキーボードのキーマップを、新規キーマップまたは既存キーマップの新しいバージョンとして Abyss にアップロードします。",
   "Pick a compatible keymap from Abyss, review what would change, and write it to the connected keyboard.":
     "Abyss から互換性のあるキーマップを選び、変更内容を確認したうえで接続中のキーボードに書き込みます。",
-  "Not available in this build yet — the Abyss keyboard adapter has not been released.":
-    "このビルドではまだ利用できません（Abyss のキーボードアダプタが未リリースです）。",
+  "Not available yet — this is still being built.":
+    "まだ利用できません（実装中です）。",
 
   // Import/Export — device snapshot
   "Keyboard snapshot": "キーボードの読み取り",
@@ -1148,6 +1148,31 @@ const ja: Record<string, string> = {
     "このレイアウトはまだ Abyss に登録されていません。エクスポート時に追加されます。",
   "This keyboard is not registered on Abyss yet. Exporting will create it under your account.":
     "このキーボードはまだ Abyss に登録されていません。エクスポート時にあなたのアカウントで作成されます。",
+
+  // Import/Export — export section
+  "Read the keyboard first to enable exporting.":
+    "エクスポートするには、先にキーボードを読み取ってください。",
+  "Exporting uploads this keymap to abyss.keyboard-hub.com under your account.":
+    "エクスポートすると、このキーマップがあなたのアカウントで abyss.keyboard-hub.com にアップロードされます。",
+  Destination: "保存先",
+  "Export as a new keymap": "新しいキーマップとしてエクスポート",
+  "Update an existing keymap": "既存のキーマップを更新",
+  "Export as new keymap": "新規キーマップとしてエクスポート",
+  "Update keymap": "キーマップを更新",
+  "Keymap name": "キーマップ名",
+  "Keymap to update": "更新するキーマップ",
+  "Loading your keymaps...": "キーマップを読み込んでいます...",
+  "No keymaps found for this keyboard":
+    "このキーボード用のキーマップが見つかりません",
+  "Select a keymap": "キーマップを選択",
+  "Saved to Abyss as version {{version}}.":
+    "Abyss にバージョン {{version}} として保存しました。",
+  "Open on Abyss": "Abyss で開く",
+  Include: "含める項目",
+  "Keymap (layers & key bindings)": "キーマップ（レイヤーとキー割り当て）",
+  // "Combos" and "Macros" are already translated above, shared with the
+  // Macro & Combo tab.
+  "Module settings": "モジュール設定",
 
   // Import/Export — OAuth callback route
   "Completing Abyss sign-in...": "Abyss のサインインを完了しています...",

--- a/src/i18n/translations.ts
+++ b/src/i18n/translations.ts
@@ -1117,8 +1117,8 @@ const ja: Record<string, string> = {
     "サインインするとキーマップのインポート／エクスポートができます。",
   "Sign in with Abyss": "Abyss でサインイン",
   "Sign out": "サインアウト",
-  "A sign-in window opens at abyss.keyboard-hub.com. Your session lasts until this tab is closed.":
-    "abyss.keyboard-hub.com のサインイン画面が開きます。セッションはこのタブを閉じるまで有効です。",
+  "A sign-in window opens at {{host}}. Your session lasts until this tab is closed.":
+    "{{host}} のサインイン画面が開きます。セッションはこのタブを閉じるまで有効です。",
   Export: "エクスポート",
   Import: "インポート",
   "Upload the connected keyboard's keymap to Abyss, either as a new keymap or as a new version of an existing one.":
@@ -1152,8 +1152,8 @@ const ja: Record<string, string> = {
   // Import/Export — export section
   "Read the keyboard first to enable exporting.":
     "エクスポートするには、先にキーボードを読み取ってください。",
-  "Exporting uploads this keymap to abyss.keyboard-hub.com under your account.":
-    "エクスポートすると、このキーマップがあなたのアカウントで abyss.keyboard-hub.com にアップロードされます。",
+  "Exporting uploads this keymap to {{host}} under your account.":
+    "エクスポートすると、このキーマップがあなたのアカウントで {{host}} にアップロードされます。",
   Destination: "保存先",
   "Export as a new keymap": "新しいキーマップとしてエクスポート",
   "Update an existing keymap": "既存のキーマップを更新",

--- a/src/index.css
+++ b/src/index.css
@@ -519,3 +519,48 @@
     opacity: 0.6;
   }
 }
+
+/* JSON diff viewer (react-diff-view)
+   The library ships a light-only stylesheet, so the palette is re-pointed at
+   the app's theme tokens. Without this the diff is unreadable in dark mode. */
+.abyss-diff .diff {
+  background: transparent;
+  color: var(--color-text);
+  font-size: 11px;
+}
+
+.abyss-diff .diff-gutter,
+.abyss-diff .diff-code {
+  background: transparent;
+  color: var(--color-text);
+}
+
+.abyss-diff .diff-gutter {
+  color: var(--color-text-muted);
+}
+
+.abyss-diff .diff-code-insert,
+.abyss-diff .diff-gutter-insert {
+  background: rgba(34, 197, 94, 0.14);
+}
+
+.abyss-diff .diff-code-delete,
+.abyss-diff .diff-gutter-delete {
+  background: rgba(239, 68, 68, 0.14);
+}
+
+/* Character-level highlight inside a changed line. */
+.abyss-diff .diff-code-insert ins {
+  background: rgba(34, 197, 94, 0.3);
+  text-decoration: none;
+}
+
+.abyss-diff .diff-code-delete del {
+  background: rgba(239, 68, 68, 0.3);
+  text-decoration: none;
+}
+
+.abyss-diff .diff-hunk-header {
+  background: var(--color-border);
+  color: var(--color-text-muted);
+}

--- a/src/index.css
+++ b/src/index.css
@@ -564,3 +564,40 @@
   background: var(--color-border);
   color: var(--color-text-muted);
 }
+
+/* JSON diff viewer on small screens.
+   The library's gutters are sized for a desktop code review: two line-number
+   columns cost 98px of a 373px phone, a quarter of the width, to show numbers
+   nobody reads on a phone. Narrow them and let the code have the space. */
+@media (max-width: 767px) {
+  .abyss-diff .diff-gutter {
+    min-width: 0;
+    width: 1.6rem;
+    padding: 0 0.25rem;
+    font-size: 9px;
+  }
+
+  /* The width actually comes from the table's <col>, which wins over the cell
+     in table layout — narrowing the <td> alone changed nothing. Two 49px
+     columns become two 24px ones, handing ~50px back to the code. */
+  .abyss-diff .diff-gutter-col {
+    width: 1.5rem;
+  }
+
+  .abyss-diff .diff-code {
+    padding-left: 0.4rem;
+    padding-right: 0.4rem;
+  }
+}
+
+/* Full-bleed diff sheet on phones.
+   `.glass-card` is plain CSS rather than a Tailwind utility, so it wins over
+   `rounded-none`/`border-0` on the same element — the sheet kept a 12px radius
+   and a 1px border while covering the whole screen, leaving the page showing
+   through at the corners. */
+@media (max-width: 767px) {
+  .diff-sheet {
+    border-radius: 0;
+    border-width: 0;
+  }
+}

--- a/src/lib/__mocks__/viteEnv.ts
+++ b/src/lib/__mocks__/viteEnv.ts
@@ -5,3 +5,5 @@
  */
 export const RPC_LOG_ENABLED = false;
 export const BUILD_LABEL: string | null = null;
+export const ABYSS_CLIENT_ID = "test-abyss-client-id";
+export const ABYSS_BASE_URL = "";

--- a/src/lib/__tests__/studioUnlock.test.ts
+++ b/src/lib/__tests__/studioUnlock.test.ts
@@ -49,6 +49,20 @@ describe("isStudioUnlockError", () => {
     expect(isStudioUnlockError({ meta: { simpleError: 99 } })).toBe(false);
   });
 
+  it("is true for the Abyss adapter's locked-firmware error", () => {
+    // Matched by shape so a locked device reached through the Abyss adapter
+    // opens the same unlock modal as every other feature.
+    expect(isStudioUnlockError({ name: "FirmwareLockedError" })).toBe(true);
+    expect(isStudioUnlockError({ code: "LOCKED" })).toBe(true);
+  });
+
+  it("is false for an unrelated error that merely mentions being locked", () => {
+    // The adapter's own isFirmwareLockedError matches any message containing
+    // "locked"; that looseness must not leak in here, or unrelated failures get
+    // routed into the unlock modal and retried forever.
+    expect(isStudioUnlockError(new Error("the file is locked"))).toBe(false);
+  });
+
   it("is false for unrelated errors, null, and plain values", () => {
     expect(isStudioUnlockError(new Error("boom"))).toBe(false);
     expect(isStudioUnlockError(null)).toBe(false);

--- a/src/lib/abyss/__tests__/abyssConfig.test.ts
+++ b/src/lib/abyss/__tests__/abyssConfig.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Tests for how the configured Abyss instance is resolved.
+ *
+ * Dev and PR builds point at a staging deployment, so anything that links to
+ * Abyss or names it in copy must follow this rather than the production host —
+ * otherwise a dev build tells the user it is uploading somewhere it is not.
+ */
+
+const DEV_INSTANCE = "https://keyboard-abyss.cormoran707.workers.dev";
+
+/** Reloads abyssConfig with a specific VITE_ABYSS_BASE_URL. */
+async function loadConfig(baseUrl: string) {
+  jest.resetModules();
+  jest.doMock("../../viteEnv", () => ({
+    RPC_LOG_ENABLED: false,
+    BUILD_LABEL: null,
+    ABYSS_CLIENT_ID: "test-client",
+    ABYSS_BASE_URL: baseUrl,
+  }));
+  return import("../abyssConfig");
+}
+
+afterEach(() => {
+  jest.dontMock("../../viteEnv");
+  jest.resetModules();
+});
+
+describe("abyssBaseUrl", () => {
+  it("falls back to production when unset", async () => {
+    const { abyssBaseUrl } = await loadConfig("");
+    expect(abyssBaseUrl()).toBe("https://abyss.keyboard-hub.com");
+  });
+
+  it("uses the configured instance for dev and PR builds", async () => {
+    const { abyssBaseUrl } = await loadConfig(DEV_INSTANCE);
+    expect(abyssBaseUrl()).toBe(DEV_INSTANCE);
+  });
+});
+
+describe("abyssHost", () => {
+  it("shows the production host by default", async () => {
+    const { abyssHost } = await loadConfig("");
+    expect(abyssHost()).toBe("abyss.keyboard-hub.com");
+  });
+
+  it("shows the configured host so dev copy is not misleading", async () => {
+    const { abyssHost } = await loadConfig(DEV_INSTANCE);
+    expect(abyssHost()).toBe("keyboard-abyss.cormoran707.workers.dev");
+  });
+
+  it("falls back rather than throwing on an unparseable value", async () => {
+    const { abyssHost } = await loadConfig("not a url");
+    expect(abyssHost()).toBe("abyss.keyboard-hub.com");
+  });
+});
+
+describe("isAbyssConfigured", () => {
+  it("is false without a client id, which hides the tab entirely", async () => {
+    jest.resetModules();
+    jest.doMock("../../viteEnv", () => ({
+      RPC_LOG_ENABLED: false,
+      BUILD_LABEL: null,
+      ABYSS_CLIENT_ID: "",
+      ABYSS_BASE_URL: "",
+    }));
+    const { isAbyssConfigured } = await import("../abyssConfig");
+    expect(isAbyssConfigured()).toBe(false);
+  });
+});

--- a/src/lib/abyss/__tests__/abyssDiff.test.ts
+++ b/src/lib/abyss/__tests__/abyssDiff.test.ts
@@ -1,0 +1,169 @@
+/**
+ * Tests for the diff shaping helpers that drive the import UI.
+ */
+import {
+  EMPTY_DIFF,
+  bindingLabel,
+  countDiff,
+  filterDiff,
+  globalModuleChanges,
+  groupByLayer,
+  isEmptyDiff,
+  maxLayerIndex,
+  type KeymapDiff,
+} from "../abyssDiff";
+
+const diff: KeymapDiff = {
+  bindingChanges: [
+    { layerIndex: 0, layerName: "Base", keyIndex: 3, to: { type: "trans" } },
+    { layerIndex: 2, layerName: "Nav", keyIndex: 1, to: { type: "none" } },
+  ],
+  layerNameChanges: [{ layerIndex: 2, from: "Nav", to: "Navigation" }],
+  comboChanges: [{ index: 0, label: "Combo 1" }],
+  macroChanges: [],
+  moduleChanges: [
+    { scope: "global", moduleName: "trackball" },
+    { scope: "layer", layerIndex: 2, moduleName: "encoder" },
+  ],
+};
+
+describe("filterDiff", () => {
+  it("keeps layer names with bindings, since one RPC path writes both", () => {
+    const result = filterDiff(diff, {
+      keymap: true,
+      combos: false,
+      macros: false,
+      modules: false,
+    });
+
+    expect(result.bindingChanges).toHaveLength(2);
+    expect(result.layerNameChanges).toHaveLength(1);
+    expect(result.comboChanges).toHaveLength(0);
+    expect(result.moduleChanges).toHaveLength(0);
+  });
+
+  it("drops bindings and layer names together", () => {
+    const result = filterDiff(diff, {
+      keymap: false,
+      combos: true,
+      macros: true,
+      modules: true,
+    });
+
+    expect(result.bindingChanges).toHaveLength(0);
+    expect(result.layerNameChanges).toHaveLength(0);
+    expect(result.comboChanges).toHaveLength(1);
+    expect(result.moduleChanges).toHaveLength(2);
+  });
+});
+
+describe("isEmptyDiff", () => {
+  it("is true only when nothing is left to write", () => {
+    expect(isEmptyDiff(EMPTY_DIFF)).toBe(true);
+    expect(isEmptyDiff(diff)).toBe(false);
+    // A selection that removes every change must read as "in sync", or the
+    // write button stays enabled with nothing to do.
+    expect(
+      isEmptyDiff(
+        filterDiff(diff, {
+          keymap: false,
+          combos: false,
+          macros: false,
+          modules: false,
+        }),
+      ),
+    ).toBe(true);
+  });
+});
+
+describe("maxLayerIndex", () => {
+  it("spans bindings, layer names and layer-scoped modules", () => {
+    expect(maxLayerIndex(diff)).toBe(2);
+  });
+
+  it("is -1 when no layer is touched", () => {
+    expect(
+      maxLayerIndex({
+        ...EMPTY_DIFF,
+        comboChanges: [{ index: 0, label: "c" }],
+      }),
+    ).toBe(-1);
+  });
+
+  it("ignores global module changes, which have no layer", () => {
+    expect(
+      maxLayerIndex({
+        ...EMPTY_DIFF,
+        moduleChanges: [{ scope: "global", moduleName: "trackball" }],
+      }),
+    ).toBe(-1);
+  });
+});
+
+describe("countDiff", () => {
+  it("totals every category", () => {
+    expect(countDiff(diff)).toEqual({
+      bindings: 2,
+      layerNames: 1,
+      combos: 1,
+      macros: 0,
+      modules: 2,
+      total: 6,
+    });
+  });
+});
+
+describe("groupByLayer", () => {
+  it("groups changes by layer in layer order", () => {
+    const groups = groupByLayer(diff);
+
+    expect(groups.map((group) => group.layerIndex)).toEqual([0, 2]);
+    expect(groups[0].bindingChanges).toHaveLength(1);
+    expect(groups[1].nameChange?.to).toBe("Navigation");
+    expect(groups[1].moduleChanges).toHaveLength(1);
+  });
+
+  it("keeps global module changes out of the layer groups", () => {
+    expect(groupByLayer(diff).flatMap((g) => g.moduleChanges)).toHaveLength(1);
+    expect(globalModuleChanges(diff)).toHaveLength(1);
+  });
+
+  it("names a layer known only from its rename", () => {
+    const groups = groupByLayer({
+      ...EMPTY_DIFF,
+      layerNameChanges: [{ layerIndex: 1, to: "Symbols" }],
+    });
+    expect(groups[0].layerName).toBe("Symbols");
+  });
+});
+
+describe("bindingLabel", () => {
+  it("renders an empty side as a dash", () => {
+    expect(bindingLabel(undefined)).toBe("—");
+    expect(bindingLabel(null)).toBe("—");
+  });
+
+  it("renders the common binding types", () => {
+    expect(bindingLabel({ type: "key", usage: 0x04 })).toBe("0x4");
+    expect(bindingLabel({ type: "key", usage: 0x04, mods: ["LSHIFT"] })).toBe(
+      "LSHIFT+0x4",
+    );
+    expect(bindingLabel({ type: "mo", layer: 2 })).toBe("MO(2)");
+    expect(bindingLabel({ type: "lt", layer: 1, usage: 0x2c })).toBe(
+      "LT(1, 0x2c)",
+    );
+    expect(bindingLabel({ type: "trans" })).toBe("▽");
+    expect(bindingLabel({ type: "none" })).toBe("✕");
+    expect(bindingLabel({ type: "raw", zmk: "&custom X" })).toBe("&custom X");
+  });
+
+  it("falls back to the type name rather than guessing", () => {
+    // An unrecognised binding still shows something truthful instead of a
+    // misleading label or a blank cell.
+    expect(bindingLabel({ type: "caps_word" })).toBe("caps_word");
+    expect(bindingLabel({ type: "some_future_thing" })).toBe(
+      "some_future_thing",
+    );
+    expect(bindingLabel({})).toBe("—");
+  });
+});

--- a/src/lib/abyss/__tests__/abyssErrors.test.ts
+++ b/src/lib/abyss/__tests__/abyssErrors.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Tests for the Abyss error classification.
+ */
+import { AbyssApiError, AbyssOAuthError } from "@keyboard-hub/abyss-client";
+import {
+  abyssErrorMessageKey,
+  classifyAbyssError,
+  isAbyssUnauthorized,
+} from "../abyssErrors";
+
+describe("classifyAbyssError", () => {
+  it.each([
+    [401, "unauthorized"],
+    [403, "forbidden"],
+    [404, "not_found"],
+    [409, "conflict"],
+    [422, "conflict"],
+    [429, "rate_limited"],
+    [500, "server"],
+    [503, "server"],
+    [418, "error"],
+  ])("maps HTTP %i to %s", (status, expected) => {
+    expect(classifyAbyssError(new AbyssApiError(status))).toBe(expected);
+  });
+
+  it("treats a user-declined consent as cancelled", () => {
+    expect(
+      classifyAbyssError(new AbyssOAuthError("denied", "access_denied")),
+    ).toBe("cancelled");
+  });
+
+  it("treats a broken OAuth flow as its own bucket, not as cancelled", () => {
+    // State mismatch / expired transaction is not the user backing out; saying
+    // "cancelled" would send them looking for a mistake they did not make.
+    expect(
+      classifyAbyssError(new AbyssOAuthError("OAuth state mismatch")),
+    ).toBe("oauth");
+  });
+
+  it("recognises the adapter's locked-keyboard error by duck typing", () => {
+    expect(classifyAbyssError({ name: "FirmwareLockedError" })).toBe("locked");
+    expect(classifyAbyssError({ code: "LOCKED" })).toBe("locked");
+  });
+
+  it("maps a failed fetch to a network error", () => {
+    expect(classifyAbyssError(new TypeError("Failed to fetch"))).toBe(
+      "network",
+    );
+  });
+
+  it("falls back to a generic bucket", () => {
+    expect(classifyAbyssError(new Error("boom"))).toBe("error");
+    expect(classifyAbyssError(undefined)).toBe("error");
+  });
+});
+
+describe("isAbyssUnauthorized", () => {
+  it("is true only for a 401", () => {
+    expect(isAbyssUnauthorized(new AbyssApiError(401))).toBe(true);
+    expect(isAbyssUnauthorized(new AbyssApiError(403))).toBe(false);
+    expect(isAbyssUnauthorized(new Error("401"))).toBe(false);
+  });
+});
+
+describe("abyssErrorMessageKey", () => {
+  it("never leaks the server's own message", () => {
+    const error = new AbyssApiError(409);
+    error.message = "keymap 01JABC does not match layout 01JXYZ";
+    expect(abyssErrorMessageKey(error)).not.toContain("01JABC");
+  });
+
+  it("returns a distinct message per bucket", () => {
+    const keys = [401, 403, 404, 429, 500].map((status) =>
+      abyssErrorMessageKey(new AbyssApiError(status)),
+    );
+    expect(new Set(keys).size).toBe(keys.length);
+  });
+});

--- a/src/lib/abyss/__tests__/abyssExportPayload.test.ts
+++ b/src/lib/abyss/__tests__/abyssExportPayload.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Tests for the export payload builder.
+ *
+ * The behaviour that matters is what an *update* does to data the user did not
+ * select: it must be left alone, and the Abyss keymap's own name must survive.
+ */
+import {
+  ALL_SECTIONS,
+  buildExportData,
+  buildNewExportData,
+  selectedSectionIds,
+  type KeymapDocument,
+} from "../abyssExportPayload";
+
+const device: KeymapDocument = {
+  keyboard: "dya2",
+  name: "DYA Keyboard (Demo)",
+  description: "read from the device",
+  layers: [
+    { name: "Base", bindings: ["d0"], modules: ["dm0"] },
+    { name: "Nav", bindings: ["d1"], modules: [] },
+  ],
+  modules: ["device-module"],
+  combos: ["device-combo"],
+  macros: ["device-macro"],
+};
+
+const existing: KeymapDocument = {
+  keyboard: "dya2",
+  name: "My saved keymap",
+  description: "kept on Abyss",
+  layers: [{ name: "Old", bindings: ["a0"], modules: ["am0"] }],
+  modules: ["abyss-module"],
+  combos: ["abyss-combo"],
+  macros: ["abyss-macro"],
+};
+
+describe("buildExportData", () => {
+  it("never renames the Abyss keymap it is updating", () => {
+    // applyKeyboardHubKeymapSelection upstream overwrites these from the device
+    // side, which would rename the user's keymap to the device name on every
+    // save. This is the reason the merge lives here.
+    const result = buildExportData(device, existing, ALL_SECTIONS);
+
+    expect(result.name).toBe("My saved keymap");
+    expect(result.description).toBe("kept on Abyss");
+  });
+
+  it("takes every selected section from the device", () => {
+    const result = buildExportData(device, existing, ALL_SECTIONS);
+
+    expect(result.layers.map((layer) => layer.name)).toEqual(["Base", "Nav"]);
+    expect(result.layers[0].bindings).toEqual(["d0"]);
+    expect(result.combos).toEqual(["device-combo"]);
+    expect(result.macros).toEqual(["device-macro"]);
+    expect(result.modules).toEqual(["device-module"]);
+  });
+
+  it("leaves deselected sections exactly as Abyss had them", () => {
+    const result = buildExportData(device, existing, {
+      keymap: true,
+      combos: false,
+      macros: false,
+      modules: false,
+    });
+
+    expect(result.combos).toEqual(["abyss-combo"]);
+    expect(result.macros).toEqual(["abyss-macro"]);
+    expect(result.modules).toEqual(["abyss-module"]);
+    // Per-layer modules follow the modules selection, not the keymap one.
+    expect(result.layers[0].modules).toEqual(["am0"]);
+  });
+
+  it("does not add device layers when keymap data was not selected", () => {
+    const result = buildExportData(device, existing, {
+      keymap: false,
+      combos: true,
+      macros: true,
+      modules: true,
+    });
+
+    expect(result.layers).toHaveLength(1);
+    expect(result.layers[0].name).toBe("Old");
+    expect(result.layers[0].bindings).toEqual(["a0"]);
+  });
+});
+
+describe("buildNewExportData", () => {
+  it("uses the supplied name and keeps the device's keymap data", () => {
+    const result = buildNewExportData(device, ALL_SECTIONS, "Exported 2026");
+
+    expect(result.name).toBe("Exported 2026");
+    expect(result.layers).toHaveLength(2);
+    expect(result.combos).toEqual(["device-combo"]);
+  });
+
+  it("omits deselected collections instead of sending them empty", () => {
+    // "this export did not cover combos" is different from "this keymap has no
+    // combos", and only the first is true here.
+    const result = buildNewExportData(
+      device,
+      { keymap: true, combos: false, macros: false, modules: false },
+      "Keymap only",
+    );
+
+    expect(result).not.toHaveProperty("combos");
+    expect(result).not.toHaveProperty("macros");
+    expect(result).not.toHaveProperty("modules");
+    expect(result.layers).toHaveLength(2);
+  });
+
+  it("keeps keymap data even if the caller deselects it", () => {
+    const result = buildNewExportData(
+      device,
+      { keymap: false, combos: true, macros: true, modules: true },
+      "Still has layers",
+    );
+
+    expect(result.layers).toHaveLength(2);
+  });
+});
+
+describe("selectedSectionIds", () => {
+  it("is stable and sorted so analytics values group", () => {
+    expect(selectedSectionIds(ALL_SECTIONS)).toBe(
+      "keymap,combos,macros,modules",
+    );
+    expect(
+      selectedSectionIds({
+        keymap: true,
+        combos: false,
+        macros: true,
+        modules: false,
+      }),
+    ).toBe("keymap,macros");
+  });
+});

--- a/src/lib/abyss/__tests__/abyssKeymapList.test.ts
+++ b/src/lib/abyss/__tests__/abyssKeymapList.test.ts
@@ -9,65 +9,90 @@
 import type { AbyssClient } from "@keyboard-hub/abyss-client";
 import { listCandidateKeymaps } from "../abyssKeymapList";
 
-function fakeClient(...pages: unknown[][]) {
+/**
+ * Each argument is one *query* (the filtered attempt, then the widened retry),
+ * given as the pages that query returns.
+ */
+function fakeClient(...queries: unknown[][][]) {
   const listMyKeymaps = jest.fn();
-  for (const items of pages.length ? pages : [[]]) {
-    listMyKeymaps.mockResolvedValueOnce({ items });
+  for (const pages of queries.length ? queries : [[[]]]) {
+    pages.forEach((items, index) => {
+      listMyKeymaps.mockResolvedValueOnce({
+        items,
+        pageCount: pages.length,
+        page: index + 1,
+      });
+    });
   }
-  listMyKeymaps.mockResolvedValue({ items: [] });
+  listMyKeymaps.mockResolvedValue({ items: [], pageCount: 1, page: 1 });
   return {
     client: { listMyKeymaps } as unknown as AbyssClient,
     listMyKeymaps,
   };
 }
 
+/** One query returning a single page. */
+const onePage = (items: unknown[]) => [items];
+
 describe("listCandidateKeymaps", () => {
   it("never filters by keyboard slug", async () => {
     // The device reports "DYA Keyboard", which the adapter turns into
     // "dya-keyboard", while the catalog knows the same board as "dya2".
-    const { client, listMyKeymaps } = fakeClient();
+    const { client, listMyKeymaps } = fakeClient(onePage([]));
 
-    await listCandidateKeymaps(client, {
-      layoutId: "layout-1",
-      layoutVariationId: "variation-1",
-    });
+    await listCandidateKeymaps(client, { layoutId: "layout-1" });
 
     const [query] = listMyKeymaps.mock.calls[0];
     expect(query).not.toHaveProperty("keyboard");
   });
 
-  it("filters by the resolved layout, which is a catalog identity", async () => {
-    const { client, listMyKeymaps } = fakeClient();
+  it("filters by layout but never by variation", async () => {
+    // A keymap saved against another variation of the same layout is still a
+    // valid update target; narrowing to the variation hid those entirely.
+    const { client, listMyKeymaps } = fakeClient(onePage([]));
 
-    await listCandidateKeymaps(client, {
-      layoutId: "layout-1",
-      layoutVariationId: "variation-1",
-    });
+    await listCandidateKeymaps(client, { layoutId: "layout-1" });
 
-    expect(listMyKeymaps).toHaveBeenCalledWith(
-      expect.objectContaining({
-        visibility: "all",
-        layoutId: "layout-1",
-        layoutVariationId: "variation-1",
-      }),
-    );
+    const [query] = listMyKeymaps.mock.calls[0];
+    expect(query).toMatchObject({ visibility: "all", layoutId: "layout-1" });
+    expect(query).not.toHaveProperty("layoutVariationId");
   });
 
   it("omits layout filters entirely when the layout was not resolved", async () => {
     // Sending undefined would still be a filter key; showing the user's whole
     // list beats showing them nothing, and pre-flight catches a bad choice.
-    const { client, listMyKeymaps } = fakeClient();
+    const { client, listMyKeymaps } = fakeClient(onePage([]));
 
     await listCandidateKeymaps(client, {});
 
     const [query] = listMyKeymaps.mock.calls[0];
     expect(query).not.toHaveProperty("layoutId");
-    expect(query).not.toHaveProperty("layoutVariationId");
     expect(query.visibility).toBe("all");
   });
 
+  it("never asks for more than the API's limit of 20", async () => {
+    // GET /me/keymaps rejects limit > 20 with a 400 rather than clamping, so
+    // asking for 50 failed every request and looked like an empty account.
+    const { client, listMyKeymaps } = fakeClient(onePage([{ id: "k1" }]));
+
+    await listCandidateKeymaps(client, {});
+
+    expect(listMyKeymaps.mock.calls[0][0].limit).toBe(20);
+  });
+
+  it("pages through results beyond the first 20", async () => {
+    const first = Array.from({ length: 20 }, (_, i) => ({ id: `k${i}` }));
+    const { client, listMyKeymaps } = fakeClient([first, [{ id: "k20" }]]);
+
+    const result = await listCandidateKeymaps(client, {});
+
+    expect(listMyKeymaps).toHaveBeenCalledTimes(2);
+    expect(listMyKeymaps.mock.calls[1][0].page).toBe(2);
+    expect(result.items).toHaveLength(21);
+  });
+
   it("returns the page items", async () => {
-    const { client } = fakeClient([{ id: "k1" }, { id: "k2" }]);
+    const { client } = fakeClient(onePage([{ id: "k1" }, { id: "k2" }]));
     const result = await listCandidateKeymaps(client, {});
 
     expect(result.items).toHaveLength(2);
@@ -78,12 +103,12 @@ describe("listCandidateKeymaps", () => {
     // resolveLayout matches on the geometry the firmware reports, so a keymap
     // saved against a slightly different variation of the same layout falls
     // outside the filter — which looked exactly like having no keymaps at all.
-    const { client, listMyKeymaps } = fakeClient([], [{ id: "k1" }]);
+    const { client, listMyKeymaps } = fakeClient(
+      onePage([]),
+      onePage([{ id: "k1" }]),
+    );
 
-    const result = await listCandidateKeymaps(client, {
-      layoutId: "layout-1",
-      layoutVariationId: "variation-1",
-    });
+    const result = await listCandidateKeymaps(client, { layoutId: "layout-1" });
 
     expect(listMyKeymaps).toHaveBeenCalledTimes(2);
     expect(listMyKeymaps.mock.calls[1][0]).not.toHaveProperty("layoutId");
@@ -92,7 +117,7 @@ describe("listCandidateKeymaps", () => {
   });
 
   it("does not retry when the filtered query already found something", async () => {
-    const { client, listMyKeymaps } = fakeClient([{ id: "k1" }]);
+    const { client, listMyKeymaps } = fakeClient(onePage([{ id: "k1" }]));
 
     await listCandidateKeymaps(client, { layoutId: "layout-1" });
 
@@ -100,7 +125,7 @@ describe("listCandidateKeymaps", () => {
   });
 
   it("does not retry when there was no filter to widen", async () => {
-    const { client, listMyKeymaps } = fakeClient([]);
+    const { client, listMyKeymaps } = fakeClient(onePage([]));
 
     const result = await listCandidateKeymaps(client, {});
 

--- a/src/lib/abyss/__tests__/abyssKeymapList.test.ts
+++ b/src/lib/abyss/__tests__/abyssKeymapList.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Tests for how candidate keymaps are queried.
+ *
+ * These pin a regression that made both dropdowns permanently empty: the
+ * keyboard slug on the device snapshot is derived by the adapter from the ZMK
+ * device name, not from the Abyss catalog, so filtering on it excluded
+ * everything.
+ */
+import type { AbyssClient } from "@keyboard-hub/abyss-client";
+import { listCandidateKeymaps } from "../abyssKeymapList";
+
+function fakeClient(items: unknown[] = []) {
+  const listMyKeymaps = jest.fn().mockResolvedValue({ items });
+  return {
+    client: { listMyKeymaps } as unknown as AbyssClient,
+    listMyKeymaps,
+  };
+}
+
+describe("listCandidateKeymaps", () => {
+  it("never filters by keyboard slug", async () => {
+    // The device reports "DYA Keyboard", which the adapter turns into
+    // "dya-keyboard", while the catalog knows the same board as "dya2".
+    const { client, listMyKeymaps } = fakeClient();
+
+    await listCandidateKeymaps(client, {
+      layoutId: "layout-1",
+      layoutVariationId: "variation-1",
+    });
+
+    const [query] = listMyKeymaps.mock.calls[0];
+    expect(query).not.toHaveProperty("keyboard");
+  });
+
+  it("filters by the resolved layout, which is a catalog identity", async () => {
+    const { client, listMyKeymaps } = fakeClient();
+
+    await listCandidateKeymaps(client, {
+      layoutId: "layout-1",
+      layoutVariationId: "variation-1",
+    });
+
+    expect(listMyKeymaps).toHaveBeenCalledWith(
+      expect.objectContaining({
+        visibility: "all",
+        layoutId: "layout-1",
+        layoutVariationId: "variation-1",
+      }),
+    );
+  });
+
+  it("omits layout filters entirely when the layout was not resolved", async () => {
+    // Sending undefined would still be a filter key; showing the user's whole
+    // list beats showing them nothing, and pre-flight catches a bad choice.
+    const { client, listMyKeymaps } = fakeClient();
+
+    await listCandidateKeymaps(client, {});
+
+    const [query] = listMyKeymaps.mock.calls[0];
+    expect(query).not.toHaveProperty("layoutId");
+    expect(query).not.toHaveProperty("layoutVariationId");
+    expect(query.visibility).toBe("all");
+  });
+
+  it("returns the page items", async () => {
+    const { client } = fakeClient([{ id: "k1" }, { id: "k2" }]);
+    await expect(listCandidateKeymaps(client, {})).resolves.toHaveLength(2);
+  });
+});

--- a/src/lib/abyss/__tests__/abyssKeymapList.test.ts
+++ b/src/lib/abyss/__tests__/abyssKeymapList.test.ts
@@ -9,8 +9,12 @@
 import type { AbyssClient } from "@keyboard-hub/abyss-client";
 import { listCandidateKeymaps } from "../abyssKeymapList";
 
-function fakeClient(items: unknown[] = []) {
-  const listMyKeymaps = jest.fn().mockResolvedValue({ items });
+function fakeClient(...pages: unknown[][]) {
+  const listMyKeymaps = jest.fn();
+  for (const items of pages.length ? pages : [[]]) {
+    listMyKeymaps.mockResolvedValueOnce({ items });
+  }
+  listMyKeymaps.mockResolvedValue({ items: [] });
   return {
     client: { listMyKeymaps } as unknown as AbyssClient,
     listMyKeymaps,
@@ -64,6 +68,43 @@ describe("listCandidateKeymaps", () => {
 
   it("returns the page items", async () => {
     const { client } = fakeClient([{ id: "k1" }, { id: "k2" }]);
-    await expect(listCandidateKeymaps(client, {})).resolves.toHaveLength(2);
+    const result = await listCandidateKeymaps(client, {});
+
+    expect(result.items).toHaveLength(2);
+    expect(result.widened).toBe(false);
+  });
+
+  it("widens the search when the layout filter matches nothing", async () => {
+    // resolveLayout matches on the geometry the firmware reports, so a keymap
+    // saved against a slightly different variation of the same layout falls
+    // outside the filter — which looked exactly like having no keymaps at all.
+    const { client, listMyKeymaps } = fakeClient([], [{ id: "k1" }]);
+
+    const result = await listCandidateKeymaps(client, {
+      layoutId: "layout-1",
+      layoutVariationId: "variation-1",
+    });
+
+    expect(listMyKeymaps).toHaveBeenCalledTimes(2);
+    expect(listMyKeymaps.mock.calls[1][0]).not.toHaveProperty("layoutId");
+    expect(result.items).toHaveLength(1);
+    expect(result.widened).toBe(true);
+  });
+
+  it("does not retry when the filtered query already found something", async () => {
+    const { client, listMyKeymaps } = fakeClient([{ id: "k1" }]);
+
+    await listCandidateKeymaps(client, { layoutId: "layout-1" });
+
+    expect(listMyKeymaps).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not retry when there was no filter to widen", async () => {
+    const { client, listMyKeymaps } = fakeClient([]);
+
+    const result = await listCandidateKeymaps(client, {});
+
+    expect(listMyKeymaps).toHaveBeenCalledTimes(1);
+    expect(result.widened).toBe(false);
   });
 });

--- a/src/lib/abyss/__tests__/abyssNotifications.test.ts
+++ b/src/lib/abyss/__tests__/abyssNotifications.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Tests for the notification fan-out handed to the Abyss adapter.
+ *
+ * This bridge is the difference between the adapter seeing runtime input
+ * processors and silently reporting none, so the shape it produces has to match
+ * what the adapter unwraps.
+ */
+import type { CustomNotification } from "@zmkfirmware/zmk-studio-ts-client/custom";
+import { createAbyssNotificationSource } from "../abyssNotifications";
+
+function customNotification(subsystemIndex: number): CustomNotification {
+  return { subsystemIndex, payload: new Uint8Array([1]) } as CustomNotification;
+}
+
+describe("createAbyssNotificationSource", () => {
+  it("subscribes to every advertised subsystem", () => {
+    const onNotification = jest.fn(() => () => {});
+
+    createAbyssNotificationSource({
+      subsystemIndexes: [0, 2, 5],
+      onNotification,
+    }).subscribe(() => {});
+
+    expect(onNotification).toHaveBeenCalledTimes(3);
+    expect(onNotification.mock.calls.map(([s]) => s.subsystemIndex)).toEqual([
+      0, 2, 5,
+    ]);
+  });
+
+  it("rewraps custom notifications into the Studio envelope", () => {
+    // The app subscribes per subsystem and receives the inner payload, but the
+    // adapter reads `notification.custom.customNotification` and filters by
+    // index itself.
+    let deliver: ((notification: CustomNotification) => void) | undefined;
+    const source = createAbyssNotificationSource({
+      subsystemIndexes: [3],
+      onNotification: ({ callback }) => {
+        deliver = callback;
+        return () => {};
+      },
+    });
+
+    const received: unknown[] = [];
+    source.subscribe((notification) => received.push(notification));
+    deliver?.(customNotification(3));
+
+    expect(received).toEqual([
+      { custom: { customNotification: customNotification(3) } },
+    ]);
+  });
+
+  it("unsubscribes from every subsystem", () => {
+    const unsubscribes = [jest.fn(), jest.fn()];
+    let call = 0;
+    const source = createAbyssNotificationSource({
+      subsystemIndexes: [0, 1],
+      onNotification: () => unsubscribes[call++],
+    });
+
+    source.subscribe(() => {})();
+
+    expect(unsubscribes[0]).toHaveBeenCalledTimes(1);
+    expect(unsubscribes[1]).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/lib/abyss/__tests__/abyssOAuth.test.ts
+++ b/src/lib/abyss/__tests__/abyssOAuth.test.ts
@@ -1,0 +1,167 @@
+/**
+ * Tests for the OAuth popup/redirect plumbing.
+ *
+ * The interesting behaviour is entirely about *which* document exchanges the
+ * authorization code, so the tests drive both halves of the handshake against
+ * a real `BroadcastChannel`.
+ */
+import type { AbyssClient } from "@keyboard-hub/abyss-client";
+import {
+  IMPORT_EXPORT_PATH,
+  OAUTH_CALLBACK_PATH,
+  relayAbyssCallback,
+  saveReturnPath,
+  startAbyssLogin,
+  takeReturnPath,
+} from "../abyssOAuth";
+
+jest.mock("../../navigate");
+import { navigateTo } from "../../navigate";
+const mockNavigateTo = navigateTo as jest.MockedFunction<typeof navigateTo>;
+
+const AUTHORIZE_URL = "https://abyss.keyboard-hub.com/oauth/authorize?x=1";
+
+function callbackHref(state: string): string {
+  return `http://localhost${OAUTH_CALLBACK_PATH}?code=abc&state=${state}`;
+}
+
+/** Minimal client stand-in: only the two methods the login flow calls. */
+function createFakeClient(): {
+  client: AbyssClient;
+  buildAuthorizationUrl: jest.Mock;
+  handleRedirectCallback: jest.Mock;
+  lastState: () => string;
+} {
+  let lastState = "";
+  const buildAuthorizationUrl = jest.fn(
+    async (options?: { state?: string }) => {
+      lastState = options?.state ?? "";
+      return AUTHORIZE_URL;
+    },
+  );
+  const handleRedirectCallback = jest.fn(async () => ({}));
+  return {
+    client: {
+      buildAuthorizationUrl,
+      handleRedirectCallback,
+    } as unknown as AbyssClient,
+    buildAuthorizationUrl,
+    handleRedirectCallback,
+    lastState: () => lastState,
+  };
+}
+
+/** A popup handle the test can "close" on demand. */
+function createFakePopup() {
+  return { closed: false, close: jest.fn() } as unknown as Window & {
+    closed: boolean;
+    close: jest.Mock;
+  };
+}
+
+describe("abyssOAuth", () => {
+  let openSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    sessionStorage.clear();
+    mockNavigateTo.mockReset();
+    openSpy = jest.spyOn(window, "open");
+  });
+
+  afterEach(() => {
+    openSpy.mockRestore();
+    jest.useRealTimers();
+  });
+
+  describe("return path", () => {
+    it("round-trips a saved path and clears it", () => {
+      saveReturnPath("/import-export");
+      expect(takeReturnPath()).toBe("/import-export");
+      // Consumed, so a later read falls back to the default.
+      expect(takeReturnPath()).toBe(IMPORT_EXPORT_PATH);
+    });
+
+    it("defaults to the Import/Export tab when nothing was saved", () => {
+      expect(takeReturnPath()).toBe(IMPORT_EXPORT_PATH);
+    });
+  });
+
+  describe("startAbyssLogin", () => {
+    it("exchanges the code in the opener when the popup reports back", async () => {
+      const popup = createFakePopup();
+      openSpy.mockReturnValue(popup);
+      const { client, handleRedirectCallback, lastState } = createFakeClient();
+
+      const login = startAbyssLogin(client, "/import-export");
+      // Let buildAuthorizationUrl resolve so the state exists.
+      await Promise.resolve();
+      await Promise.resolve();
+
+      const relayed = relayAbyssCallback(callbackHref(lastState()));
+
+      await expect(login).resolves.toEqual({ status: "authorized" });
+      // The callback page must learn that the opener claimed it, so that it
+      // closes instead of burning the single-use code a second time.
+      await expect(relayed).resolves.toBe(true);
+      expect(handleRedirectCallback).toHaveBeenCalledWith(
+        callbackHref(lastState()),
+      );
+      expect(popup.close).toHaveBeenCalled();
+    });
+
+    it("ignores a callback carrying a different state", async () => {
+      const popup = createFakePopup();
+      openSpy.mockReturnValue(popup);
+      const { client, handleRedirectCallback } = createFakeClient();
+
+      const login = startAbyssLogin(client, "/import-export");
+      await Promise.resolve();
+      await Promise.resolve();
+
+      // Another tab's login finishing must not be claimed by this one: only
+      // the initiating tab holds the matching PKCE verifier.
+      await expect(
+        relayAbyssCallback(callbackHref("someone-else")),
+      ).resolves.toBe(false);
+      expect(handleRedirectCallback).not.toHaveBeenCalled();
+
+      popup.closed = true;
+      await expect(login).resolves.toEqual({ status: "cancelled" });
+    });
+
+    it("reports cancelled when the user closes the popup", async () => {
+      const popup = createFakePopup();
+      openSpy.mockReturnValue(popup);
+      const { client, handleRedirectCallback } = createFakeClient();
+
+      const login = startAbyssLogin(client, "/import-export");
+      await Promise.resolve();
+      await Promise.resolve();
+      popup.closed = true;
+
+      await expect(login).resolves.toEqual({ status: "cancelled" });
+      expect(handleRedirectCallback).not.toHaveBeenCalled();
+    });
+
+    it("falls back to a full-page redirect when the popup is blocked", async () => {
+      openSpy.mockReturnValue(null);
+      const { client, handleRedirectCallback } = createFakeClient();
+
+      await expect(startAbyssLogin(client, "/import-export")).resolves.toEqual({
+        status: "redirecting",
+      });
+      expect(mockNavigateTo).toHaveBeenCalledWith(AUTHORIZE_URL);
+      // The redirect leaves this document; nothing is exchanged here.
+      expect(handleRedirectCallback).not.toHaveBeenCalled();
+      expect(takeReturnPath()).toBe("/import-export");
+    });
+  });
+
+  describe("relayAbyssCallback", () => {
+    it("reports unclaimed when no tab answers", async () => {
+      await expect(relayAbyssCallback(callbackHref("orphan"))).resolves.toBe(
+        false,
+      );
+    });
+  });
+});

--- a/src/lib/abyss/__tests__/abyssPreflight.test.ts
+++ b/src/lib/abyss/__tests__/abyssPreflight.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Tests for the checks that gate writing an Abyss keymap to the keyboard.
+ */
+import { EMPTY_DIFF, type KeymapDiff } from "../abyssDiff";
+import { isBlocked, layoutNamesMatch, runPreflight } from "../abyssPreflight";
+
+const baseInput = {
+  diff: EMPTY_DIFF,
+  deviceKeyCount: 87,
+  targetKeyCount: 87,
+  deviceLayerCount: 3,
+};
+
+function idsOf(checks: ReturnType<typeof runPreflight>) {
+  return checks.map((check) => check.id);
+}
+
+describe("runPreflight", () => {
+  it("passes cleanly when the keymap matches the keyboard", () => {
+    const checks = runPreflight(baseInput);
+    expect(checks).toHaveLength(0);
+    expect(isBlocked(checks)).toBe(false);
+  });
+
+  it("blocks a keymap with more keys than the keyboard has", () => {
+    // Positions are indices into the layout, so a too-wide keymap would map
+    // bindings onto the wrong physical keys rather than fail loudly.
+    const checks = runPreflight({ ...baseInput, targetKeyCount: 104 });
+
+    expect(idsOf(checks)).toContain("key-count");
+    expect(isBlocked(checks)).toBe(true);
+  });
+
+  it("only warns when the keymap covers fewer keys", () => {
+    const checks = runPreflight({ ...baseInput, targetKeyCount: 60 });
+
+    expect(idsOf(checks)).toEqual(["key-count-partial"]);
+    expect(isBlocked(checks)).toBe(false);
+  });
+
+  it("warns when the write needs layers the keyboard does not have yet", () => {
+    const diff: KeymapDiff = {
+      ...EMPTY_DIFF,
+      bindingChanges: [
+        { layerIndex: 4, layerName: "Extra", keyIndex: 0, to: {} },
+      ],
+    };
+    const checks = runPreflight({ ...baseInput, diff });
+
+    expect(idsOf(checks)).toContain("layer-count");
+    // The adapter adds layers itself; firmware may refuse, but that is not
+    // knowable here, so it must not block.
+    expect(isBlocked(checks)).toBe(false);
+  });
+
+  it("warns when the layouts differ", () => {
+    const checks = runPreflight({
+      ...baseInput,
+      deviceLayoutName: "DYA2 ANSI",
+      targetLayoutName: "DYA2 ISO",
+    });
+
+    expect(idsOf(checks)).toContain("layout-name");
+  });
+
+  it("does not warn on cosmetic layout-name differences", () => {
+    // A false mismatch here trains users to ignore the warnings that matter.
+    const checks = runPreflight({
+      ...baseInput,
+      deviceLayoutName: "DYA2 ANSI",
+      targetLayoutName: "dya2_ansi",
+    });
+
+    expect(idsOf(checks)).not.toContain("layout-name");
+  });
+
+  it("says nothing about the layout when either side is unknown", () => {
+    expect(
+      idsOf(runPreflight({ ...baseInput, deviceLayoutName: "DYA2 ANSI" })),
+    ).not.toContain("layout-name");
+    expect(
+      idsOf(runPreflight({ ...baseInput, targetLayoutName: "DYA2 ISO" })),
+    ).not.toContain("layout-name");
+  });
+});
+
+describe("layoutNamesMatch", () => {
+  it.each([
+    ["DYA2 ANSI", "dya2-ansi", true],
+    ["dya2_ansi", "DYA2ANSI", true],
+    ["DYA2 ANSI", "DYA2 ISO", false],
+  ])("%s vs %s -> %s", (left, right, expected) => {
+    expect(layoutNamesMatch(left, right)).toBe(expected);
+  });
+});

--- a/src/lib/abyss/__tests__/jsonDiff.test.ts
+++ b/src/lib/abyss/__tests__/jsonDiff.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Tests for the JSON patch that backs the diff viewer.
+ */
+import {
+  COLLAPSED_CONTEXT_LINES,
+  buildJsonDiff,
+  toDiffJson,
+} from "../jsonDiff";
+
+/** Total rendered lines across every hunk. */
+function lineCount(files: ReturnType<typeof buildJsonDiff>["collapsedFiles"]) {
+  return files.reduce(
+    (total, file) =>
+      total + file.hunks.reduce((sum, hunk) => sum + hunk.changes.length, 0),
+    0,
+  );
+}
+
+const long = (marker: string) =>
+  toDiffJson({
+    keyboard: "dya2",
+    layers: Array.from({ length: 40 }, (_, index) => ({
+      name: index === 20 ? marker : `Layer ${index}`,
+      bindings: [index],
+    })),
+  });
+
+describe("toDiffJson", () => {
+  it("pretty-prints with a trailing newline so the last line diffs cleanly", () => {
+    expect(toDiffJson({ a: 1 })).toBe('{\n  "a": 1\n}\n');
+  });
+
+  it("renders an absent document as empty rather than 'null'", () => {
+    expect(toDiffJson(null)).toBe("");
+    expect(toDiffJson(undefined)).toBe("");
+  });
+});
+
+describe("buildJsonDiff", () => {
+  it("reports no changes for identical documents", () => {
+    const json = toDiffJson({ keyboard: "dya2" });
+    const diff = buildJsonDiff(json, json);
+
+    expect(diff.hasChanges).toBe(false);
+    expect(diff.hasHiddenContext).toBe(false);
+  });
+
+  it("finds changes between different documents", () => {
+    const diff = buildJsonDiff(
+      toDiffJson({ keyboard: "dya2", name: "Before" }),
+      toDiffJson({ keyboard: "dya2", name: "After" }),
+    );
+
+    expect(diff.hasChanges).toBe(true);
+    expect(diff.collapsedFiles[0].hunks.length).toBeGreaterThan(0);
+  });
+
+  it("shows fewer lines collapsed than expanded for a long document", () => {
+    // This is the whole point of the toggle: a 40-layer keymap with one changed
+    // line should not render 200 unchanged lines by default.
+    const diff = buildJsonDiff(long("Before"), long("After"));
+
+    expect(lineCount(diff.collapsedFiles)).toBeLessThan(
+      lineCount(diff.expandedFiles),
+    );
+    expect(diff.hasHiddenContext).toBe(true);
+  });
+
+  it("keeps context around the change in the collapsed view", () => {
+    const diff = buildJsonDiff(long("Before"), long("After"));
+    const changes = diff.collapsedFiles[0].hunks.flatMap(
+      (hunk) => hunk.changes,
+    );
+    const normal = changes.filter((change) => change.type === "normal");
+
+    // Context on both sides of the change, so a reader can tell where they are.
+    expect(normal.length).toBeGreaterThanOrEqual(COLLAPSED_CONTEXT_LINES);
+  });
+
+  it("does not offer to expand when nothing is hidden", () => {
+    // A tiny document is fully visible collapsed; a toggle here would do
+    // nothing when clicked.
+    const diff = buildJsonDiff(toDiffJson({ a: 1 }), toDiffJson({ a: 2 }));
+
+    expect(diff.hasChanges).toBe(true);
+    expect(diff.hasHiddenContext).toBe(false);
+  });
+
+  it("handles one side being absent, as when a keymap has no data yet", () => {
+    const diff = buildJsonDiff("", toDiffJson({ keyboard: "dya2" }));
+    expect(diff.hasChanges).toBe(true);
+  });
+});

--- a/src/lib/abyss/__tests__/zmkConnectionAdapter.test.ts
+++ b/src/lib/abyss/__tests__/zmkConnectionAdapter.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Tests for the bridge between DYA Studio's connection and the Abyss adapter.
+ */
+import type { RpcConnection } from "@zmkfirmware/zmk-studio-ts-client";
+import { createAbyssZmkConnection } from "../zmkConnectionAdapter";
+
+const rpcConnection = { label: "test" } as unknown as RpcConnection;
+
+describe("createAbyssZmkConnection", () => {
+  it("passes the live RPC connection straight through", () => {
+    const connection = createAbyssZmkConnection({
+      rpcConnection,
+      deviceName: "DYA2",
+      method: "serial",
+    });
+
+    // Identity matters: the adapter must drive the same connection the app
+    // already owns, not a copy.
+    expect(connection.rpcConnection).toBe(rpcConnection);
+    expect(connection.method).toBe("zmk");
+    expect(connection.deviceName).toBe("DYA2");
+  });
+
+  it.each([
+    ["serial", "usb"],
+    ["demo", "usb"],
+    ["ble", "ble"],
+  ] as const)("maps the %s method to the %s transport", (method, transport) => {
+    expect(createAbyssZmkConnection({ rpcConnection, method }).transport).toBe(
+      transport,
+    );
+  });
+
+  it("throws if the adapter reaches for the transport", () => {
+    const connection = createAbyssZmkConnection({
+      rpcConnection,
+      method: "serial",
+    });
+
+    // DYA Studio owns the transport; the adapter closing it would kill the
+    // user's session. Fail loudly rather than hand over undefined.
+    expect(
+      () => (connection.transportConnection as { label: string }).label,
+    ).toThrow(/owns the transport/);
+  });
+
+  it("never aborts the connection it was handed", () => {
+    const connection = createAbyssZmkConnection({
+      rpcConnection,
+      method: "serial",
+    });
+
+    expect(connection.rpcAbortController.signal.aborted).toBe(false);
+    // Disconnecting is the app's decision, so this is a no-op rather than a
+    // teardown.
+    expect(connection.disconnect?.()).toBeUndefined();
+  });
+
+  it("carries the notification source through", () => {
+    const notificationSource = { subscribe: () => () => {} };
+    expect(
+      createAbyssZmkConnection({
+        rpcConnection,
+        method: "serial",
+        notificationSource,
+      }).notificationSource,
+    ).toBe(notificationSource);
+  });
+});

--- a/src/lib/abyss/__tests__/zmkConnectionAdapter.test.ts
+++ b/src/lib/abyss/__tests__/zmkConnectionAdapter.test.ts
@@ -31,17 +31,21 @@ describe("createAbyssZmkConnection", () => {
     );
   });
 
-  it("throws if the adapter reaches for the transport", () => {
+  it("hands over an inert transport placeholder", () => {
     const connection = createAbyssZmkConnection({
       rpcConnection,
       method: "serial",
     });
 
-    // DYA Studio owns the transport; the adapter closing it would kill the
-    // user's session. Fail loudly rather than hand over undefined.
+    // This was briefly a Proxy that threw on access. The loaded connection is
+    // stored in React state and something in the render path introspects state
+    // objects, so the throw fired during rendering and froze the whole page
+    // after the first device read. It must be inert, and safe to read.
+    expect(() => JSON.stringify(connection.transportConnection)).not.toThrow();
     expect(
-      () => (connection.transportConnection as { label: string }).label,
-    ).toThrow(/owns the transport/);
+      (connection.transportConnection as { label?: string }).label,
+    ).toBeUndefined();
+    expect(Object.isFrozen(connection.transportConnection)).toBe(true);
   });
 
   it("never aborts the connection it was handed", () => {

--- a/src/lib/abyss/abyssClient.ts
+++ b/src/lib/abyss/abyssClient.ts
@@ -1,0 +1,66 @@
+/**
+ * Lazily-constructed Keyboard Abyss API client.
+ *
+ * One client instance per page load. It owns the OAuth token set, so every
+ * caller must go through {@link getAbyssClient} rather than constructing its
+ * own — two clients would each hold a different token and silently disagree
+ * about whether the user is logged in.
+ *
+ * Tokens live in `sessionStorage`: they survive a reload (which the OAuth
+ * redirect fallback needs) but are gone when the tab closes. The library
+ * defaults to in-memory storage, which would drop the token on every reload.
+ */
+import {
+  createAbyssClient,
+  type AbyssClient,
+} from "@keyboard-hub/abyss-client";
+import {
+  ABYSS_BASE_URL,
+  ABYSS_CLIENT_ID,
+  isAbyssConfigured,
+} from "./abyssConfig";
+import { OAUTH_CALLBACK_PATH } from "./abyssOAuth";
+
+export { isAbyssConfigured };
+
+/** Scopes the Import/Export tab needs: read the profile, read and write
+ * keymaps, and resolve the connected keyboard's layout. */
+const ABYSS_SCOPES = [
+  "profile:read",
+  "keymap:read",
+  "keymap:write",
+  "layout:read",
+] as const;
+
+let client: AbyssClient | null = null;
+let clientBuilt = false;
+
+/**
+ * The shared client, or `null` when unconfigured.
+ *
+ * `createAbyssClient` throws on an empty client id, so the configured check has
+ * to happen before construction rather than being handled by the caller.
+ */
+export function getAbyssClient(): AbyssClient | null {
+  if (clientBuilt) return client;
+  clientBuilt = true;
+  if (!isAbyssConfigured()) return null;
+  client = createAbyssClient({
+    clientId: ABYSS_CLIENT_ID,
+    redirectUri: `${window.location.origin}${OAUTH_CALLBACK_PATH}`,
+    scopes: ABYSS_SCOPES,
+    // Both the token set and the in-flight PKCE transaction are tab-scoped.
+    // The transaction *must* stay in this tab: the tab that builds the
+    // authorization URL is the tab that exchanges the code for a token.
+    storage: window.sessionStorage,
+    transactionStorage: window.sessionStorage,
+    ...(ABYSS_BASE_URL ? { abyssBaseUrl: ABYSS_BASE_URL } : {}),
+  });
+  return client;
+}
+
+/** Test seam: drops the memoized client so the next call rebuilds it. */
+export function resetAbyssClientForTest(): void {
+  client = null;
+  clientBuilt = false;
+}

--- a/src/lib/abyss/abyssConfig.ts
+++ b/src/lib/abyss/abyssConfig.ts
@@ -1,0 +1,21 @@
+/**
+ * Build-time Keyboard Abyss configuration.
+ *
+ * Deliberately separate from {@link ./abyssClient.ts}: `App.tsx` only needs to
+ * know *whether* Abyss is configured in order to decide if the Import/Export
+ * tab exists, and that question should not drag the Abyss SDK into the app
+ * shell's module graph.
+ */
+import { ABYSS_BASE_URL, ABYSS_CLIENT_ID } from "../viteEnv";
+
+export { ABYSS_BASE_URL, ABYSS_CLIENT_ID };
+
+/**
+ * Whether this build was given an Abyss OAuth client id.
+ *
+ * When false the Import/Export tab is not registered at all — its only entry
+ * point is a sign-in that could not succeed.
+ */
+export function isAbyssConfigured(): boolean {
+  return ABYSS_CLIENT_ID.length > 0;
+}

--- a/src/lib/abyss/abyssConfig.ts
+++ b/src/lib/abyss/abyssConfig.ts
@@ -43,3 +43,13 @@ export function abyssHost(): string {
     return DEFAULT_ABYSS_BASE_URL.replace("https://", "");
   }
 }
+
+/** Public page for a keyboard in the Abyss catalog. */
+export function abyssKeyboardUrl(slug: string): string {
+  return `${abyssBaseUrl()}/keyboard/${encodeURIComponent(slug)}`;
+}
+
+/** Where a user registers a keyboard/keymap that Abyss does not know yet. */
+export function abyssRegisterUrl(): string {
+  return `${abyssBaseUrl()}/keymaps/register`;
+}

--- a/src/lib/abyss/abyssConfig.ts
+++ b/src/lib/abyss/abyssConfig.ts
@@ -19,3 +19,27 @@ export { ABYSS_BASE_URL, ABYSS_CLIENT_ID };
 export function isAbyssConfigured(): boolean {
   return ABYSS_CLIENT_ID.length > 0;
 }
+
+/** Where the client library points when `VITE_ABYSS_BASE_URL` is unset. */
+const DEFAULT_ABYSS_BASE_URL = "https://abyss.keyboard-hub.com";
+
+/**
+ * Origin of the Abyss instance this build talks to.
+ *
+ * Dev and PR preview builds point at the staging deployment, so anything that
+ * links to Abyss or names it in copy has to read this rather than hardcoding
+ * the production host — otherwise a dev build tells the user it is uploading
+ * somewhere it is not.
+ */
+export function abyssBaseUrl(): string {
+  return ABYSS_BASE_URL || DEFAULT_ABYSS_BASE_URL;
+}
+
+/** Host shown in UI copy, e.g. `abyss.keyboard-hub.com`. */
+export function abyssHost(): string {
+  try {
+    return new URL(abyssBaseUrl()).host;
+  } catch {
+    return DEFAULT_ABYSS_BASE_URL.replace("https://", "");
+  }
+}

--- a/src/lib/abyss/abyssDiff.ts
+++ b/src/lib/abyss/abyssDiff.ts
@@ -1,0 +1,246 @@
+/**
+ * Shaping and summarising the writeback diff for the import UI.
+ *
+ * The diff itself is computed by `compareKeyboardHubKeymaps` in
+ * `@keyboard-hub/adapter-common`. Everything here works on the resulting shape:
+ * filtering it by the user's section selection, counting it, and turning
+ * bindings into labels. Kept structural and local so it is unit-testable — the
+ * ESM-only adapter packages cannot be loaded by the CommonJS test runtime.
+ */
+import type { AbyssSectionSelection } from "./abyssExportPayload";
+
+/** One key binding that differs between the Abyss keymap and the device. */
+export interface BindingChange {
+  layerIndex: number;
+  layerName: string;
+  keyIndex: number;
+  from?: unknown;
+  to?: unknown;
+}
+
+/** An entry in an ordered collection (combos, macros) that differs. */
+export interface CollectionChange {
+  index: number;
+  label: string;
+  from?: unknown;
+  to?: unknown;
+}
+
+/** A module setting that differs, at keymap or layer scope. */
+export interface ModuleChange {
+  scope: "global" | "layer";
+  layerIndex?: number;
+  moduleName: string;
+  from?: unknown;
+  to?: unknown;
+}
+
+export interface LayerNameChange {
+  layerIndex: number;
+  from?: string;
+  to: string;
+}
+
+/** The firmware-neutral writeback diff, as adapter-common produces it. */
+export interface KeymapDiff {
+  bindingChanges: BindingChange[];
+  comboChanges: CollectionChange[];
+  macroChanges: CollectionChange[];
+  moduleChanges: ModuleChange[];
+  layerNameChanges: LayerNameChange[];
+}
+
+export const EMPTY_DIFF: KeymapDiff = {
+  bindingChanges: [],
+  comboChanges: [],
+  macroChanges: [],
+  moduleChanges: [],
+  layerNameChanges: [],
+};
+
+/**
+ * Drops the sections the user did not tick.
+ *
+ * `keymap` covers both bindings and layer names — they are written by the same
+ * RPCs and make no sense to split.
+ */
+export function filterDiff(
+  diff: KeymapDiff,
+  selection: AbyssSectionSelection,
+): KeymapDiff {
+  return {
+    bindingChanges: selection.keymap ? diff.bindingChanges : [],
+    layerNameChanges: selection.keymap ? diff.layerNameChanges : [],
+    comboChanges: selection.combos ? diff.comboChanges : [],
+    macroChanges: selection.macros ? diff.macroChanges : [],
+    moduleChanges: selection.modules ? diff.moduleChanges : [],
+  };
+}
+
+/** True when there is nothing left to write. */
+export function isEmptyDiff(diff: KeymapDiff): boolean {
+  return (
+    diff.bindingChanges.length === 0 &&
+    diff.layerNameChanges.length === 0 &&
+    diff.comboChanges.length === 0 &&
+    diff.macroChanges.length === 0 &&
+    diff.moduleChanges.length === 0
+  );
+}
+
+/** Highest layer index the diff touches, or -1 when it touches no layer. */
+export function maxLayerIndex(diff: KeymapDiff): number {
+  return Math.max(
+    -1,
+    ...diff.layerNameChanges.map((change) => change.layerIndex),
+    ...diff.bindingChanges.map((change) => change.layerIndex),
+    ...diff.moduleChanges
+      .map((change) => change.layerIndex)
+      .filter((index): index is number => index !== undefined),
+  );
+}
+
+/** Headline counts for the summary bar. */
+export interface DiffCounts {
+  bindings: number;
+  layerNames: number;
+  combos: number;
+  macros: number;
+  modules: number;
+  total: number;
+}
+
+export function countDiff(diff: KeymapDiff): DiffCounts {
+  const counts = {
+    bindings: diff.bindingChanges.length,
+    layerNames: diff.layerNameChanges.length,
+    combos: diff.comboChanges.length,
+    macros: diff.macroChanges.length,
+    modules: diff.moduleChanges.length,
+  };
+  return {
+    ...counts,
+    total: Object.values(counts).reduce((sum, count) => sum + count, 0),
+  };
+}
+
+/** Everything the diff changes within one layer. */
+export interface LayerDiff {
+  layerIndex: number;
+  layerName: string;
+  nameChange?: LayerNameChange;
+  bindingChanges: BindingChange[];
+  moduleChanges: ModuleChange[];
+}
+
+/**
+ * Regroups the flat change lists by layer, in layer order.
+ *
+ * The UI shows one collapsible card per affected layer; a flat list of 300
+ * binding rows is unreadable, and grouping is what makes "the whole alpha block
+ * moved" distinguishable from "three keys changed".
+ */
+export function groupByLayer(diff: KeymapDiff): LayerDiff[] {
+  const byIndex = new Map<number, LayerDiff>();
+  const ensure = (layerIndex: number, layerName?: string) => {
+    const existing = byIndex.get(layerIndex);
+    if (existing) {
+      if (layerName && !existing.layerName) existing.layerName = layerName;
+      return existing;
+    }
+    const created: LayerDiff = {
+      layerIndex,
+      layerName: layerName ?? "",
+      bindingChanges: [],
+      moduleChanges: [],
+    };
+    byIndex.set(layerIndex, created);
+    return created;
+  };
+
+  for (const change of diff.layerNameChanges) {
+    ensure(change.layerIndex, change.to).nameChange = change;
+  }
+  for (const change of diff.bindingChanges) {
+    ensure(change.layerIndex, change.layerName).bindingChanges.push(change);
+  }
+  for (const change of diff.moduleChanges) {
+    if (change.layerIndex === undefined) continue;
+    ensure(change.layerIndex).moduleChanges.push(change);
+  }
+
+  return [...byIndex.values()].sort((a, b) => a.layerIndex - b.layerIndex);
+}
+
+/** Module changes that apply to the whole keymap rather than one layer. */
+export function globalModuleChanges(diff: KeymapDiff): ModuleChange[] {
+  return diff.moduleChanges.filter((change) => change.scope === "global");
+}
+
+/**
+ * Above this many binding rows the UI shows counts only until the user asks for
+ * the full list. A full keymap replacement is several hundred rows, and
+ * rendering them all is both slow and useless.
+ */
+export const BINDING_ROW_LIMIT = 250;
+
+/**
+ * A short human label for one binding.
+ *
+ * KeyboardHub bindings are discriminated by `type`, with the interesting detail
+ * in different fields per variant. This covers the common ones and degrades to
+ * the type name rather than guessing, so an unrecognised binding still shows
+ * *something* truthful.
+ */
+export function bindingLabel(binding: unknown): string {
+  if (binding === undefined || binding === null) return "—";
+  if (typeof binding !== "object") return String(binding);
+
+  const value = binding as Record<string, unknown>;
+  const type = typeof value.type === "string" ? value.type : null;
+  if (!type) return "—";
+
+  const usage = typeof value.usage === "number" ? value.usage : null;
+  const mods = Array.isArray(value.mods) ? (value.mods as string[]) : [];
+  const withMods = (label: string) =>
+    mods.length ? `${mods.join("+")}+${label}` : label;
+  const hex = (code: number) => `0x${code.toString(16)}`;
+
+  switch (type) {
+    case "key":
+      return usage === null ? "key" : withMods(hex(usage));
+    case "mt":
+      return `MT(${String(value.mod ?? "?")}, ${usage === null ? "?" : hex(usage)})`;
+    case "lt":
+      return `LT(${String(value.layer ?? "?")}, ${usage === null ? "?" : hex(usage)})`;
+    case "mo":
+    case "tog":
+    case "to":
+    case "sl":
+      return `${type.toUpperCase()}(${String(value.layer ?? "?")})`;
+    case "sticky_key":
+      return usage === null ? "sticky" : `SK(${withMods(hex(usage))})`;
+    case "key_toggle":
+      return usage === null ? "KT" : `KT(${withMods(hex(usage))})`;
+    case "mouse_button":
+      return `MB${String(value.button ?? "?")}`;
+    case "mouse_move":
+    case "mouse_scroll":
+      return `${type === "mouse_move" ? "MOVE" : "SCRL"} ${String(value.direction ?? "?")}`;
+    case "bluetooth":
+      return `BT ${String(value.action ?? "?")}`;
+    case "output":
+      return `OUT ${String(value.action ?? "?")}`;
+    case "macro":
+      return `macro ${String(value.macro ?? "?")}`;
+    case "raw":
+      return String(value.zmk ?? value.label ?? "raw");
+    case "trans":
+      return "▽";
+    case "none":
+      return "✕";
+    default:
+      // caps_word, key_repeat, grave_escape, bootloader, reset, …
+      return type;
+  }
+}

--- a/src/lib/abyss/abyssErrors.ts
+++ b/src/lib/abyss/abyssErrors.ts
@@ -1,0 +1,90 @@
+/**
+ * Turns Keyboard Abyss client errors into user-facing text and coarse
+ * analytics buckets.
+ *
+ * API error bodies can echo request data back, so they are never surfaced
+ * verbatim or sent to analytics — the HTTP status is mapped to a fixed message
+ * key instead.
+ */
+import { AbyssApiError, AbyssOAuthError } from "@keyboard-hub/abyss-client";
+
+/** Coarse, non-identifying bucket for a failed Abyss operation. */
+export type AbyssFailReason =
+  | "cancelled"
+  | "oauth"
+  | "unauthorized"
+  | "forbidden"
+  | "not_found"
+  | "conflict"
+  | "rate_limited"
+  | "network"
+  | "locked"
+  | "server"
+  | "error";
+
+/** True when the failure means the stored token is no longer usable. The
+ * client refreshes on its own, so a 401 that reaches us means the refresh token
+ * is gone too and the user has to log in again. */
+export function isAbyssUnauthorized(error: unknown): boolean {
+  return error instanceof AbyssApiError && error.status === 401;
+}
+
+/** Map an arbitrary error to a coarse bucket safe to send to analytics. */
+export function classifyAbyssError(error: unknown): AbyssFailReason {
+  if (error instanceof AbyssApiError) {
+    if (error.status === 401) return "unauthorized";
+    if (error.status === 403) return "forbidden";
+    if (error.status === 404) return "not_found";
+    if (error.status === 409 || error.status === 422) return "conflict";
+    if (error.status === 429) return "rate_limited";
+    if (error.status >= 500) return "server";
+    return "error";
+  }
+  if (error instanceof AbyssOAuthError) {
+    // `code` is only set when Abyss itself returned an OAuth `error` param.
+    // Everything else (state mismatch, expired or missing PKCE transaction) is
+    // a broken flow, not a user declining consent — saying "cancelled" there
+    // would send the user looking for a mistake they did not make.
+    return error.code === "access_denied" ? "cancelled" : "oauth";
+  }
+  const named = error as { code?: unknown; name?: unknown } | null;
+  if (named?.code === "LOCKED" || named?.name === "FirmwareLockedError") {
+    return "locked";
+  }
+  // `fetch` rejects with a TypeError when it cannot reach the host at all.
+  if (error instanceof TypeError) return "network";
+  return "error";
+}
+
+/**
+ * English message key for an Abyss error, to be passed through `t()`.
+ *
+ * Returns fixed strings rather than the server's message so that nothing from
+ * a response body is rendered directly.
+ */
+export function abyssErrorMessageKey(error: unknown): string {
+  switch (classifyAbyssError(error)) {
+    case "unauthorized":
+      return "Your Abyss session expired. Please log in again.";
+    case "forbidden":
+      return "Your Abyss account does not have permission for this action.";
+    case "not_found":
+      return "This keymap no longer exists on Abyss.";
+    case "conflict":
+      return "Abyss rejected this keymap. It may not match the connected keyboard.";
+    case "rate_limited":
+      return "Too many requests to Abyss. Please wait a moment and try again.";
+    case "server":
+      return "Abyss is having trouble right now. Please try again later.";
+    case "network":
+      return "Could not reach Abyss. Check your network connection.";
+    case "locked":
+      return "The keyboard is locked. Unlock it and try again.";
+    case "cancelled":
+      return "Abyss login was cancelled.";
+    case "oauth":
+      return "Abyss sign-in could not be completed. Please start again from the Import/Export tab.";
+    default:
+      return "Something went wrong talking to Abyss.";
+  }
+}

--- a/src/lib/abyss/abyssExportPayload.ts
+++ b/src/lib/abyss/abyssExportPayload.ts
@@ -1,0 +1,129 @@
+/**
+ * Builds the KeyboardHub JSON uploaded to Abyss from the device snapshot and
+ * the user's section selection.
+ *
+ * Written here rather than using adapter-common's
+ * `applyKeyboardHubKeymapSelection` for two reasons: that helper unconditionally
+ * overwrites `keyboard`, `name` and `description` from the device side, which
+ * would silently rename the user's Abyss keymap to the device name on every
+ * update; and keeping this pure and local means it is unit-testable, which the
+ * ESM-only adapter packages are not under the CommonJS test runtime.
+ */
+
+/** Which parts of the keymap the user chose to upload. */
+export interface AbyssSectionSelection {
+  /** Layer names and key bindings. */
+  keymap: boolean;
+  combos: boolean;
+  macros: boolean;
+  /** Global and per-layer module settings (trackball, encoders, …). */
+  modules: boolean;
+}
+
+/** Every section on, the default for a first export. */
+export const ALL_SECTIONS: AbyssSectionSelection = {
+  keymap: true,
+  combos: true,
+  macros: true,
+  modules: true,
+};
+
+/** Stable order for display and for the analytics `sections` parameter. */
+export const SECTION_IDS = ["keymap", "combos", "macros", "modules"] as const;
+
+export type AbyssSectionId = (typeof SECTION_IDS)[number];
+
+/** Sorted, comma-joined ids of the selected sections. Safe to send to analytics. */
+export function selectedSectionIds(selection: AbyssSectionSelection): string {
+  return SECTION_IDS.filter((id) => selection[id]).join(",");
+}
+
+/** Minimal structural view of the keymap JSON, shared by device and Abyss. */
+type KeymapLayer = {
+  name?: string;
+  bindings: unknown[];
+  modules?: unknown[];
+};
+
+export type KeymapDocument = {
+  keyboard: string;
+  name?: string;
+  description?: string | null;
+  layers: KeymapLayer[];
+  modules?: unknown[];
+  combos?: unknown[];
+  macros?: unknown[];
+  [key: string]: unknown;
+};
+
+/**
+ * Produces the document to upload.
+ *
+ * `base` is what the result starts from — the existing Abyss keymap when
+ * updating, or the device snapshot itself when creating a new one. Selected
+ * sections are taken from `device`; unselected ones keep whatever `base` had,
+ * so an update never clobbers data the user did not choose to overwrite.
+ *
+ * Identity fields (`keyboard`, `name`, `description`) always come from `base`:
+ * an export replaces keymap *data*, never the record's own metadata.
+ */
+export function buildExportData(
+  device: KeymapDocument,
+  base: KeymapDocument,
+  selection: AbyssSectionSelection,
+): KeymapDocument {
+  const layerCount = selection.keymap
+    ? Math.max(device.layers.length, base.layers.length)
+    : base.layers.length;
+
+  const layers = Array.from({ length: layerCount }, (_, index) => {
+    const baseLayer = base.layers[index];
+    const deviceLayer = device.layers[index];
+    // A layer the device has but Abyss does not is only added when the user is
+    // uploading keymap data at all.
+    if (!baseLayer) return selection.keymap ? deviceLayer : undefined;
+    if (!deviceLayer) return baseLayer;
+    return {
+      ...baseLayer,
+      name: selection.keymap ? deviceLayer.name : baseLayer.name,
+      bindings: selection.keymap ? deviceLayer.bindings : baseLayer.bindings,
+      modules: selection.modules ? deviceLayer.modules : baseLayer.modules,
+    };
+  }).filter((layer): layer is KeymapLayer => Boolean(layer));
+
+  return {
+    ...base,
+    keyboard: base.keyboard,
+    name: base.name,
+    description: base.description,
+    layers,
+    modules: selection.modules ? device.modules : base.modules,
+    combos: selection.combos ? device.combos : base.combos,
+    macros: selection.macros ? device.macros : base.macros,
+  };
+}
+
+/**
+ * The document for a brand-new Abyss keymap.
+ *
+ * Same merge with the device as its own base, which reduces to "keep the
+ * selected sections, drop the rest". `keymap` is always on for a new keymap —
+ * a keymap with no layers is meaningless — so the caller forces it.
+ */
+export function buildNewExportData(
+  device: KeymapDocument,
+  selection: AbyssSectionSelection,
+  name: string,
+): KeymapDocument {
+  const merged = buildExportData(
+    device,
+    { ...device, name },
+    { ...selection, keymap: true },
+  );
+  // Unselected collections are dropped rather than sent empty, so Abyss stores
+  // "this export did not cover combos" rather than "this keymap has no combos".
+  if (!selection.combos) delete merged.combos;
+  if (!selection.macros) delete merged.macros;
+  if (!selection.modules) delete merged.modules;
+  return merged;
+}

--- a/src/lib/abyss/abyssKeymapList.ts
+++ b/src/lib/abyss/abyssKeymapList.ts
@@ -16,23 +16,13 @@ export interface KeymapListFilter {
   layoutVariationId?: string;
 }
 
-/**
- * Fetches candidate keymaps.
- *
- * Deliberately does *not* filter by keyboard slug. The slug on the device
- * snapshot is derived by the adapter from the ZMK device name
- * (`normalizeKeyboardSlug(deviceName)`), which is a different thing from the
- * Abyss catalog slug — a keyboard reporting itself as "DYA Keyboard" yields
- * "dya-keyboard" while the catalog knows it as "dya2". Passing that through
- * filtered every result out, so both dropdowns were permanently empty.
- *
- * The layout ids from `resolveLayout` *are* catalog identities, so they are
- * used when available. When the layout was not recognised there is nothing
- * trustworthy to filter on, and showing the user's full list beats showing an
- * empty one — the pre-flight checks catch a genuinely incompatible choice
- * before anything is written.
- */
-export async function listCandidateKeymaps(
+export interface KeymapListResult {
+  items: AbyssKeymapSummary[];
+  /** True when the layout filter matched nothing and the list was widened. */
+  widened: boolean;
+}
+
+async function fetchPage(
   client: AbyssClient,
   filter: KeymapListFilter,
 ): Promise<AbyssKeymapSummary[]> {
@@ -46,4 +36,34 @@ export async function listCandidateKeymaps(
     limit: 50,
   });
   return page.items;
+}
+
+/**
+ * Fetches candidate keymaps, widening the search rather than showing nothing.
+ *
+ * Deliberately never filters by keyboard slug. The slug on the device snapshot
+ * is derived by the adapter from the ZMK device name
+ * (`normalizeKeyboardSlug(deviceName)`), which is a different thing from the
+ * Abyss catalog slug — a board reporting itself as "DYA Keyboard" yields
+ * "dya-keyboard" while the catalog knows it as "dya2". Passing that through
+ * filtered every result out.
+ *
+ * The layout ids from `resolveLayout` *are* catalog identities, so they narrow
+ * the list when available. But `resolveLayout` matches on the geometry the
+ * firmware reports, and a keymap saved against a slightly different variation
+ * of the same layout then falls outside the filter — which looked exactly like
+ * having no keymaps at all. So when the filtered query comes back empty, the
+ * search is retried unfiltered and the caller is told it was widened. The
+ * pre-flight checks are what actually stop an incompatible write.
+ */
+export async function listCandidateKeymaps(
+  client: AbyssClient,
+  filter: KeymapListFilter,
+): Promise<KeymapListResult> {
+  const hasFilter = Boolean(filter.layoutId || filter.layoutVariationId);
+  const filtered = await fetchPage(client, filter);
+  if (filtered.length > 0 || !hasFilter) {
+    return { items: filtered, widened: false };
+  }
+  return { items: await fetchPage(client, {}), widened: true };
 }

--- a/src/lib/abyss/abyssKeymapList.ts
+++ b/src/lib/abyss/abyssKeymapList.ts
@@ -9,11 +9,24 @@ import type {
   AbyssKeymapSummary,
 } from "@keyboard-hub/abyss-client";
 
+/**
+ * `GET /me/keymaps` rejects `limit` above 20 outright — a 400
+ * `VALIDATION_ERROR`, not a clamp — so candidates have to be paged in. Matches
+ * what Abyss's own import modal does.
+ */
+const PAGE_SIZE = 20;
+const MAX_PAGES = 5;
+
 export interface KeymapListFilter {
-  /** Abyss layout id from `resolveLayout`, when the layout was recognised. */
+  /**
+   * Abyss layout id from `resolveLayout`, when the layout was recognised.
+   *
+   * Deliberately the only filter. Narrowing further by `layoutVariationId`
+   * excluded keymaps saved against a different variation of the *same* layout,
+   * which are still perfectly writable — the pre-flight checks are what decide
+   * whether a given keymap actually fits the connected keyboard.
+   */
   layoutId?: string;
-  /** Abyss layout variation id from `resolveLayout`. */
-  layoutVariationId?: string;
 }
 
 export interface KeymapListResult {
@@ -22,20 +35,26 @@ export interface KeymapListResult {
   widened: boolean;
 }
 
-async function fetchPage(
+/** Pages through the user's keymaps, up to {@link MAX_PAGES}. */
+async function fetchAll(
   client: AbyssClient,
   filter: KeymapListFilter,
 ): Promise<AbyssKeymapSummary[]> {
-  const page = await client.listMyKeymaps({
-    visibility: "all",
-    ...(filter.layoutId ? { layoutId: filter.layoutId } : {}),
-    ...(filter.layoutVariationId
-      ? { layoutVariationId: filter.layoutVariationId }
-      : {}),
-    page: 1,
-    limit: 50,
-  });
-  return page.items;
+  const collected: AbyssKeymapSummary[] = [];
+  for (let page = 1; page <= MAX_PAGES; page += 1) {
+    const result = await client.listMyKeymaps({
+      visibility: "all",
+      ...(filter.layoutId ? { layoutId: filter.layoutId } : {}),
+      page,
+      limit: PAGE_SIZE,
+    });
+    collected.push(...result.items);
+    // Stop on a short page as well as on `pageCount`: a full page is the only
+    // reliable signal that another one might exist, and it keeps the loop
+    // terminating even if the field is missing.
+    if (result.items.length < PAGE_SIZE || page >= result.pageCount) break;
+  }
+  return collected;
 }
 
 /**
@@ -45,25 +64,23 @@ async function fetchPage(
  * is derived by the adapter from the ZMK device name
  * (`normalizeKeyboardSlug(deviceName)`), which is a different thing from the
  * Abyss catalog slug — a board reporting itself as "DYA Keyboard" yields
- * "dya-keyboard" while the catalog knows it as "dya2". Passing that through
- * filtered every result out.
+ * "dya-keyboard" while the catalog knows it as "dya2".
  *
- * The layout ids from `resolveLayout` *are* catalog identities, so they narrow
- * the list when available. But `resolveLayout` matches on the geometry the
- * firmware reports, and a keymap saved against a slightly different variation
- * of the same layout then falls outside the filter — which looked exactly like
- * having no keymaps at all. So when the filtered query comes back empty, the
- * search is retried unfiltered and the caller is told it was widened. The
- * pre-flight checks are what actually stop an incompatible write.
+ * The layout id from `resolveLayout` *is* a catalog identity, so it narrows the
+ * list when available — but only the layout, never the variation: a keymap on
+ * another variation of the same layout is still a valid update target. When
+ * even that comes back empty the search is retried unfiltered and the caller is
+ * told it was widened; the pre-flight checks are what actually stop an
+ * incompatible write.
  */
 export async function listCandidateKeymaps(
   client: AbyssClient,
   filter: KeymapListFilter,
 ): Promise<KeymapListResult> {
-  const hasFilter = Boolean(filter.layoutId || filter.layoutVariationId);
-  const filtered = await fetchPage(client, filter);
+  const hasFilter = Boolean(filter.layoutId);
+  const filtered = await fetchAll(client, filter);
   if (filtered.length > 0 || !hasFilter) {
     return { items: filtered, widened: false };
   }
-  return { items: await fetchPage(client, {}), widened: true };
+  return { items: await fetchAll(client, {}), widened: true };
 }

--- a/src/lib/abyss/abyssKeymapList.ts
+++ b/src/lib/abyss/abyssKeymapList.ts
@@ -1,0 +1,49 @@
+/**
+ * Lists the signed-in user's keymaps that are candidates for this keyboard.
+ *
+ * Shared by the export and import sections so they cannot drift apart on which
+ * keymaps they consider compatible.
+ */
+import type {
+  AbyssClient,
+  AbyssKeymapSummary,
+} from "@keyboard-hub/abyss-client";
+
+export interface KeymapListFilter {
+  /** Abyss layout id from `resolveLayout`, when the layout was recognised. */
+  layoutId?: string;
+  /** Abyss layout variation id from `resolveLayout`. */
+  layoutVariationId?: string;
+}
+
+/**
+ * Fetches candidate keymaps.
+ *
+ * Deliberately does *not* filter by keyboard slug. The slug on the device
+ * snapshot is derived by the adapter from the ZMK device name
+ * (`normalizeKeyboardSlug(deviceName)`), which is a different thing from the
+ * Abyss catalog slug — a keyboard reporting itself as "DYA Keyboard" yields
+ * "dya-keyboard" while the catalog knows it as "dya2". Passing that through
+ * filtered every result out, so both dropdowns were permanently empty.
+ *
+ * The layout ids from `resolveLayout` *are* catalog identities, so they are
+ * used when available. When the layout was not recognised there is nothing
+ * trustworthy to filter on, and showing the user's full list beats showing an
+ * empty one — the pre-flight checks catch a genuinely incompatible choice
+ * before anything is written.
+ */
+export async function listCandidateKeymaps(
+  client: AbyssClient,
+  filter: KeymapListFilter,
+): Promise<AbyssKeymapSummary[]> {
+  const page = await client.listMyKeymaps({
+    visibility: "all",
+    ...(filter.layoutId ? { layoutId: filter.layoutId } : {}),
+    ...(filter.layoutVariationId
+      ? { layoutVariationId: filter.layoutVariationId }
+      : {}),
+    page: 1,
+    limit: 50,
+  });
+  return page.items;
+}

--- a/src/lib/abyss/abyssNotifications.ts
+++ b/src/lib/abyss/abyssNotifications.ts
@@ -1,0 +1,57 @@
+/**
+ * Bridges DYA Studio's notification subscriptions to the Abyss adapter.
+ *
+ * `RpcConnection.notification_readable` permits a single reader, and
+ * `useZMKApp` takes it for the lifetime of the connection so the app can react
+ * to lock-state and keymap-change notifications. The adapter therefore cannot
+ * read the stream itself: its `getReader()` throws, `loadZmkPreview` swallows
+ * that via a `.catch()`, and every trackball / runtime input processor
+ * disappears from the import with no error to explain it.
+ *
+ * `ZmkNotificationSource` is the adapter's escape hatch for exactly this. We
+ * re-broadcast what the app is already receiving.
+ */
+import type { ZmkNotificationSource } from "@keyboard-hub/adapter-zmk";
+import type { Notification as StudioNotification } from "@zmkfirmware/zmk-studio-ts-client/studio";
+import type { CustomNotification } from "@zmkfirmware/zmk-studio-ts-client/custom";
+
+/** The slice of `UseZMKAppReturn` this needs. */
+export interface NotificationBridgeInput {
+  /** Custom subsystem indices to relay. */
+  subsystemIndexes: number[];
+  /** `zmkApp.onNotification`, returning an unsubscribe. */
+  onNotification: (subscription: {
+    type: "custom";
+    subsystemIndex: number;
+    callback: (notification: CustomNotification) => void;
+  }) => () => void;
+}
+
+/**
+ * Builds a notification source over every advertised custom subsystem.
+ *
+ * The app subscribes per subsystem index, while the adapter wants the outer
+ * Studio envelope and does its own index filtering — so each notification is
+ * rewrapped on the way through. Subscribing to all advertised subsystems keeps
+ * this independent of which one the adapter happens to be interested in.
+ */
+export function createAbyssNotificationSource({
+  subsystemIndexes,
+  onNotification,
+}: NotificationBridgeInput): ZmkNotificationSource {
+  return {
+    subscribe(listener) {
+      const unsubscribes = subsystemIndexes.map((subsystemIndex) =>
+        onNotification({
+          type: "custom",
+          subsystemIndex,
+          callback: (customNotification) =>
+            listener({
+              custom: { customNotification },
+            } as StudioNotification),
+        }),
+      );
+      return () => unsubscribes.forEach((unsubscribe) => unsubscribe());
+    },
+  };
+}

--- a/src/lib/abyss/abyssOAuth.ts
+++ b/src/lib/abyss/abyssOAuth.ts
@@ -1,0 +1,248 @@
+/**
+ * OAuth redirect plumbing for the Keyboard Abyss login.
+ *
+ * ## Why a popup rather than a plain redirect
+ *
+ * The Import/Export tab only renders while a keyboard is connected, so the user
+ * is *by construction* connected when they press "Log in". A full-page
+ * navigation to abyss.keyboard-hub.com tears down the Web Serial / WebUSB / BLE
+ * session; on BLE they would have to re-pick the device from the browser picker
+ * afterwards. A popup keeps the connection alive in the opener.
+ *
+ * The full-page redirect is still supported as a fallback for popup blockers,
+ * which is why the callback route has to work standalone.
+ *
+ * ## How the popup talks back
+ *
+ * The callback page broadcasts the callback URL on a `BroadcastChannel` and,
+ * belt-and-braces, via `window.opener.postMessage`. `BroadcastChannel` is the
+ * primary path because `window.opener` is severed if Abyss serves
+ * `Cross-Origin-Opener-Policy: same-origin`.
+ *
+ * Only the tab that *started* the login answers, and it proves that by matching
+ * the OAuth `state` parameter against the one it generated. That matters: the
+ * PKCE code verifier lives in the initiating tab's `sessionStorage`, so any
+ * other open DYA Studio tab would fail the exchange. The acknowledgement is
+ * also how the callback page tells which mode it is in — acknowledged means it
+ * is a popup and should close, silence means it is a full-page redirect and
+ * must exchange the code itself.
+ */
+import type { AbyssClient } from "@keyboard-hub/abyss-client";
+import { navigateTo } from "../navigate";
+
+/** Standalone route that Abyss redirects back to. Must match the redirect URI
+ * registered on the OAuth client. */
+export const OAUTH_CALLBACK_PATH = "/oauth/callback";
+
+/** Path the user is sent back to after a full-page redirect login. */
+export const IMPORT_EXPORT_PATH = "/import-export";
+
+const CHANNEL_NAME = "dya-studio-abyss-oauth";
+const MSG_CALLBACK = "dya-studio:abyss-oauth-callback";
+const MSG_ACK = "dya-studio:abyss-oauth-ack";
+const RETURN_PATH_KEY = "dya-studio-abyss-return-path";
+
+/** How long the callback page waits for the opener to claim the callback
+ * before assuming it is a full-page redirect and exchanging the code itself. */
+const ACK_TIMEOUT_MS = 1500;
+/** Give up on a login the user never finished. */
+const LOGIN_TIMEOUT_MS = 5 * 60 * 1000;
+/** `window.closed` is the only way to notice the user dismissed the popup. */
+const POPUP_POLL_MS = 500;
+
+const POPUP_FEATURES = "width=520,height=760,menubar=no,toolbar=no";
+const POPUP_NAME = "abyss-oauth";
+
+/** Outcome of a login attempt started from the Import/Export tab. */
+export type AbyssLoginOutcome =
+  /** Tokens are stored; the caller should refresh its auth state. */
+  | { status: "authorized" }
+  /** Popups are blocked, so the whole page is navigating to Abyss. Nothing
+   * further will run in this document. */
+  | { status: "redirecting" }
+  /** The user closed the popup, or it never reported back in time. */
+  | { status: "cancelled" };
+
+type CallbackMessage = { type: typeof MSG_CALLBACK; href: string };
+type AckMessage = { type: typeof MSG_ACK; state: string };
+
+function openChannel(): BroadcastChannel | null {
+  if (typeof BroadcastChannel === "undefined") return null;
+  try {
+    return new BroadcastChannel(CHANNEL_NAME);
+  } catch {
+    return null;
+  }
+}
+
+function randomState(): string {
+  const bytes = new Uint8Array(16);
+  crypto.getRandomValues(bytes);
+  return Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+/** The `state` value carried by a callback URL, or `null` if it has none. */
+function stateOf(href: string): string | null {
+  try {
+    return new URL(href).searchParams.get("state");
+  } catch {
+    return null;
+  }
+}
+
+/** Where to send the user after a full-page redirect login. */
+export function saveReturnPath(path: string): void {
+  try {
+    window.sessionStorage.setItem(RETURN_PATH_KEY, path);
+  } catch {
+    // Private-mode storage failures just cost us the deep link.
+  }
+}
+
+/** The stashed return path, defaulting to the Import/Export tab. */
+export function takeReturnPath(): string {
+  try {
+    const path = window.sessionStorage.getItem(RETURN_PATH_KEY);
+    window.sessionStorage.removeItem(RETURN_PATH_KEY);
+    return path || IMPORT_EXPORT_PATH;
+  } catch {
+    return IMPORT_EXPORT_PATH;
+  }
+}
+
+/**
+ * Starts the Abyss login and resolves once tokens are stored.
+ *
+ * Opens a popup when it can and falls back to navigating the whole page. The
+ * returned promise never rejects for user-driven outcomes (a dismissed popup
+ * resolves as `cancelled`); it only rejects if the token exchange itself fails.
+ */
+export async function startAbyssLogin(
+  client: AbyssClient,
+  returnPath: string,
+): Promise<AbyssLoginOutcome> {
+  const state = randomState();
+  // Persists the PKCE verifier + state into *this* tab's transaction storage.
+  const authorizeUrl = await client.buildAuthorizationUrl({ state });
+  saveReturnPath(returnPath);
+
+  let popup: Window | null = null;
+  try {
+    popup = window.open(authorizeUrl, POPUP_NAME, POPUP_FEATURES);
+  } catch {
+    popup = null;
+  }
+
+  if (!popup) {
+    navigateTo(authorizeUrl);
+    return { status: "redirecting" };
+  }
+
+  const href = await waitForCallback(state, popup);
+  try {
+    popup.close();
+  } catch {
+    // A popup we are not allowed to close is harmless.
+  }
+  if (!href) return { status: "cancelled" };
+
+  await client.handleRedirectCallback(href);
+  return { status: "authorized" };
+}
+
+/**
+ * Waits for the callback page to report the redirect URL for `state`.
+ *
+ * Resolves with the callback href, or `null` when the user closed the popup or
+ * the login timed out.
+ */
+function waitForCallback(state: string, popup: Window): Promise<string | null> {
+  return new Promise((resolve) => {
+    const channel = openChannel();
+    let settled = false;
+
+    const finish = (href: string | null) => {
+      if (settled) return;
+      settled = true;
+      window.clearInterval(pollTimer);
+      window.clearTimeout(timeoutTimer);
+      window.removeEventListener("message", onMessage);
+      channel?.removeEventListener("message", onChannelMessage);
+      channel?.close();
+      resolve(href);
+    };
+
+    const accept = (href: string) => {
+      if (stateOf(href) !== state) return;
+      // Tell the callback page we own this login so it closes instead of
+      // trying to exchange the code itself.
+      const ack: AckMessage = { type: MSG_ACK, state };
+      channel?.postMessage(ack);
+      finish(href);
+    };
+
+    const onChannelMessage = (event: MessageEvent) => {
+      const data = event.data as CallbackMessage | AckMessage | undefined;
+      if (data?.type === MSG_CALLBACK) accept(data.href);
+    };
+    const onMessage = (event: MessageEvent) => {
+      if (event.origin !== window.location.origin) return;
+      const data = event.data as CallbackMessage | undefined;
+      if (data?.type === MSG_CALLBACK) accept(data.href);
+    };
+
+    channel?.addEventListener("message", onChannelMessage);
+    window.addEventListener("message", onMessage);
+
+    // The popup closing without a message is the only "user cancelled" signal
+    // the browser gives us.
+    const pollTimer = window.setInterval(() => {
+      if (popup.closed) finish(null);
+    }, POPUP_POLL_MS);
+    const timeoutTimer = window.setTimeout(
+      () => finish(null),
+      LOGIN_TIMEOUT_MS,
+    );
+  });
+}
+
+/**
+ * Announces a finished OAuth redirect to the tab that started it.
+ *
+ * Resolves `true` when that tab claimed the callback — meaning this document is
+ * the popup and should just close. Resolves `false` when nobody answered, in
+ * which case this document is a full-page redirect and owns the token exchange.
+ */
+export function relayAbyssCallback(href: string): Promise<boolean> {
+  return new Promise((resolve) => {
+    const state = stateOf(href);
+    const channel = openChannel();
+    let settled = false;
+
+    const finish = (claimed: boolean) => {
+      if (settled) return;
+      settled = true;
+      window.clearTimeout(timeoutTimer);
+      channel?.removeEventListener("message", onChannelMessage);
+      channel?.close();
+      resolve(claimed);
+    };
+
+    const onChannelMessage = (event: MessageEvent) => {
+      const data = event.data as AckMessage | CallbackMessage | undefined;
+      if (data?.type === MSG_ACK && data.state === state) finish(true);
+    };
+    channel?.addEventListener("message", onChannelMessage);
+
+    const message: CallbackMessage = { type: MSG_CALLBACK, href };
+    channel?.postMessage(message);
+    try {
+      // Only reaches an opener that survived COOP; the channel is the real path.
+      window.opener?.postMessage(message, window.location.origin);
+    } catch {
+      // No opener, or one we may not talk to.
+    }
+
+    const timeoutTimer = window.setTimeout(() => finish(false), ACK_TIMEOUT_MS);
+  });
+}

--- a/src/lib/abyss/abyssPreflight.ts
+++ b/src/lib/abyss/abyssPreflight.ts
@@ -1,0 +1,123 @@
+/**
+ * Compatibility checks run before writing an Abyss keymap to the keyboard.
+ *
+ * Writing is the one destructive thing this tab does, and the adapter applies
+ * changes one RPC at a time — a diff that fails halfway leaves the keyboard in
+ * a mixed state. So mismatches that are knowable up front are caught here
+ * rather than discovered mid-write.
+ */
+import { maxLayerIndex, type KeymapDiff } from "./abyssDiff";
+
+/**
+ * `blocked` prevents the write outright; `warning` is shown but lets the user
+ * proceed, for cases that are merely suspicious rather than wrong.
+ */
+export type PreflightLevel = "ok" | "warning" | "blocked";
+
+export interface PreflightCheck {
+  id: string;
+  level: PreflightLevel;
+  /** English message key, rendered through `t()` with `params`. */
+  message: string;
+  params?: Record<string, string | number>;
+}
+
+export interface PreflightInput {
+  /** The filtered diff about to be written. */
+  diff: KeymapDiff;
+  /** Key count of the widest layer on the device. */
+  deviceKeyCount: number;
+  /** Key count of the widest layer in the Abyss keymap. */
+  targetKeyCount: number;
+  /** Layers currently on the device. */
+  deviceLayerCount: number;
+  /** Physical layout name the device reported, if any. */
+  deviceLayoutName?: string;
+  /** Layout name recorded on the Abyss keymap, if any. */
+  targetLayoutName?: string;
+}
+
+/**
+ * Runs every check. The caller blocks the write if any result is `blocked`.
+ *
+ * Order matters only for display; each check is independent.
+ */
+export function runPreflight(input: PreflightInput): PreflightCheck[] {
+  const checks: PreflightCheck[] = [];
+
+  // A keymap built for a different key count cannot be written meaningfully:
+  // positions are indices into the layout, so a mismatch silently maps bindings
+  // onto the wrong physical keys.
+  if (input.targetKeyCount > input.deviceKeyCount) {
+    checks.push({
+      id: "key-count",
+      level: "blocked",
+      message:
+        "This keymap has {{target}} keys per layer but the keyboard has {{device}}.",
+      params: { target: input.targetKeyCount, device: input.deviceKeyCount },
+    });
+  } else if (
+    input.targetKeyCount > 0 &&
+    input.targetKeyCount < input.deviceKeyCount
+  ) {
+    checks.push({
+      id: "key-count-partial",
+      level: "warning",
+      message:
+        "This keymap covers {{target}} of the keyboard's {{device}} keys. The rest are left unchanged.",
+      params: { target: input.targetKeyCount, device: input.deviceKeyCount },
+    });
+  }
+
+  // The adapter adds layers as needed, but firmware can refuse — and that
+  // failure would land mid-write, so warn rather than discover it there.
+  const layersNeeded = maxLayerIndex(input.diff) + 1;
+  if (layersNeeded > input.deviceLayerCount) {
+    checks.push({
+      id: "layer-count",
+      level: "warning",
+      message:
+        "Writing needs {{needed}} layers; the keyboard has {{device}}. The missing ones will be added.",
+      params: { needed: layersNeeded, device: input.deviceLayerCount },
+    });
+  }
+
+  // A different physical layout usually means the bindings are ordered for
+  // different key positions. Not provably wrong, so it warns.
+  if (
+    input.deviceLayoutName &&
+    input.targetLayoutName &&
+    !layoutNamesMatch(input.deviceLayoutName, input.targetLayoutName)
+  ) {
+    checks.push({
+      id: "layout-name",
+      level: "warning",
+      message:
+        "This keymap was made for the {{target}} layout; the keyboard reports {{device}}.",
+      params: {
+        target: input.targetLayoutName,
+        device: input.deviceLayoutName,
+      },
+    });
+  }
+
+  return checks;
+}
+
+/** Whether any check blocks the write. */
+export function isBlocked(checks: PreflightCheck[]): boolean {
+  return checks.some((check) => check.level === "blocked");
+}
+
+/**
+ * Compares layout names loosely.
+ *
+ * The same layout is spelled inconsistently across firmware and catalog —
+ * "DYA2 ANSI", "dya2_ansi", "dya2-ansi" — and a false mismatch warning trains
+ * users to ignore the warnings that matter.
+ */
+export function layoutNamesMatch(left: string, right: string): boolean {
+  const normalize = (value: string) =>
+    value.toLowerCase().replace(/[^a-z0-9]+/g, "");
+  return normalize(left) === normalize(right);
+}

--- a/src/lib/abyss/jsonDiff.ts
+++ b/src/lib/abyss/jsonDiff.ts
@@ -1,0 +1,108 @@
+/**
+ * Builds the unified patch that backs the JSON diff viewer.
+ *
+ * Mirrors Keyboard Abyss's own diff editor so the same keymap reads the same
+ * way on both sides: a unified patch from `diff`, parsed by `react-diff-view`,
+ * rendered either inline or side by side, with a collapsed view that keeps a
+ * few lines of context around each change and an expanded view that shows the
+ * whole document.
+ */
+import { createTwoFilesPatch } from "diff";
+import { parseDiff, type FileData } from "react-diff-view";
+
+/** Lines of context kept around each change in the collapsed view. */
+export const COLLAPSED_CONTEXT_LINES = 3;
+
+/** `react-diff-view` calls side-by-side "split". */
+export type DiffViewMode = "unified" | "split";
+
+/** `createTwoFilesPatch` emits this separator line, which `parseDiff` chokes on. */
+const PATCH_SEPARATOR =
+  "===================================================================";
+
+/** Pretty-prints a value the way both sides of the diff should see it. */
+export function toDiffJson(value: unknown): string {
+  if (value === null || value === undefined) return "";
+  return `${JSON.stringify(value, null, 2)}\n`;
+}
+
+function countLines(source: string): number {
+  if (!source) return 0;
+  return source.split("\n").length;
+}
+
+/**
+ * Parses a two-file patch into the file model `react-diff-view` renders.
+ *
+ * The synthetic `diff --git` header is what makes `parseDiff` treat this as a
+ * real file rather than a bare hunk list.
+ */
+function buildFiles(
+  before: string,
+  after: string,
+  contextLines: number,
+): FileData[] {
+  const patch = createTwoFilesPatch(
+    "a/keymap.json",
+    "b/keymap.json",
+    before,
+    after,
+    "",
+    "",
+    { context: contextLines },
+  );
+
+  return parseDiff(
+    [
+      "diff --git a/keymap.json b/keymap.json",
+      "index 0000000..1111111 100644",
+      ...patch.split("\n").filter((line) => line !== PATCH_SEPARATOR),
+    ].join("\n"),
+    { nearbySequences: "zip" },
+  );
+}
+
+export interface JsonDiff {
+  /** A few lines of context around each change. */
+  collapsedFiles: FileData[];
+  /** The whole document, changes highlighted in place. */
+  expandedFiles: FileData[];
+  /** False when the two documents are identical. */
+  hasChanges: boolean;
+  /**
+   * Whether collapsing actually hides anything. When the documents are small
+   * enough that the collapsed view already shows every line, offering the
+   * toggle would be a control that does nothing.
+   */
+  hasHiddenContext: boolean;
+}
+
+/** Diffs two JSON documents, in both collapsed and expanded form. */
+export function buildJsonDiff(before: string, after: string): JsonDiff {
+  const beforeLines = countLines(before);
+  const afterLines = countLines(after);
+  // "Show everything" is just a context radius larger than the document.
+  const expandedContext = Math.max(beforeLines, afterLines, 1);
+
+  const collapsedFiles = buildFiles(before, after, COLLAPSED_CONTEXT_LINES);
+  const expandedFiles = buildFiles(before, after, expandedContext);
+  const hasChanges = collapsedFiles.some((file) => file.hunks.length > 0);
+
+  const collapsedLines = collapsedFiles.reduce(
+    (total, file) =>
+      total + file.hunks.reduce((sum, hunk) => sum + hunk.changes.length, 0),
+    0,
+  );
+  const expandedLines = expandedFiles.reduce(
+    (total, file) =>
+      total + file.hunks.reduce((sum, hunk) => sum + hunk.changes.length, 0),
+    0,
+  );
+
+  return {
+    collapsedFiles,
+    expandedFiles,
+    hasChanges,
+    hasHiddenContext: hasChanges && expandedLines > collapsedLines,
+  };
+}

--- a/src/lib/abyss/previewLayout.ts
+++ b/src/lib/abyss/previewLayout.ts
@@ -1,0 +1,81 @@
+/**
+ * Sizing helpers for the keymap preview.
+ *
+ * Kept out of the component file so fast refresh keeps working — a module that
+ * exports both components and plain functions is not refreshable, and this app
+ * is developed almost entirely through the dev server.
+ */
+
+/**
+ * Smallest scale worth rendering. Below this the legends stop being readable,
+ * so a very wide board scrolls instead of shrinking into illegibility.
+ */
+export const MIN_PREVIEW_SCALE = 0.45;
+
+/**
+ * Scale that fits `naturalWidth` into `availableWidth`, never enlarging.
+ *
+ * Returns 1 when the available width is unknown (0), which is what happens
+ * before the first measurement and in environments without layout — better to
+ * render at full size for a frame than to collapse to nothing.
+ */
+export function previewScale(
+  naturalWidth: number,
+  availableWidth: number,
+): number {
+  if (naturalWidth <= 0 || availableWidth <= 0) return 1;
+  return Math.max(
+    MIN_PREVIEW_SCALE,
+    Math.min(1, availableWidth / naturalWidth),
+  );
+}
+
+/** Key geometry as it arrives from the Abyss layout document. */
+export interface RawPreviewPosition {
+  x: number;
+  y: number;
+  w?: number;
+  h?: number;
+  r?: number;
+  rx?: number;
+  ry?: number;
+}
+
+/**
+ * Above this, the geometry cannot plausibly be in key units — no keyboard is
+ * 40 units wide — so it is being reported in hundredths.
+ */
+const CENTI_UNIT_THRESHOLD = 40;
+
+/**
+ * Converts key geometry to key units, whichever unit it arrived in.
+ *
+ * The KeyboardHub layout schema documents `x`/`y`/`w`/`h` in key units, but the
+ * ZMK adapter copies ZMK Studio's `KeyPhysicalAttrs` through verbatim, and those
+ * are hundredths of a key unit — a 1u key is `width: 100`. Taking the schema at
+ * its word rendered the preview a hundred times too large.
+ *
+ * Detected from the data rather than hardcoded, so this keeps working if the
+ * adapter is fixed upstream to match its own schema.
+ */
+export function normalizePositions(
+  positions: RawPreviewPosition[],
+): RawPreviewPosition[] {
+  if (positions.length === 0) return positions;
+  const extent = Math.max(
+    ...positions.map((position) => position.x + (position.w ?? 1)),
+  );
+  if (extent <= CENTI_UNIT_THRESHOLD) return positions;
+
+  const scale = 1 / 100;
+  return positions.map((position) => ({
+    x: position.x * scale,
+    y: position.y * scale,
+    w: position.w === undefined ? undefined : position.w * scale,
+    h: position.h === undefined ? undefined : position.h * scale,
+    // Rotation stays in centidegrees either way; only lengths are affected.
+    r: position.r,
+    rx: position.rx === undefined ? undefined : position.rx * scale,
+    ry: position.ry === undefined ? undefined : position.ry * scale,
+  }));
+}

--- a/src/lib/abyss/previewLayout.ts
+++ b/src/lib/abyss/previewLayout.ts
@@ -79,3 +79,20 @@ export function normalizePositions(
     ry: position.ry === undefined ? undefined : position.ry * scale,
   }));
 }
+
+/**
+ * Whether the primary pointer cannot hover — i.e. a touch screen.
+ *
+ * Radix's Tooltip opens on hover and focus, neither of which a tap produces, so
+ * on touch the key detail has to come from a click-driven Popover instead.
+ * Read once at call time rather than tracked: a device does not change pointer
+ * type mid-session in any way worth re-rendering for.
+ */
+export function isCoarsePointer(): boolean {
+  if (typeof window === "undefined" || !window.matchMedia) return false;
+  try {
+    return window.matchMedia("(pointer: coarse)").matches;
+  } catch {
+    return false;
+  }
+}

--- a/src/lib/abyss/zmkConnectionAdapter.ts
+++ b/src/lib/abyss/zmkConnectionAdapter.ts
@@ -19,25 +19,21 @@ import type { RpcConnection } from "@zmkfirmware/zmk-studio-ts-client";
 import type { ConnectionMethod } from "../../components/DeviceConnection";
 
 /**
- * Accessing this throws rather than returning `undefined`.
+ * Placeholder for the transport the adapter is not allowed to touch.
  *
  * `transportConnection` is required by `ZmkConnection`, but DYA Studio owns the
  * transport and must not hand it over — the adapter closing it would kill the
- * user's session. Nothing in the adapter's load or writeback paths reads it
- * today; if that changes, this turns a silent `undefined` dereference into an
- * obvious failure naming the cause.
+ * user's session. Nothing in the adapter's load or writeback paths reads it.
+ *
+ * This was briefly a Proxy that threw on any access, to turn a future misuse
+ * into a loud error. That broke the app: the loaded connection is stored in
+ * React state, and something in the render path introspects state objects, so
+ * the throw fired during rendering and silently froze the whole subtree —
+ * every button on the page stopped responding after the first device read.
+ * A plain frozen object is worth more than a tripwire that maims the host.
  */
-const FORBIDDEN_TRANSPORT = new Proxy(
+const UNAVAILABLE_TRANSPORT = Object.freeze(
   {},
-  {
-    get(_target, property) {
-      throw new Error(
-        `The Abyss ZMK adapter read connection.transportConnection.${String(
-          property,
-        )}, but DYA Studio owns the transport and does not expose it.`,
-      );
-    },
-  },
 ) as ZmkConnection["transportConnection"];
 
 /** Maps a DYA Studio connection method onto the adapter's transport label. */
@@ -78,7 +74,7 @@ export function createAbyssZmkConnection({
     rpcConnection,
     // The adapter never aborts this; DYA Studio owns the connection lifecycle.
     rpcAbortController: new AbortController(),
-    transportConnection: FORBIDDEN_TRANSPORT,
+    transportConnection: UNAVAILABLE_TRANSPORT,
     notificationSource,
     // Disconnecting is the app's decision, not the adapter's.
     disconnect: () => {},

--- a/src/lib/abyss/zmkConnectionAdapter.ts
+++ b/src/lib/abyss/zmkConnectionAdapter.ts
@@ -1,0 +1,86 @@
+/**
+ * Adapts DYA Studio's live ZMK Studio connection into the shape
+ * `@keyboard-hub/adapter-zmk` expects.
+ *
+ * The adapter is built to own its connection: `zmkAdapter.connect()` opens a
+ * transport, creates the RPC connection, and hands back a `ZmkConnection`. DYA
+ * Studio already has all of that, and ZMK Studio permits one connection at a
+ * time — opening a second would mean disconnecting the user first. So we wrap
+ * what we have instead.
+ *
+ * This is the only module allowed to fabricate a `ZmkConnection`. Keeping the
+ * casts here means the rest of the app deals in the adapter's real types.
+ */
+import type {
+  ZmkConnection,
+  ZmkNotificationSource,
+} from "@keyboard-hub/adapter-zmk";
+import type { RpcConnection } from "@zmkfirmware/zmk-studio-ts-client";
+import type { ConnectionMethod } from "../../components/DeviceConnection";
+
+/**
+ * Accessing this throws rather than returning `undefined`.
+ *
+ * `transportConnection` is required by `ZmkConnection`, but DYA Studio owns the
+ * transport and must not hand it over — the adapter closing it would kill the
+ * user's session. Nothing in the adapter's load or writeback paths reads it
+ * today; if that changes, this turns a silent `undefined` dereference into an
+ * obvious failure naming the cause.
+ */
+const FORBIDDEN_TRANSPORT = new Proxy(
+  {},
+  {
+    get(_target, property) {
+      throw new Error(
+        `The Abyss ZMK adapter read connection.transportConnection.${String(
+          property,
+        )}, but DYA Studio owns the transport and does not expose it.`,
+      );
+    },
+  },
+) as ZmkConnection["transportConnection"];
+
+/** Maps a DYA Studio connection method onto the adapter's transport label. */
+function transportOf(method: ConnectionMethod): ZmkConnection["transport"] {
+  return method === "ble" ? "ble" : "usb";
+}
+
+export interface AbyssZmkConnectionInput {
+  /** The live RPC connection from `ZMKAppContext`. */
+  rpcConnection: RpcConnection;
+  /** Device name from the Studio handshake, shown in import previews. */
+  deviceName?: string;
+  /** How the user connected. Only affects the adapter's display label. */
+  method: ConnectionMethod;
+  /**
+   * Fan-out over notifications the app already receives.
+   *
+   * Required in practice: `notification_readable` allows one reader and
+   * `useZMKApp` holds it for the lifetime of the connection, so without this
+   * the adapter's own `getReader()` throws, `loadZmkPreview` swallows it, and
+   * every trackball / runtime input processor silently disappears from the
+   * import.
+   */
+  notificationSource?: ZmkNotificationSource;
+}
+
+/** Wraps DYA Studio's connection so the Abyss adapter can read and write it. */
+export function createAbyssZmkConnection({
+  rpcConnection,
+  deviceName,
+  method,
+  notificationSource,
+}: AbyssZmkConnectionInput): ZmkConnection {
+  return {
+    method: "zmk",
+    transport: transportOf(method),
+    deviceName,
+    rpcConnection,
+    // The adapter never aborts this; DYA Studio owns the connection lifecycle.
+    rpcAbortController: new AbortController(),
+    transportConnection: FORBIDDEN_TRANSPORT,
+    notificationSource,
+    // Disconnecting is the app's decision, not the adapter's.
+    disconnect: () => {},
+  };
+}

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -16,6 +16,7 @@
  * and bump `NOTICE_VERSION` in `connectionNoticeStorage.ts` so users re-consent.
  */
 import type { ConnectionMethod } from "../components/DeviceConnection";
+import type { AbyssFailReason } from "./abyss/abyssErrors";
 
 /** Coarse, non-identifying bucket for a failed connection attempt. */
 export type ConnectFailReason =
@@ -58,6 +59,36 @@ export function trackConnectFailed(
   reason: ConnectFailReason,
 ): void {
   trackEvent("keyboard_connect_failed", { method, reason });
+}
+
+/** Keyboard Abyss operations worth counting in aggregate. */
+export type AbyssOperation = "login" | "export" | "import";
+
+/**
+ * A Keyboard Abyss operation succeeded.
+ *
+ * `sections` is the sorted list of data sections the user ticked (e.g.
+ * `"combos,keymap"`) — a UI preference, not configuration data. Nothing that
+ * identifies the keyboard, the keymap, or the Abyss account is sent: no
+ * keyboard slug, no keymap id, no Abyss user id, and no change counts (which
+ * would leak the shape of the keyboard).
+ */
+export function trackAbyssOperation(
+  operation: AbyssOperation,
+  params?: { mode?: "new" | "update"; sections?: string },
+): void {
+  trackEvent("abyss_operation", { operation, ...params });
+}
+
+/**
+ * A Keyboard Abyss operation failed. Only a coarse reason bucket is sent --
+ * never the API response body, which can echo request data back.
+ */
+export function trackAbyssFailed(
+  operation: AbyssOperation,
+  reason: AbyssFailReason,
+): void {
+  trackEvent("abyss_failed", { operation, reason });
 }
 
 /**

--- a/src/lib/studioUnlock.ts
+++ b/src/lib/studioUnlock.ts
@@ -90,6 +90,15 @@ export function isStudioUnlockError(x: unknown): boolean {
     if (meta?.simpleError === ErrorConditions.UNLOCK_REQUIRED) {
       return true;
     }
+    // The Abyss ZMK adapter reports a locked device with its own
+    // `FirmwareLockedError`. Matched by shape rather than imported, both to keep
+    // this module dependency-free and because the adapter's own
+    // `isFirmwareLockedError` also matches any message merely containing
+    // "locked" — too loose to route into the unlock modal.
+    const named = x as { code?: unknown; name?: unknown };
+    if (named.code === "LOCKED" || named.name === "FirmwareLockedError") {
+      return true;
+    }
   }
   return false;
 }

--- a/src/lib/viteEnv.ts
+++ b/src/lib/viteEnv.ts
@@ -34,3 +34,24 @@ export const RPC_LOG_ENABLED: boolean =
 export const BUILD_LABEL: string | null =
   (import.meta.env.VITE_BUILD_LABEL as string | undefined) ||
   (import.meta.env.DEV ? "Dev" : null);
+
+/**
+ * OAuth client id issued by Keyboard Abyss (Settings > Developer), or `""` when
+ * the build was produced without one.
+ *
+ * The Import/Export tab is hidden entirely when this is empty — a local
+ * `vite dev` without a `.env` should not show a tab whose only action is a login
+ * that cannot succeed. Set `VITE_ABYSS_CLIENT_ID` in the build environment
+ * (`.github/workflows/test.yml` and `.github/workflows/release.yml`) to enable
+ * it.
+ */
+export const ABYSS_CLIENT_ID: string =
+  (import.meta.env.VITE_ABYSS_CLIENT_ID as string | undefined) || "";
+
+/**
+ * Base URL of the Keyboard Abyss instance to talk to. Empty means "use the
+ * library default" (https://abyss.keyboard-hub.com). Overridden by
+ * `VITE_ABYSS_BASE_URL` when pointing a build at a local or staging Abyss.
+ */
+export const ABYSS_BASE_URL: string =
+  (import.meta.env.VITE_ABYSS_BASE_URL as string | undefined) || "";

--- a/src/pages/AbyssCallbackPage.tsx
+++ b/src/pages/AbyssCallbackPage.tsx
@@ -1,0 +1,136 @@
+/**
+ * Standalone route Keyboard Abyss redirects back to after consent.
+ *
+ * It runs in one of two very different situations and has to work out which:
+ *
+ * - **Popup** (the normal case): the tab that started the login claims the
+ *   callback, exchanges the code itself, and closes this window. All this page
+ *   does is relay the URL and get out of the way. It must *not* exchange the
+ *   code — the PKCE verifier is in the opener's `sessionStorage`, and the code
+ *   is single-use.
+ * - **Full-page redirect** (popup blocker fallback): nobody answers the relay,
+ *   so this document owns the exchange and then navigates back into the app.
+ *
+ * See {@link relayAbyssCallback} for how the two are told apart. Because this
+ * route renders before the connection gate in `App.tsx`, it works with no
+ * keyboard connected — which is always the case after a full-page redirect.
+ */
+import { useEffect, useRef, useState } from "react";
+import { IconCheck, IconAlertTriangle } from "@tabler/icons-react";
+import DyaLogo from "../assets/dya.svg?react";
+import { useLanguage } from "../hooks/useLanguage";
+import { LoadingIndicator } from "../components/LoadingIndicator";
+import { getAbyssClient } from "../lib/abyss/abyssClient";
+import {
+  IMPORT_EXPORT_PATH,
+  relayAbyssCallback,
+  takeReturnPath,
+} from "../lib/abyss/abyssOAuth";
+import { abyssErrorMessageKey } from "../lib/abyss/abyssErrors";
+
+type CallbackState =
+  | { phase: "working" }
+  /** This document was the popup; the opener took over. */
+  | { phase: "relayed" }
+  | { phase: "error"; messageKey: string };
+
+export function AbyssCallbackPage({
+  onDone,
+}: {
+  /** Navigates back into the SPA, replacing history so Back never returns to a
+   * spent authorization code. */
+  onDone: (path: string) => void;
+}) {
+  const { t } = useLanguage();
+  const [state, setState] = useState<CallbackState>({ phase: "working" });
+  // React runs effects twice in development StrictMode; exchanging the same
+  // single-use code twice would fail the second time and show a false error.
+  //
+  // Deliberately no "cancelled" flag paired with this: the cleanup from
+  // StrictMode's first pass would abort the one run that actually started, and
+  // the second pass short-circuits here — leaving the page stuck on the
+  // spinner forever. Settling state after unmount is harmless.
+  const startedRef = useRef(false);
+
+  useEffect(() => {
+    if (startedRef.current) return;
+    startedRef.current = true;
+
+    void (async () => {
+      const href = window.location.href;
+      const claimed = await relayAbyssCallback(href);
+      if (claimed) {
+        setState({ phase: "relayed" });
+        try {
+          window.close();
+        } catch {
+          // Some browsers refuse to close a window they did not open; the
+          // "you can close this" message below covers that.
+        }
+        return;
+      }
+
+      const client = getAbyssClient();
+      if (!client) {
+        setState({
+          phase: "error",
+          messageKey: "Abyss is not configured for this build.",
+        });
+        return;
+      }
+      try {
+        await client.handleRedirectCallback(href);
+        onDone(takeReturnPath());
+      } catch (caught) {
+        setState({ phase: "error", messageKey: abyssErrorMessageKey(caught) });
+      }
+    })();
+  }, [onDone]);
+
+  return (
+    <div className="fixed inset-0 z-40 overflow-auto bg-[var(--color-bg)]">
+      <div className="absolute inset-0 bg-gradient-cyber opacity-20 pointer-events-none" />
+      <div className="relative min-h-full flex items-center justify-center p-6">
+        <div className="glass-card p-8 w-full max-w-md text-center">
+          <DyaLogo className="w-10 h-10 mx-auto mb-6 [&_polygon]:fill-[var(--color-text)]" />
+
+          {state.phase === "working" && (
+            <LoadingIndicator label={t("Completing Abyss sign-in...")} />
+          )}
+
+          {state.phase === "relayed" && (
+            <>
+              <div className="flex justify-center mb-3 text-[var(--color-neon)]">
+                <IconCheck size={24} />
+              </div>
+              <h1 className="text-base font-medium text-[var(--color-text)] mb-2">
+                {t("Signed in to Abyss")}
+              </h1>
+              <p className="text-sm text-[var(--color-text-muted)]">
+                {t("You can close this window.")}
+              </p>
+            </>
+          )}
+
+          {state.phase === "error" && (
+            <>
+              <div className="flex justify-center mb-3 text-red-400">
+                <IconAlertTriangle size={24} />
+              </div>
+              <h1 className="text-base font-medium text-[var(--color-text)] mb-2">
+                {t("Abyss sign-in failed")}
+              </h1>
+              <p className="text-sm text-red-400 mb-6">{t(state.messageKey)}</p>
+              <button
+                className="btn-ghost border border-[var(--color-border)] text-sm"
+                onClick={() => onDone(IMPORT_EXPORT_PATH)}
+              >
+                {t("Back to DYA Studio")}
+              </button>
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/ImportExportPage.tsx
+++ b/src/pages/ImportExportPage.tsx
@@ -30,6 +30,13 @@ export function ImportExportPage() {
   const device = useAbyssDevice();
   const exporter = useAbyssExport(device.loaded, device.resolved);
   const importer = useAbyssImport(device);
+  // The catalog slug is not in the resolveLayout response, so take it from the
+  // keymaps listed for this keyboard — the device snapshot's own slug is
+  // derived from the ZMK device name and does not identify the catalog entry.
+  const keyboardSlug =
+    importer.keymaps.find((keymap) => keymap.keyboardSlug ?? keymap.keyboard)
+      ?.keyboardSlug ??
+    importer.keymaps.find((keymap) => keymap.keyboard?.slug)?.keyboard?.slug;
 
   return (
     <div className="p-6 h-full overflow-auto">
@@ -57,7 +64,7 @@ export function ImportExportPage() {
 
           {auth.isAuthenticated && (
             <>
-              <DeviceSnapshotCard device={device} />
+              <DeviceSnapshotCard device={device} keyboardSlug={keyboardSlug} />
               <ExportSection device={device} exporter={exporter} />
               <ImportSection device={device} importer={importer} />
             </>

--- a/src/pages/ImportExportPage.tsx
+++ b/src/pages/ImportExportPage.tsx
@@ -9,6 +9,7 @@
  * `@keyboard-hub/adapter-common`; this page is the wiring and the UI around
  * them.
  */
+import { useState } from "react";
 import { IconCloudUpload } from "@tabler/icons-react";
 import { useLanguage } from "../hooks/useLanguage";
 import { useAbyssAuth } from "../hooks/useAbyssAuth";
@@ -30,6 +31,7 @@ export function ImportExportPage() {
   const device = useAbyssDevice();
   const exporter = useAbyssExport(device.loaded, device.resolved);
   const importer = useAbyssImport(device);
+  const [direction, setDirection] = useState<"export" | "import">("export");
   // The catalog slug is not in the resolveLayout response, so take it from the
   // keymaps listed for this keyboard — the device snapshot's own slug is
   // derived from the ZMK device name and does not identify the catalog entry.
@@ -65,8 +67,41 @@ export function ImportExportPage() {
           {auth.isAuthenticated && (
             <>
               <DeviceSnapshotCard device={device} keyboardSlug={keyboardSlug} />
-              <ExportSection device={device} exporter={exporter} />
-              <ImportSection device={device} importer={importer} />
+              {/*
+                Export and import are alternatives, not a checklist. Stacking
+                both cards meant scrolling past a long export form to reach
+                import, and the diff previews made that worse. One card, one
+                direction at a time.
+              */}
+              <div className="glass-card p-6">
+                <div
+                  role="tablist"
+                  aria-label={t("Import/Export")}
+                  className="flex gap-1 mb-5"
+                >
+                  {(["export", "import"] as const).map((value) => (
+                    <button
+                      key={value}
+                      role="tab"
+                      aria-selected={direction === value}
+                      onClick={() => setDirection(value)}
+                      className={`px-4 py-2 rounded-lg text-sm transition-colors border ${
+                        direction === value
+                          ? "border-[var(--color-electric)] bg-[var(--color-electric)]/15 text-[var(--color-electric)]"
+                          : "border-[var(--color-border)] text-[var(--color-text-muted)] hover:text-[var(--color-text)]"
+                      }`}
+                    >
+                      {value === "export" ? t("Export") : t("Import")}
+                    </button>
+                  ))}
+                </div>
+
+                {direction === "export" ? (
+                  <ExportSection device={device} exporter={exporter} />
+                ) : (
+                  <ImportSection device={device} importer={importer} />
+                )}
+              </div>
             </>
           )}
         </div>

--- a/src/pages/ImportExportPage.tsx
+++ b/src/pages/ImportExportPage.tsx
@@ -1,0 +1,96 @@
+/**
+ * Import/Export tab — moves keymaps between the connected keyboard and
+ * Keyboard Abyss (https://abyss.keyboard-hub.com).
+ *
+ * Sign-in lives here; the export and import sections below it are gated on it.
+ *
+ * The device-side halves (reading the keyboard into KeyboardHub JSON, diffing
+ * an Abyss keymap against it, and writing the diff back) are provided by the
+ * `@keyboard-hub/adapter-zmk` / `@keyboard-hub/adapter-common` packages, which
+ * are not published to npm yet. Until they are, those sections render an
+ * explicit notice rather than a half-working flow.
+ */
+import { IconCloudUpload } from "@tabler/icons-react";
+import { useLanguage } from "../hooks/useLanguage";
+import { useAbyssAuth } from "../hooks/useAbyssAuth";
+import { AbyssAccountCard } from "../components/importExport/AbyssAccountCard";
+
+/** Route path for the Import/Export tab. Must equal the tab id in `App.tsx`. */
+export const IMPORT_EXPORT_TAB_ID = "import-export";
+
+function PendingSection({
+  title,
+  description,
+}: {
+  title: string;
+  description: string;
+}) {
+  const { t } = useLanguage();
+  return (
+    <div className="glass-card p-6">
+      <h3 className="text-sm font-medium text-[var(--color-text)] mb-2">
+        {title}
+      </h3>
+      <p className="text-sm text-[var(--color-text-muted)] mb-4">
+        {description}
+      </p>
+      <div className="p-4 rounded-lg bg-[var(--color-border)] border border-[var(--color-border-hover)]">
+        <p className="text-sm text-[var(--color-text-muted)]">
+          {t(
+            "Not available in this build yet — the Abyss keyboard adapter has not been released.",
+          )}
+        </p>
+      </div>
+    </div>
+  );
+}
+
+export function ImportExportPage() {
+  const { t } = useLanguage();
+  const auth = useAbyssAuth();
+
+  return (
+    <div className="p-6 h-full overflow-auto">
+      <div className="max-w-4xl mx-auto">
+        {/* Header */}
+        <div className="flex items-center gap-3 mb-8">
+          <div className="p-2 rounded-lg bg-[var(--color-electric)]/10 border border-[var(--color-electric)]/20">
+            <IconCloudUpload
+              size={24}
+              className="text-[var(--color-electric)]"
+            />
+          </div>
+          <div>
+            <h1 className="text-xl font-medium text-[var(--color-text)]">
+              {t("Import/Export")}
+            </h1>
+            <p className="text-sm text-[var(--color-text-muted)]">
+              {t("Sync keymaps with Keyboard Abyss")}
+            </p>
+          </div>
+        </div>
+
+        <div className="space-y-6">
+          <AbyssAccountCard auth={auth} />
+
+          {auth.isAuthenticated && (
+            <>
+              <PendingSection
+                title={t("Export")}
+                description={t(
+                  "Upload the connected keyboard's keymap to Abyss, either as a new keymap or as a new version of an existing one.",
+                )}
+              />
+              <PendingSection
+                title={t("Import")}
+                description={t(
+                  "Pick a compatible keymap from Abyss, review what would change, and write it to the connected keyboard.",
+                )}
+              />
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/ImportExportPage.tsx
+++ b/src/pages/ImportExportPage.tsx
@@ -13,7 +13,9 @@
 import { IconCloudUpload } from "@tabler/icons-react";
 import { useLanguage } from "../hooks/useLanguage";
 import { useAbyssAuth } from "../hooks/useAbyssAuth";
+import { useAbyssDevice } from "../hooks/useAbyssDevice";
 import { AbyssAccountCard } from "../components/importExport/AbyssAccountCard";
+import { DeviceSnapshotCard } from "../components/importExport/DeviceSnapshotCard";
 
 /** Route path for the Import/Export tab. Must equal the tab id in `App.tsx`. */
 export const IMPORT_EXPORT_TAB_ID = "import-export";
@@ -48,6 +50,8 @@ function PendingSection({
 export function ImportExportPage() {
   const { t } = useLanguage();
   const auth = useAbyssAuth();
+  // One snapshot shared by both sections — reading the device is expensive.
+  const device = useAbyssDevice();
 
   return (
     <div className="p-6 h-full overflow-auto">
@@ -75,6 +79,7 @@ export function ImportExportPage() {
 
           {auth.isAuthenticated && (
             <>
+              <DeviceSnapshotCard device={device} />
               <PendingSection
                 title={t("Export")}
                 description={t(

--- a/src/pages/ImportExportPage.tsx
+++ b/src/pages/ImportExportPage.tsx
@@ -4,11 +4,10 @@
  *
  * Sign-in lives here; the export and import sections below it are gated on it.
  *
- * The device-side halves (reading the keyboard into KeyboardHub JSON, diffing
- * an Abyss keymap against it, and writing the diff back) are provided by the
- * `@keyboard-hub/adapter-zmk` / `@keyboard-hub/adapter-common` packages, which
- * are not published to npm yet. Until they are, those sections render an
- * explicit notice rather than a half-working flow.
+ * Reading the keyboard, diffing an Abyss keymap against it, and writing the
+ * diff back are all handled by `@keyboard-hub/adapter-zmk` and
+ * `@keyboard-hub/adapter-common`; this page is the wiring and the UI around
+ * them.
  */
 import { IconCloudUpload } from "@tabler/icons-react";
 import { useLanguage } from "../hooks/useLanguage";
@@ -17,35 +16,12 @@ import { useAbyssDevice } from "../hooks/useAbyssDevice";
 import { AbyssAccountCard } from "../components/importExport/AbyssAccountCard";
 import { DeviceSnapshotCard } from "../components/importExport/DeviceSnapshotCard";
 import { ExportSection } from "../components/importExport/ExportSection";
+import { ImportSection } from "../components/importExport/ImportSection";
 import { useAbyssExport } from "../hooks/useAbyssExport";
+import { useAbyssImport } from "../hooks/useAbyssImport";
 
 /** Route path for the Import/Export tab. Must equal the tab id in `App.tsx`. */
 export const IMPORT_EXPORT_TAB_ID = "import-export";
-
-function PendingSection({
-  title,
-  description,
-}: {
-  title: string;
-  description: string;
-}) {
-  const { t } = useLanguage();
-  return (
-    <div className="glass-card p-6">
-      <h3 className="text-sm font-medium text-[var(--color-text)] mb-2">
-        {title}
-      </h3>
-      <p className="text-sm text-[var(--color-text-muted)] mb-4">
-        {description}
-      </p>
-      <div className="p-4 rounded-lg bg-[var(--color-border)] border border-[var(--color-border-hover)]">
-        <p className="text-sm text-[var(--color-text-muted)]">
-          {t("Not available yet — this is still being built.")}
-        </p>
-      </div>
-    </div>
-  );
-}
 
 export function ImportExportPage() {
   const { t } = useLanguage();
@@ -53,6 +29,7 @@ export function ImportExportPage() {
   // One snapshot shared by both sections — reading the device is expensive.
   const device = useAbyssDevice();
   const exporter = useAbyssExport(device.loaded, device.resolved);
+  const importer = useAbyssImport(device);
 
   return (
     <div className="p-6 h-full overflow-auto">
@@ -82,12 +59,7 @@ export function ImportExportPage() {
             <>
               <DeviceSnapshotCard device={device} />
               <ExportSection device={device} exporter={exporter} />
-              <PendingSection
-                title={t("Import")}
-                description={t(
-                  "Pick a compatible keymap from Abyss, review what would change, and write it to the connected keyboard.",
-                )}
-              />
+              <ImportSection device={device} importer={importer} />
             </>
           )}
         </div>

--- a/src/pages/ImportExportPage.tsx
+++ b/src/pages/ImportExportPage.tsx
@@ -16,6 +16,8 @@ import { useAbyssAuth } from "../hooks/useAbyssAuth";
 import { useAbyssDevice } from "../hooks/useAbyssDevice";
 import { AbyssAccountCard } from "../components/importExport/AbyssAccountCard";
 import { DeviceSnapshotCard } from "../components/importExport/DeviceSnapshotCard";
+import { ExportSection } from "../components/importExport/ExportSection";
+import { useAbyssExport } from "../hooks/useAbyssExport";
 
 /** Route path for the Import/Export tab. Must equal the tab id in `App.tsx`. */
 export const IMPORT_EXPORT_TAB_ID = "import-export";
@@ -38,9 +40,7 @@ function PendingSection({
       </p>
       <div className="p-4 rounded-lg bg-[var(--color-border)] border border-[var(--color-border-hover)]">
         <p className="text-sm text-[var(--color-text-muted)]">
-          {t(
-            "Not available in this build yet — the Abyss keyboard adapter has not been released.",
-          )}
+          {t("Not available yet — this is still being built.")}
         </p>
       </div>
     </div>
@@ -52,6 +52,7 @@ export function ImportExportPage() {
   const auth = useAbyssAuth();
   // One snapshot shared by both sections — reading the device is expensive.
   const device = useAbyssDevice();
+  const exporter = useAbyssExport(device.loaded, device.resolved);
 
   return (
     <div className="p-6 h-full overflow-auto">
@@ -80,12 +81,7 @@ export function ImportExportPage() {
           {auth.isAuthenticated && (
             <>
               <DeviceSnapshotCard device={device} />
-              <PendingSection
-                title={t("Export")}
-                description={t(
-                  "Upload the connected keyboard's keymap to Abyss, either as a new keymap or as a new version of an existing one.",
-                )}
-              />
+              <ExportSection device={device} exporter={exporter} />
               <PendingSection
                 title={t("Import")}
                 description={t(

--- a/src/pages/__tests__/AbyssCallbackPage.test.tsx
+++ b/src/pages/__tests__/AbyssCallbackPage.test.tsx
@@ -1,0 +1,99 @@
+/**
+ * Tests for the standalone OAuth callback route.
+ *
+ * The behaviour that matters is which document exchanges the single-use
+ * authorization code: the popup must relay and close, while a full-page
+ * redirect must exchange it itself.
+ */
+import { StrictMode } from "react";
+import { render as rtlRender, screen, waitFor } from "@testing-library/react";
+import { AbyssCallbackPage } from "../AbyssCallbackPage";
+
+// Rendered under StrictMode on purpose: main.tsx does, and StrictMode's
+// double-invoked effect is exactly what once left this page stuck on its
+// spinner forever.
+const render = (ui: React.ReactElement) =>
+  rtlRender(<StrictMode>{ui}</StrictMode>);
+
+jest.mock("../../lib/abyss/abyssClient");
+import { getAbyssClient } from "../../lib/abyss/abyssClient";
+const mockGetAbyssClient = getAbyssClient as jest.MockedFunction<
+  typeof getAbyssClient
+>;
+
+jest.mock("../../lib/abyss/abyssOAuth", () => ({
+  ...jest.requireActual("../../lib/abyss/abyssOAuth"),
+  relayAbyssCallback: jest.fn(),
+}));
+import { relayAbyssCallback } from "../../lib/abyss/abyssOAuth";
+const mockRelay = relayAbyssCallback as jest.MockedFunction<
+  typeof relayAbyssCallback
+>;
+
+function mockClient(handleRedirectCallback: jest.Mock) {
+  mockGetAbyssClient.mockReturnValue({
+    handleRedirectCallback,
+  } as unknown as ReturnType<typeof getAbyssClient>);
+}
+
+describe("AbyssCallbackPage", () => {
+  let closeSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    sessionStorage.clear();
+    mockGetAbyssClient.mockReset();
+    mockRelay.mockReset();
+    window.history.replaceState(null, "", "/oauth/callback?code=abc&state=xyz");
+    closeSpy = jest.spyOn(window, "close").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    closeSpy.mockRestore();
+  });
+
+  it("closes without exchanging the code when the opener claims it", async () => {
+    mockRelay.mockResolvedValue(true);
+    const handleRedirectCallback = jest.fn();
+    mockClient(handleRedirectCallback);
+    const onDone = jest.fn();
+
+    render(<AbyssCallbackPage onDone={onDone} />);
+
+    expect(
+      await screen.findByText("You can close this window."),
+    ).toBeInTheDocument();
+    // Exchanging here too would burn the single-use code and fail.
+    expect(handleRedirectCallback).not.toHaveBeenCalled();
+    expect(closeSpy).toHaveBeenCalled();
+    expect(onDone).not.toHaveBeenCalled();
+  });
+
+  it("exchanges the code itself and navigates back when nobody claims it", async () => {
+    mockRelay.mockResolvedValue(false);
+    const handleRedirectCallback = jest.fn().mockResolvedValue({});
+    mockClient(handleRedirectCallback);
+    const onDone = jest.fn();
+    sessionStorage.setItem("dya-studio-abyss-return-path", "/import-export");
+
+    render(<AbyssCallbackPage onDone={onDone} />);
+
+    await waitFor(() => expect(onDone).toHaveBeenCalledWith("/import-export"));
+    expect(handleRedirectCallback).toHaveBeenCalledWith(window.location.href);
+  });
+
+  it("shows a recoverable error when the exchange fails", async () => {
+    mockRelay.mockResolvedValue(false);
+    mockClient(jest.fn().mockRejectedValue(new Error("boom")));
+    const onDone = jest.fn();
+
+    render(<AbyssCallbackPage onDone={onDone} />);
+
+    expect(await screen.findByText("Abyss sign-in failed")).toBeInTheDocument();
+    expect(
+      screen.getByText("Something went wrong talking to Abyss."),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Back to DYA Studio" }),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/pages/__tests__/ImportExportPage.test.tsx
+++ b/src/pages/__tests__/ImportExportPage.test.tsx
@@ -1,0 +1,85 @@
+/**
+ * Tests for the Import/Export tab shell.
+ */
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ImportExportPage } from "../ImportExportPage";
+import type { UseAbyssAuthReturn } from "../../hooks/useAbyssAuth";
+
+jest.mock("../../hooks/useAbyssAuth");
+import { useAbyssAuth } from "../../hooks/useAbyssAuth";
+const mockUseAbyssAuth = useAbyssAuth as jest.MockedFunction<
+  typeof useAbyssAuth
+>;
+
+function auth(overrides: Partial<UseAbyssAuthReturn> = {}): UseAbyssAuthReturn {
+  return {
+    isConfigured: true,
+    isAuthenticated: false,
+    user: null,
+    isLoading: false,
+    error: null,
+    login: jest.fn(),
+    logout: jest.fn(),
+    ...overrides,
+  };
+}
+
+describe("ImportExportPage", () => {
+  beforeEach(() => {
+    mockUseAbyssAuth.mockReset();
+  });
+
+  it("shows only the sign-in prompt when signed out", () => {
+    mockUseAbyssAuth.mockReturnValue(auth());
+
+    render(<ImportExportPage />);
+
+    expect(
+      screen.getByRole("button", { name: /Sign in with Abyss/ }),
+    ).toBeInTheDocument();
+    // The export/import sections are gated on being signed in.
+    expect(screen.queryByText("Export")).not.toBeInTheDocument();
+    expect(screen.queryByText("Import")).not.toBeInTheDocument();
+  });
+
+  it("shows the account and both sections when signed in", () => {
+    mockUseAbyssAuth.mockReturnValue(
+      auth({
+        isAuthenticated: true,
+        user: { sub: "u1", username: "cormoran", displayName: "Cormoran" },
+      }),
+    );
+
+    render(<ImportExportPage />);
+
+    expect(screen.getByText("Cormoran")).toBeInTheDocument();
+    expect(screen.getByText("@cormoran")).toBeInTheDocument();
+    expect(screen.getByText("Export")).toBeInTheDocument();
+    expect(screen.getByText("Import")).toBeInTheDocument();
+  });
+
+  it("starts a login when the sign-in button is pressed", async () => {
+    const login = jest.fn();
+    mockUseAbyssAuth.mockReturnValue(auth({ login }));
+
+    render(<ImportExportPage />);
+    await userEvent.click(
+      screen.getByRole("button", { name: /Sign in with Abyss/ }),
+    );
+
+    expect(login).toHaveBeenCalled();
+  });
+
+  it("renders an auth error", () => {
+    mockUseAbyssAuth.mockReturnValue(
+      auth({ error: "Could not reach Abyss. Check your network connection." }),
+    );
+
+    render(<ImportExportPage />);
+
+    expect(
+      screen.getByText("Could not reach Abyss. Check your network connection."),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -4,11 +4,8 @@
 // learn more: https://github.com/testing-library/jest-dom
 import "@testing-library/jest-dom";
 import { TextEncoder, TextDecoder } from "util";
-import {
-  ReadableStream,
-  WritableStream,
-  TransformStream,
-} from "stream/web";
+import { ReadableStream, WritableStream, TransformStream } from "stream/web";
+import { BroadcastChannel } from "worker_threads";
 
 // Polyfill TextEncoder and TextDecoder for protobuf support
 global.TextEncoder = TextEncoder;
@@ -26,10 +23,20 @@ Object.defineProperty(navigator, "serial", {
 // a `TransformStream` to track packet activity. jsdom does not expose these
 // globals (and lacks `TransformStream` entirely), so pull the real ones from
 // Node's `stream/web` to get proper `pipeThrough` support.
-global.ReadableStream = ReadableStream as unknown as typeof global.ReadableStream;
-global.WritableStream = WritableStream as unknown as typeof global.WritableStream;
+global.ReadableStream =
+  ReadableStream as unknown as typeof global.ReadableStream;
+global.WritableStream =
+  WritableStream as unknown as typeof global.WritableStream;
 global.TransformStream =
   TransformStream as unknown as typeof global.TransformStream;
+
+// jsdom does not implement BroadcastChannel, which the Abyss OAuth popup uses
+// to hand the callback URL back to the tab that started the login. Node's
+// implementation delivers between channels in the same process, which is
+// exactly the opener/popup relationship the tests exercise. Production code
+// still guards on `typeof BroadcastChannel` for browsers without it.
+global.BroadcastChannel =
+  BroadcastChannel as unknown as typeof global.BroadcastChannel;
 
 // Mock window.matchMedia
 Object.defineProperty(window, "matchMedia", {

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -38,6 +38,19 @@ global.TransformStream =
 global.BroadcastChannel =
   BroadcastChannel as unknown as typeof global.BroadcastChannel;
 
+// jsdom implements no layout, so it has no ResizeObserver. Radix's floating
+// primitives (Popover, and anything else positioned against a trigger) construct
+// one unconditionally, and the keymap preview measures its own container with
+// one. A stub that never fires is enough: nothing under test depends on being
+// notified of a resize, only on the constructor existing.
+class ResizeObserverStub {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+global.ResizeObserver =
+  ResizeObserverStub as unknown as typeof global.ResizeObserver;
+
 // Mock window.matchMedia
 Object.defineProperty(window, "matchMedia", {
   writable: true,

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -10,6 +10,17 @@
 
     /* Bundler mode */
     "moduleResolution": "bundler",
+    /* Collapse @keyboard-hub/adapter-zmk's copy of the ZMK Studio client onto
+       the fork this app already uses, so `RpcConnection` is one type and
+       `call_rpc` one mutex. Mirrored in vite.config.ts and jest.config.ts. */
+    "paths": {
+      "@keyboard-hub/zmk-studio-ts-client": [
+        "./node_modules/@zmkfirmware/zmk-studio-ts-client/lib/index.d.ts"
+      ],
+      "@keyboard-hub/zmk-studio-ts-client/*": [
+        "./node_modules/@zmkfirmware/zmk-studio-ts-client/lib/*"
+      ]
+    },
     "allowImportingTsExtensions": true,
     "resolveJsonModule": true,
     "verbatimModuleSyntax": true,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -14,10 +14,26 @@ function htmlEnvVarReplacePlugin(env: Record<string, string>): Plugin {
   };
 }
 
+/**
+ * `@keyboard-hub/adapter-zmk` is built against its own copy of the ZMK Studio
+ * client, but `call_rpc` serializes through a module-level mutex. Two copies
+ * means one `RpcConnection` guarded by two independent mutexes, and concurrent
+ * calls corrupt the shared request/response streams. The two clients are the
+ * same upstream with identical wire types, so collapse them onto the fork DYA
+ * Studio already uses.
+ *
+ * Mirrored in `tsconfig.app.json` (`paths`) and `jest.config.ts`
+ * (`moduleNameMapper`) — all three must agree.
+ */
+const ZMK_STUDIO_CLIENT_ALIAS = {
+  "@keyboard-hub/zmk-studio-ts-client": "@zmkfirmware/zmk-studio-ts-client",
+};
+
 // https://vite.dev/config/
 export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd(), "VITE_");
   return {
+    resolve: { alias: ZMK_STUDIO_CLIENT_ALIAS },
     plugins: [
       tailwindcss(),
       react({


### PR DESCRIPTION
## Description

Groundwork for syncing keymaps with [Keyboard Abyss](https://abyss.keyboard-hub.com): a new top-level **Import/Export** tab, an OAuth 2.0 + PKCE sign-in, and the standalone `/oauth/callback` route the redirect lands on.

### What is *not* here

The export and import sections themselves. They need `@keyboard-hub/adapter-zmk` and `@keyboard-hub/adapter-common` for the ZMK RPC ↔ KeyboardHub JSON conversion and the writeback diff, and **those packages are not published to npm**. Rather than ship a half-working flow, both sections render an explicit "not available in this build yet" notice.

Blockers on the `cormoran/keyboard-abyss` side before the rest can land. **All of these are addressed by cormoran/keyboard-abyss#508.**

1. `adapter-zmk` / `adapter-common` are `"private": true`, as are the transitive deps `@keyboard-hub/zmk-studio-ts-client` and `@keyboard-hub/keycode-preview-zmk`.
2. `adapter-zmk` imports adapter-common by workspace-relative path (`"../../adapter-common/src"`, 20+ sites) rather than by package specifier.
3. ~~`main`/`types` point at raw `./src/index.ts`, so this repo's `tsc -b` rejects the `export namespace` in the generated protobuf code under `erasableSyntaxOnly`.~~ **Correction: this is not real.** TypeScript does not apply `erasableSyntaxOnly` to files under `node_modules`, verified by type-checking that exact generated file through this repo's config. The adapter packages can keep the raw-TypeScript shape every already-published `@keyboard-hub` package uses. The real packaging gap turned out to be that `zmk-studio-ts-client` kept `@types/web-bluetooth` and `@types/w3c-web-serial` as devDependencies, which breaks any consumer that type-checks its sources.
4. `adapter-zmk/src/connection/custom-rpc.ts` grabs `connection.notification_readable.getReader()`, but `useZMKApp` already holds a permanent reader on that stream. The conflicting call is swallowed by a `.catch()`, so trackball / input-processor modules would silently vanish from every import.

Also worth flagging for whoever does that work: `@zmkfirmware/zmk-studio-ts-client` has a **module-level `const rpcMutex = new Mutex()`**. If the adapter ships its own copy of the client, one `RpcConnection` ends up guarded by two mutexes and the streams deadlock — so `@keyboard-hub/zmk-studio-ts-client` should be aliased to this repo's copy (vite + tsconfig + jest) and declared a peer dependency upstream.

### Why a popup instead of a plain redirect

The Import/Export tab only renders while a keyboard is connected, so the user is *by construction* connected when they press sign-in. A full-page navigation to Abyss tears down the Web Serial / WebUSB / BLE session — and on BLE they would have to re-pick the device from the browser picker afterwards.

The popup hands the callback URL back over a `BroadcastChannel`, which survives `Cross-Origin-Opener-Policy` severing `window.opener`. Only the tab that *started* the login answers, and it proves that by matching the OAuth `state` it generated: the PKCE verifier lives in that tab's `sessionStorage`, so any other open DYA Studio tab would fail the exchange. That acknowledgement doubles as how the callback page tells which mode it is in — acknowledged means "I am the popup, relay and close", silence means "I am a popup-blocker fallback, exchange the code myself".

Tokens go in `sessionStorage`, so a sign-in lasts until the tab is closed.

### Notable fix along the way

`AppContent` canonicalizes any pathname that is not a tab back to `/`. `/oauth/callback` is such a pathname, so the rewrite discarded `?code=&state=` before the callback page could read it — a failure that only surfaces as "sign-in silently does nothing". Excluded it the same way the release-notes route is, with a regression test in `src/__tests__/App.test.tsx`.

### Test infrastructure

A few gaps had to be closed to cover any of this:

- jsdom has no `BroadcastChannel`; Node's delivers between channels in the same process, which is exactly the opener/popup relationship under test.
- `*.svg?react` imports are React components, so they need a component stub rather than the string one used for other assets. (Nothing rendered `AppLayout` in tests before, so this had never come up.)
- The `viteEnv` module mapper only matched `./viteEnv`, missing importers outside `src/lib`.
- `@keyboard-hub/abyss-client` publishes untranspiled ESM TypeScript with only `types` and `import` export conditions, which the CommonJS runtime can neither resolve nor execute. It is stubbed for tests and exercised by the Vite build.

`AbyssCallbackPage` is rendered under `StrictMode` in its tests on purpose: the double-invoked effect once cancelled the only run that started and left the page stuck on its spinner forever. Browser verification caught that one.

## Reviewer notes

- **`VITE_ABYSS_CLIENT_ID` must be set as a repo secret.** Without it `isAbyssConfigured()` is false and the tab is not registered at all, which is deliberate — its only entry point would be a sign-in that cannot succeed.
- PR preview deployments get a fresh origin per commit, so their `redirect_uri` will not match a statically registered one. Either register a pattern on the OAuth client or accept that Abyss is prod/dev-only.
- Verified end to end in demo mode: the authorize URL is built correctly (`/oauth/authorize`, S256 challenge, all four scopes, `redirect_uri = origin + /oauth/callback`), and the PKCE transaction lands in `sessionStorage` rather than `localStorage`.
- Nothing keymap-related is sent to analytics — `trackAbyssOperation` carries only the operation, the new/update mode, and which data sections were ticked.
- Unrelated pre-existing bug found while verifying: switching between top-level tabs leaves the new tab's content area blank until reload. Reproduced on the Settings tab with this feature's tab disabled entirely, so it is not from this change. Looks like the `AnimatePresence mode="wait"` interaction in `TabNavigation` / `PageTransition`.

## Release notes

- [x] Added an `upcoming` release notes entry, or this change is internal-only

## CLA (Contributor License Agreement)

By submitting this pull request, I agree that my contributions
are licensed under the project's current license.

I also grant the maintainer(s) of this project the right to relicense
my contributions under any license, for use in future versions of the project.
This does not affect the license of any previously released versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

