### PR TITLE
feat(tabs): keep inactive tabs mounted so their data survives a switch

### DIFF
--- a/e2e/renode/tests/dya2/keymap.spec.ts
+++ b/e2e/renode/tests/dya2/keymap.spec.ts
@@ -7,8 +7,8 @@ import { connectDya2 } from "./dya2.helpers";
 //
 // This spec proves that path end-to-end against the REAL dya2 firmware in
 // Renode: the keymap renders (named layers + per-key behaviors), then a single
-// simple-keypress binding is edited, saved to flash, re-read after a tab
-// round-trip, and finally REVERTED so the device is left exactly as found.
+// simple-keypress binding is edited, saved to flash, re-read from the device via
+// the Reload button, and finally REVERTED so the device is left exactly as found.
 //
 // Edit target: `&kp J` is a UNIQUE single-letter keypress on the Base layer
 // (this split layout duplicates Y/G/H/B, so those are avoided). It is reassigned
@@ -19,10 +19,17 @@ import { connectDya2 } from "./dya2.helpers";
 const ORIG_KEY = "J";
 const NEW_KEY = "F13";
 
+// Tab panels stay mounted once visited, so scope every text match to the panel
+// that is currently showing — otherwise a `toHaveCount(0)` would also count
+// matches inside a hidden (but still rendered) tab.
+function activePanel(page: Page): Locator {
+  return page.locator('[role="tabpanel"][data-state="active"]');
+}
+
 // A key in the on-screen physical-keymap grid renders its binding's short label
 // (for `&kp J` that's just "J") in a span; match that label exactly.
 function keyLabel(page: Page, label: string): Locator {
-  return page.getByText(label, { exact: true });
+  return activePanel(page).getByText(label, { exact: true });
 }
 
 // Open the binding editor for the (unique) key currently showing `label`.
@@ -49,18 +56,23 @@ async function pickKeycode(
   await expect(page.getByRole("dialog")).toBeHidden();
 }
 
-// Force a device re-read: KeymapPage unmounts on tab switch, so leaving and
-// returning re-fetches the keymap from the firmware.
+// Force a device re-read. Tab panels keep their state across switches, so a tab
+// round-trip no longer re-fetches; the Keymap header's Reload button re-runs the
+// keymap load. It is disabled for the duration of the load, so waiting for
+// disabled -> enabled proves the assertions below read fresh device data.
 async function reReadKeymap(page: Page): Promise<void> {
-  await page.getByRole("tab", { name: "Home" }).click();
-  await page.getByRole("tab", { name: "Keymap" }).click();
+  const reload = page.getByRole("button", { name: "Reload", exact: true });
+  await expect(reload).toBeEnabled();
+  await reload.click();
+  await expect(reload).toBeDisabled();
+  await expect(reload).toBeEnabled({ timeout: 180_000 });
 }
 
 test("dya2 Keymap tab: renders the rich keymap and round-trips (+reverts) a binding edit", async ({
   page,
 }) => {
   // The dya2 two-machine wired-split emulation is slow, and this test loads the
-  // keymap three times (initial + two tab re-reads) plus two saves; be generous.
+  // keymap three times (initial + two reloads) plus two saves; be generous.
   test.setTimeout(480_000);
   if (process.env.E2E_DEBUG) {
     page.on("console", (m) => console.log(`PAGE [${m.type()}] ${m.text()}`));

--- a/e2e/renode/tests/dya2/settings.spec.ts
+++ b/e2e/renode/tests/dya2/settings.spec.ts
@@ -9,7 +9,7 @@ import { connectDya2 } from "./dya2.helpers";
 // This spec proves the zmk__settings path end-to-end against the REAL dya2
 // firmware in Renode: the central's activity settings load over the emulated
 // USB CDC, the Idle Timeout is changed to a new preset, the debounced
-// write-through persists it (setActivitySettings RPC), a tab round-trip re-reads
+// write-through persists it (setActivitySettings RPC), the Reload button re-reads
 // it from the device (loadAllSettings via getAllActivitySettings + activity
 // notifications), and finally it is REVERTED to the exact original value so the
 // device NVS is left exactly as found. Net-zero.
@@ -59,12 +59,17 @@ async function setIdleMinutes(page: Page, minutes: number): Promise<void> {
   await expect(menu).toBeHidden();
 }
 
-// Force a device re-read: SettingsPage unmounts on tab switch (TabNavigation
-// renders only the active tab's content), so leaving and returning re-runs
-// useSettings' load-on-ready effect and re-fetches from the firmware.
+// Force a device re-read. Tab panels keep their state across switches (they stay
+// mounted), so a tab round-trip no longer re-fetches; the Settings header's
+// Reload button re-runs loadAllSettings. It is disabled for the duration of the
+// load, so waiting for disabled -> enabled proves the assertions below read
+// fresh device data.
 async function reReadSettings(page: Page): Promise<void> {
-  await page.getByRole("tab", { name: "Home" }).click();
-  await page.getByRole("tab", { name: "Settings" }).click();
+  const reload = page.getByRole("button", { name: "Reload", exact: true });
+  await expect(reload).toBeEnabled();
+  await reload.click();
+  await expect(reload).toBeDisabled();
+  await expect(reload).toBeEnabled({ timeout: 180_000 });
 }
 
 // Preset minutes -> the exact label the dropdown renders for them, used to
@@ -78,8 +83,8 @@ const PRESET_LABEL: Record<number, string> = {
 test("dya2 Settings tab: reads, changes, persists and reverts the Idle Timeout (zmk__settings)", async ({
   page,
 }) => {
-  // Two-machine wired-split emulation is slow: initial load + one write + a tab
-  // round-trip re-read + a revert write + a final re-read. Be generous.
+  // Two-machine wired-split emulation is slow: initial load + one write + a
+  // re-read + a revert write + a final re-read. Be generous.
   test.setTimeout(360_000);
   if (process.env.E2E_DEBUG) {
     page.on("console", (m) => console.log(`PAGE [${m.type()}] ${m.text()}`));

--- a/e2e/renode/tests/dya2/trackball.spec.ts
+++ b/e2e/renode/tests/dya2/trackball.spec.ts
@@ -38,17 +38,18 @@ function xInvertSwitch(page: Page): Locator {
 }
 
 // Wait for a processor's settings to actually render on the (already-open)
-// Trackball tab. Waits out the initial load first, then, on each retry, bounces
-// Home <-> Trackball to re-run listProcessors so the device re-delivers the
-// processorChanged notifications that populate the processor.
+// Trackball tab. Waits out the initial load first, then, on each retry, clicks
+// the Processors card's reload button to re-run listProcessors so the device
+// re-delivers the processorChanged notifications that populate the processor.
+// (A Home <-> Trackball bounce no longer works: tab panels stay mounted, so
+// returning does not re-run the load.)
 async function waitForInvertSwitch(page: Page): Promise<Locator> {
   const sw = xInvertSwitch(page);
   let firstAttempt = true;
   await expect(async () => {
     if (!firstAttempt) {
-      await page.getByRole("tab", { name: "Home" }).click();
+      await page.getByRole("button", { name: "Reload processors" }).click();
       await page.waitForTimeout(1_500);
-      await page.getByRole("tab", { name: "Trackball" }).click();
     }
     firstAttempt = false;
     await expect(sw).toBeVisible({ timeout: 20_000 });

--- a/e2e/renode/tests/dya2/trackball.spec.ts
+++ b/e2e/renode/tests/dya2/trackball.spec.ts
@@ -64,12 +64,12 @@ async function openTrackball(page: Page): Promise<Locator> {
   return waitForInvertSwitch(page);
 }
 
-// Force a device re-read: TrackballPage unmounts on tab switch, so leaving and
-// returning re-fetches the processors from the firmware.
+// Force a device re-read. Tab panels keep their state across switches (they stay
+// mounted), so a tab round-trip no longer re-fetches; the Processors card's
+// reload button re-runs loadProcessors.
 async function reReadTrackball(page: Page): Promise<Locator> {
-  await page.getByRole("tab", { name: "Home" }).click();
+  await page.getByRole("button", { name: "Reload processors" }).click();
   await page.waitForTimeout(1_000);
-  await page.getByRole("tab", { name: "Trackball" }).click();
   return waitForInvertSwitch(page);
 }
 

--- a/e2e/renode/tests/official/keymap.spec.ts
+++ b/e2e/renode/tests/official/keymap.spec.ts
@@ -12,10 +12,17 @@ const RENODE_TESTER_KEYS = ["A", "B", "C", "D"];
 // an unambiguous proof that our edit took effect (and round-tripped).
 const NEW_KEYCODE = "F";
 
+// Tab panels stay mounted once visited, so scope every text match to the panel
+// that is currently showing — otherwise a `toHaveCount(0)` would also count
+// matches inside a hidden (but still rendered) tab.
+function activePanel(page: Page) {
+  return page.locator('[role="tabpanel"][data-state="active"]');
+}
+
 // A key in the on-screen physical-keymap grid renders its binding's short label
 // (for `&kp A` that's just "A") in a span. Match that label exactly.
 function keyLabel(page: Page, label: string) {
-  return page.getByText(label, { exact: true });
+  return activePanel(page).getByText(label, { exact: true });
 }
 
 test("dya-studio Keymap tab: renders the keymap + behaviors and round-trips a binding edit against official ZMK in Renode", async ({
@@ -93,13 +100,18 @@ test("dya-studio Keymap tab: renders the keymap + behaviors and round-trips a bi
   });
   await expect(saveButton).toBeDisabled();
 
-  // 7) ROUND-TRIP: leave the Keymap tab and come back. KeymapPage unmounts on
-  //    tab switch, so returning re-reads the keymap from the device — proving
-  //    the change was persisted to the firmware and read back (not just held in
-  //    the browser). The new keycode must still be there, and the four original
-  //    (minus the edited A) plus F must be consistent.
-  await page.getByRole("tab", { name: "Home" }).click();
-  await page.getByRole("tab", { name: "Keymap" }).click();
+  // 7) ROUND-TRIP: re-read the keymap from the device via the header's Reload
+  //    button (tab panels stay mounted, so leaving and returning no longer
+  //    re-fetches) — proving the change was persisted to the firmware and read
+  //    back (not just held in the browser). The Reload button is disabled while
+  //    the load runs, so disabled -> enabled marks the fresh data landing. The
+  //    new keycode must still be there, and the four original (minus the edited
+  //    A) plus F must be consistent.
+  const reload = page.getByRole("button", { name: "Reload", exact: true });
+  await expect(reload).toBeEnabled();
+  await reload.click();
+  await expect(reload).toBeDisabled();
+  await expect(reload).toBeEnabled({ timeout: 60_000 });
 
   await expect(keyLabel(page, NEW_KEYCODE).first()).toBeVisible({
     timeout: 60_000,

--- a/e2e/renode/tests/official/reset.spec.ts
+++ b/e2e/renode/tests/official/reset.spec.ts
@@ -16,8 +16,15 @@ import { connect, openKeymap, layerTabs } from "../support/connect";
 const KEYS = ["A", "B", "C", "D"]; // renode_tester default_layer bindings
 const EDITED_KEYCODE = "F"; // not in the default keymap
 
+// Tab panels stay mounted once visited, so scope every text match to the panel
+// that is currently showing — otherwise a `toHaveCount(0)` would also count
+// matches inside a hidden (but still rendered) tab.
+function activePanel(page: import("@playwright/test").Page) {
+  return page.locator('[role="tabpanel"][data-state="active"]');
+}
+
 function keyLabel(page: import("@playwright/test").Page, label: string) {
-  return page.getByText(label, { exact: true });
+  return activePanel(page).getByText(label, { exact: true });
 }
 
 test("Reset all settings restores the keyboard to firmware defaults (core.resetSettings)", async ({
@@ -67,11 +74,19 @@ test("Reset all settings restores the keyboard to firmware defaults (core.resetS
   // On success the dialog closes and no error is surfaced.
   await expect(confirm).toBeHidden({ timeout: 30_000 });
 
-  // 3) Re-read the keymap (tab remount forces a fresh get_keymap) and prove the
-  //    device is back to firmware defaults: A/B/C/D are restored and the saved
-  //    `F` edit is gone. This confirms reset_settings wiped the persisted change.
-  await page.getByRole("tab", { name: "Home" }).click();
+  // 3) Re-read the keymap and prove the device is back to firmware defaults:
+  //    A/B/C/D are restored and the saved `F` edit is gone, confirming
+  //    reset_settings wiped the persisted change. Tab panels keep their state
+  //    across switches (they stay mounted), so returning to the Keymap tab shows
+  //    the pre-reset keymap until its Reload button re-runs get_keymap. Reload is
+  //    disabled for the duration of the load, so disabled -> enabled marks the
+  //    fresh device data landing.
   await page.getByRole("tab", { name: "Keymap" }).click();
+  const reload = page.getByRole("button", { name: "Reload", exact: true });
+  await expect(reload).toBeEnabled();
+  await reload.click();
+  await expect(reload).toBeDisabled();
+  await expect(reload).toBeEnabled({ timeout: 60_000 });
 
   for (const k of KEYS) {
     await expect(keyLabel(page, k).first()).toBeVisible({ timeout: 60_000 });

--- a/src/components/PageTransition.tsx
+++ b/src/components/PageTransition.tsx
@@ -1,9 +1,10 @@
 import type { ReactNode } from "react";
-import { motion, AnimatePresence } from "framer-motion";
+import { motion } from "framer-motion";
 
 interface PageTransitionProps {
   children: ReactNode;
-  transitionKey: string;
+  /** Whether this page is the visible one. */
+  isActive: boolean;
 }
 
 const pageVariants = {
@@ -29,22 +30,18 @@ const pageVariants = {
   },
 };
 
-export function PageTransition({
-  children,
-  transitionKey,
-}: PageTransitionProps) {
+// The page is animated in place rather than through AnimatePresence: pages stay
+// mounted while their tab is inactive (so they keep their state), and a keyed
+// AnimatePresence would remount — and therefore reset — them on every switch.
+export function PageTransition({ children, isActive }: PageTransitionProps) {
   return (
-    <AnimatePresence mode="wait">
-      <motion.div
-        key={transitionKey}
-        variants={pageVariants}
-        initial="initial"
-        animate="enter"
-        exit="exit"
-        className="h-full"
-      >
-        {children}
-      </motion.div>
-    </AnimatePresence>
+    <motion.div
+      variants={pageVariants}
+      initial="initial"
+      animate={isActive ? "enter" : "exit"}
+      className="h-full"
+    >
+      {children}
+    </motion.div>
   );
 }

--- a/src/components/TabNavigation.tsx
+++ b/src/components/TabNavigation.tsx
@@ -1,5 +1,6 @@
 import * as Tabs from "@radix-ui/react-tabs";
-import type { ReactNode } from "react";
+import { useState, type ReactNode } from "react";
+import { TabActiveContext } from "../contexts/TabActiveContext";
 import { PageTransition } from "./PageTransition";
 
 export interface TabItem {
@@ -20,6 +21,21 @@ export function TabNavigation({
   activeTab,
   onTabChange,
 }: TabNavigationProps) {
+  // A tab stays mounted once it has been visited, so switching away and back
+  // keeps everything the page was holding (loaded device data, in-progress
+  // edits, selected layer, scroll position) instead of tearing it down and
+  // re-reading from the keyboard. Tabs that were never opened are not mounted
+  // at all, so we still don't fire every page's device RPCs up front.
+  const [visitedTabs, setVisitedTabs] = useState<ReadonlySet<string>>(
+    () => new Set([activeTab]),
+  );
+  // Adjusted during render (React's "adjust state when props change" pattern)
+  // rather than in an effect, so the newly-selected tab is mounted in this same
+  // render instead of one frame later.
+  if (!visitedTabs.has(activeTab)) {
+    setVisitedTabs(new Set(visitedTabs).add(activeTab));
+  }
+
   return (
     <Tabs.Root
       value={activeTab}
@@ -42,18 +58,22 @@ export function TabNavigation({
 
       {/* Tab Content */}
       <div className="flex-1 overflow-hidden">
-        {tabs.map((tab) => (
-          <Tabs.Content
-            key={tab.id}
-            value={tab.id}
-            className="h-full outline-none data-[state=inactive]:hidden"
-            forceMount
-          >
-            <PageTransition transitionKey={activeTab === tab.id ? tab.id : ""}>
-              {activeTab === tab.id ? tab.content : null}
-            </PageTransition>
-          </Tabs.Content>
-        ))}
+        {tabs
+          .filter((tab) => visitedTabs.has(tab.id))
+          .map((tab) => (
+            <Tabs.Content
+              key={tab.id}
+              value={tab.id}
+              className="h-full outline-none data-[state=inactive]:hidden"
+              forceMount
+            >
+              <TabActiveContext.Provider value={activeTab === tab.id}>
+                <PageTransition isActive={activeTab === tab.id}>
+                  {tab.content}
+                </PageTransition>
+              </TabActiveContext.Provider>
+            </Tabs.Content>
+          ))}
       </div>
     </Tabs.Root>
   );

--- a/src/components/__tests__/TabNavigation.test.tsx
+++ b/src/components/__tests__/TabNavigation.test.tsx
@@ -1,0 +1,123 @@
+import { useEffect, useState } from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { TabNavigation, type TabItem } from "../TabNavigation";
+import { useIsTabActive } from "../../hooks/useIsTabActive";
+
+// A page that both holds local state (the input's value) and reports how many
+// times it has mounted, so a test can tell "kept alive" from "re-created".
+function StatefulPage({
+  name,
+  onMount,
+}: {
+  name: string;
+  onMount?: () => void;
+}) {
+  const [value, setValue] = useState("");
+  const isActive = useIsTabActive();
+  useEffect(() => {
+    onMount?.();
+  }, [onMount]);
+  return (
+    <div>
+      <input
+        aria-label={`${name} input`}
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+      />
+      <span>{`${name} active: ${isActive}`}</span>
+    </div>
+  );
+}
+
+function renderTabs(tabs: TabItem[], initialTab = tabs[0].id) {
+  function Harness() {
+    const [activeTab, setActiveTab] = useState(initialTab);
+    return (
+      <TabNavigation
+        tabs={tabs}
+        activeTab={activeTab}
+        onTabChange={setActiveTab}
+      />
+    );
+  }
+  return render(<Harness />);
+}
+
+describe("TabNavigation", () => {
+  test("a visited tab keeps its state after switching away and back", async () => {
+    const user = userEvent.setup();
+    const onMountFirst = jest.fn();
+    renderTabs([
+      {
+        id: "first",
+        label: "First",
+        icon: null,
+        content: <StatefulPage name="First" onMount={onMountFirst} />,
+      },
+      {
+        id: "second",
+        label: "Second",
+        icon: null,
+        content: <StatefulPage name="Second" />,
+      },
+    ]);
+
+    await user.type(screen.getByLabelText("First input"), "draft");
+    await user.click(screen.getByRole("tab", { name: "Second" }));
+    await user.click(screen.getByRole("tab", { name: "First" }));
+
+    expect(screen.getByLabelText("First input")).toHaveValue("draft");
+    // Kept alive rather than torn down and rebuilt.
+    expect(onMountFirst).toHaveBeenCalledTimes(1);
+  });
+
+  test("a tab is only mounted once it has been opened", async () => {
+    const user = userEvent.setup();
+    renderTabs([
+      {
+        id: "first",
+        label: "First",
+        icon: null,
+        content: <div>first body</div>,
+      },
+      {
+        id: "second",
+        label: "Second",
+        icon: null,
+        content: <div>second body</div>,
+      },
+    ]);
+
+    expect(screen.queryByText("second body")).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("tab", { name: "Second" }));
+
+    expect(screen.getByText("second body")).toBeInTheDocument();
+  });
+
+  test("an inactive tab's content sees itself as inactive", async () => {
+    const user = userEvent.setup();
+    renderTabs([
+      {
+        id: "first",
+        label: "First",
+        icon: null,
+        content: <StatefulPage name="First" />,
+      },
+      {
+        id: "second",
+        label: "Second",
+        icon: null,
+        content: <StatefulPage name="Second" />,
+      },
+    ]);
+
+    await user.click(screen.getByRole("tab", { name: "Second" }));
+
+    // First is still mounted, but knows it is off-screen — that is the signal
+    // pages use to pause streaming/polling.
+    expect(screen.getByText("First active: false")).toBeInTheDocument();
+    expect(screen.getByText("Second active: true")).toBeInTheDocument();
+  });
+});

--- a/src/contexts/TabActiveContext.tsx
+++ b/src/contexts/TabActiveContext.tsx
@@ -1,0 +1,14 @@
+/**
+ * TabActiveContext
+ *
+ * Tab panels stay mounted once they have been visited (see TabNavigation), so
+ * an inactive tab keeps its state instead of being torn down and re-read from
+ * the keyboard. Pages that drive continuous device traffic — key-event
+ * streaming, periodic polling — read this to pause while they are off-screen.
+ *
+ * Defaults to true so a page rendered outside the tab shell (tests, the
+ * standalone release notes route) behaves as if it were visible.
+ */
+import { createContext } from "react";
+
+export const TabActiveContext = createContext(true);

--- a/src/hooks/useIsTabActive.ts
+++ b/src/hooks/useIsTabActive.ts
@@ -1,0 +1,7 @@
+import { useContext } from "react";
+import { TabActiveContext } from "../contexts/TabActiveContext";
+
+/** True while the calling page's tab is the visible one. */
+export function useIsTabActive(): boolean {
+  return useContext(TabActiveContext);
+}

--- a/src/i18n/releaseNotes.json
+++ b/src/i18n/releaseNotes.json
@@ -92,6 +92,10 @@
             "en": "Anonymous usage analytics to help prioritize improvements (no keymap or configuration data is ever sent).",
             "ja": "改善の優先度付けのため匿名の利用状況分析を追加しました（キーマップや設定データは一切送信されません）。",
             "pr": 145
+          },
+          {
+            "en": "Switching tabs no longer discards what a tab was showing: each tab keeps its loaded data and in-progress edits, so returning to it is instant. Keymap, Settings and Trackball gained a Reload button for re-reading from the keyboard on demand.",
+            "ja": "タブを切り替えても、そのタブの読み込み済みデータや編集途中の内容が破棄されなくなりました。戻ったときの再読み込み待ちがなくなります。キーマップ・設定・トラックボールには、必要なときにキーボードから読み直せる再読み込みボタンを追加しました。"
           }
         ],
         "patch": [

--- a/src/i18n/translations.ts
+++ b/src/i18n/translations.ts
@@ -499,6 +499,9 @@ const ja: Record<string, string> = {
   "Changes are written to keyboard memory after a short delay. Save a section to persist them.":
     "変更は少し遅れてキーボードのメモリに書き込まれます。永続化するにはセクションを保存してください。",
   Reload: "再読み込み",
+  "Reload the keymap from the keyboard": "キーボードからキーマップを再読み込み",
+  "Reload settings from the keyboard": "キーボードから設定を再読み込み",
+  "Reload processors": "プロセッサーを再読み込み",
   "Advanced settings can change firmware behavior immediately. Incorrect values may make the keyboard hard to use; discard or reset a section if the device starts behaving unexpectedly.":
     "詳細設定はファームウェアの動作を即座に変更します。誤った値を設定するとキーボードが使いにくくなる可能性があります。デバイスが予期せず動作し始めた場合は、セクションを破棄またはリセットしてください。",
   "Custom settings subsystem is not available for this keyboard.":

--- a/src/pages/KeymapPage.tsx
+++ b/src/pages/KeymapPage.tsx
@@ -21,6 +21,7 @@ import {
   IconInfoCircle,
   IconPencil,
   IconLock,
+  IconRefresh,
 } from "@tabler/icons-react";
 import { useStudioLockState } from "@cormoran/zmk-studio-react-hook";
 import * as Tooltip from "@radix-ui/react-tooltip";
@@ -41,6 +42,7 @@ import { getAvailableLayouts, getLayoutLabel } from "../lib/keyboardLayouts";
 import type { BehaviorBinding } from "../hooks/useKeymap";
 import { useStudioUnlock } from "../hooks/useStudioUnlock";
 import { useLanguage } from "../hooks/useLanguage";
+import { useIsTabActive } from "../hooks/useIsTabActive";
 
 export function KeymapPage() {
   const { t } = useLanguage();
@@ -54,6 +56,7 @@ export function KeymapPage() {
   // compete with the keymap load. autoLoad:false suppresses the on-mount fetch.
   const runtimeMacro = useRuntimeMacro({ autoLoad: false });
   const inputStream = useInputStream();
+  const isTabActive = useIsTabActive();
   // Proactive lock state: the fast-keymap subsystem is unsecured, so the keymap
   // is viewable while Studio is locked. We use this to (a) show a lock badge in
   // place of Save/Reset and (b) prompt for unlock the moment the user tries to
@@ -177,6 +180,14 @@ export function KeymapPage() {
     } finally {
       setIsSaving(false);
     }
+  }, [keymap]);
+
+  // Re-read the keymap from the keyboard. The page keeps its state across tab
+  // switches now, so this is the way to pick up changes made outside the app
+  // (or to retry after a failed load). Unsaved edits are staged on the device
+  // itself, so a reload shows them again rather than dropping them.
+  const handleReload = useCallback(() => {
+    void keymap.loadKeymapData();
   }, [keymap]);
 
   // Handle discard
@@ -345,6 +356,17 @@ export function KeymapPage() {
     setSelectedLayerIndex(inputStream.activeLayerIndex);
   }, [inputStream.activeLayerIndex, keymap.keymap?.layers]);
 
+  // Stream mode highlights (and beeps on) every key press, which only makes
+  // sense while the Keymap tab is on screen. The page stays mounted when you
+  // switch tabs, so turn the stream off on the way out instead of letting it
+  // keep chirping in the background.
+  const { isEnabled: isStreamEnabled, toggleStream } = inputStream;
+  useEffect(() => {
+    if (!isTabActive && isStreamEnabled) {
+      void toggleStream();
+    }
+  }, [isTabActive, isStreamEnabled, toggleStream]);
+
   // Load the runtime-macro list as the FINAL step of the keymap tab load: only
   // after the keymap has fully loaded (preview + background behaviors/layers) so
   // the macro RPCs (list_macros / get_macro_global_settings) run last instead of
@@ -412,6 +434,20 @@ export function KeymapPage() {
                   </Switch.Root>
                 </div>
               )}
+              {/* Reading is allowed while locked, so Reload sits outside the
+                  lock branch below. */}
+              <button
+                className="btn-ghost text-sm flex items-center gap-1.5 flex-shrink-0"
+                onClick={handleReload}
+                disabled={keymap.isLoading}
+                title={t("Reload the keymap from the keyboard")}
+              >
+                <IconRefresh
+                  size={16}
+                  className={keymap.isLoading ? "animate-spin" : undefined}
+                />
+                {t("Reload")}
+              </button>
               {/* When Studio is locked, editing is disabled — show a lock badge
                   (click to unlock) instead of the Save / Reset controls. */}
               {locked ? (

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -14,6 +14,7 @@ import {
   IconAlertTriangle,
   IconTrash,
   IconLoader2,
+  IconRefresh,
 } from "@tabler/icons-react";
 import * as Dialog from "@radix-ui/react-dialog";
 import { AdvancedSettingsSection } from "../components/AdvancedSettingsSection";
@@ -244,8 +245,14 @@ function TimeDropdown({ value, onChange, presets }: TimeDropdownProps) {
 export function SettingsPage() {
   const { t } = useLanguage();
   const connection = useContext(ConnectionContext);
-  const { isAvailable, devices, isLoading, error, setActivitySettings } =
-    useSettings();
+  const {
+    isAvailable,
+    devices,
+    isLoading,
+    error,
+    setActivitySettings,
+    loadAllSettings,
+  } = useSettings();
   const {
     resetAllSettings,
     isResetting,
@@ -335,6 +342,22 @@ export function SettingsPage() {
               {t("Device configuration and power management")}
             </p>
           </div>
+          {/* The page keeps its state across tab switches, so re-reading the
+              device is an explicit action. */}
+          {isAvailable && (
+            <button
+              className="btn-ghost text-sm flex items-center gap-1.5 flex-shrink-0 ml-auto"
+              onClick={() => void loadAllSettings()}
+              disabled={isLoading}
+              title={t("Reload settings from the keyboard")}
+            >
+              <IconRefresh
+                size={16}
+                className={isLoading ? "animate-spin" : undefined}
+              />
+              {t("Reload")}
+            </button>
+          )}
         </div>
 
         {!isAvailable && !isLoading && !error && (

--- a/src/pages/TrackballPage.tsx
+++ b/src/pages/TrackballPage.tsx
@@ -157,6 +157,7 @@ export function TrackballPage() {
     layers,
     isLoading,
     error,
+    loadProcessors,
     setScaling,
     setRotation,
     setTempLayerEnabled,
@@ -530,12 +531,25 @@ export function TrackballPage() {
                   </h2>
                   <DocTip content={processorDoc(t)} />
                 </div>
-                {isLoading && (
-                  <IconLoader2
-                    size={14}
-                    className="animate-spin text-[var(--color-electric)]"
-                  />
-                )}
+                <div className="flex items-center gap-1">
+                  {isLoading && (
+                    <IconLoader2
+                      size={14}
+                      className="animate-spin text-[var(--color-electric)]"
+                    />
+                  )}
+                  {/* The page keeps its state across tab switches, so re-reading
+                      the processor list is an explicit action. */}
+                  <button
+                    className="p-1 rounded hover:bg-[var(--color-border)] text-[var(--color-electric)] disabled:opacity-40 transition-colors"
+                    onClick={() => void loadProcessors()}
+                    disabled={isLoading}
+                    title={t("Reload")}
+                    aria-label={t("Reload processors")}
+                  >
+                    <IconRefresh size={15} />
+                  </button>
+                </div>
               </div>
               <div className="space-y-1">
                 {processors.length === 0 ? (

--- a/src/pages/TroubleshootingPage.tsx
+++ b/src/pages/TroubleshootingPage.tsx
@@ -1,4 +1,4 @@
-import { useContext, useRef, useState } from "react";
+import { useContext, useEffect, useRef, useState } from "react";
 import {
   IconCheck,
   IconClipboardCopy,
@@ -20,6 +20,7 @@ import { KscanDiagnosticsSection } from "../components/troubleshooting/KscanDiag
 import { Pmw3610Section } from "../components/troubleshooting/Pmw3610Section";
 import { DevtoolStackUsageSection } from "../components/troubleshooting/DevtoolStackUsageSection";
 import { buildSupportReport } from "../lib/troubleshootingReport";
+import { useIsTabActive } from "../hooks/useIsTabActive";
 
 const COPIED_FEEDBACK_MS = 2000;
 
@@ -34,6 +35,17 @@ export function TroubleshootingPage() {
   const stackUsage = useDevtoolStackUsage();
   const [copied, setCopied] = useState(false);
   const copiedTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const isTabActive = useIsTabActive();
+
+  // The page stays mounted while another tab is showing, so stop the stack-usage
+  // polling on the way out — nobody is watching those numbers, and every tick is
+  // a device round-trip.
+  const { isPolling: isStackPolling, setPolling: setStackPolling } = stackUsage;
+  useEffect(() => {
+    if (!isTabActive && isStackPolling) {
+      setStackPolling(false);
+    }
+  }, [isTabActive, isStackPolling, setStackPolling]);
 
   const refreshAll = () => {
     if (deviceInfo.isAvailable) void deviceInfo.refresh();


### PR DESCRIPTION
## Description

Switching tabs threw away everything the tab was showing. `TabNavigation` rendered only the active tab's content (`activeTab === tab.id ? tab.content : null`), so leaving a tab unmounted the entire page — loaded device data, in-progress edits, selected layer, scroll position — and coming back meant sitting through a full re-read over BLE/USB.

**Keep tabs mounted.** A tab stays mounted once it has been visited; Radix hides it while inactive. Tabs never opened are still not mounted, so we don't fire every page's RPCs up front. `PageTransition` drops `AnimatePresence` (a keyed `AnimatePresence` remounts — and therefore resets — the page on every switch) and fades the panel in place instead. Visually identical: the outgoing panel was already hidden immediately by `data-[state=inactive]:hidden`, so its exit animation was never visible.

**Pause what shouldn't run off-screen.** New `TabActiveContext` / `useIsTabActive` let a page tell whether it is the visible tab. Two live features stop on the way out:

- Keymap stream mode — highlights *and beeps* on every key press
- Troubleshooting stack-usage polling — a device round-trip per tick

**Explicit reload.** Returning to a tab no longer re-reads the device, so Keymap and Settings get a Reload button in their headers and the Trackball Processors card gets one matching the PMW3610 card's. Reloading the keymap is non-destructive — unsaved edits are staged on the device itself, so a load shows them again rather than dropping them.

### e2e

Four specs used a tab round-trip as their "force a device re-read" step, which no longer re-reads. They now click Reload and wait for the button to go disabled → enabled (it is disabled for the duration of the load), which is what proves the following assertions read fresh device data rather than what was already on screen. Note the dya2 DUT serves only one Studio connection per Renode boot, so a reload/reconnect was not an option here.

`keyLabel` in both keymap specs is now scoped to the active `tabpanel`: `toHaveCount(0)` counts hidden DOM too, and Home is permanently mounted from the start now.

## Testing

- `npm run lint`, `tsc -b`: clean
- `npx jest`: 58 suites / 503 passed. New `src/components/__tests__/TabNavigation.test.tsx` covers the behavior directly — state survives a round-trip, the page mounts exactly once, an unvisited tab is not mounted, and an inactive tab sees `isActive: false`.
- Verified end-to-end in the browser on this PR's Cloudflare preview, via demo mode:
  - On Keymap, selected the **Raise** layer and edited a key to `A` (green unsaved dot + 未保存の変更 badge), switched to Settings and back — layer selection, the edit, the unsaved badge and the Discard button all survived, with no reload wait.
  - `document.querySelectorAll('[role="tabpanel"]')` after visiting Home → Keymap → Settings returns exactly those three, the two inactive ones `display: none`. The five never-opened tabs are not in the DOM, so nothing is mounted up front.
  - The new Reload buttons render on Keymap and Settings (`キーボードからキーマップを再読み込み` / `再読み込み`); clicking Keymap's re-runs the load and leaves the page consistent. No console errors throughout.
- **Not verified:** the Renode e2e specs — no DUT here, so the Reload-button re-read path in those four specs is only reasoned about, not run. Worth watching the e2e job on this PR.

## Release notes

- [x] Added an `upcoming` release notes entry (minor, en + ja)

## CLA (Contributor License Agreement)

By submitting this pull request, I agree that my contributions
are licensed under the project's current license.

I also grant the maintainer(s) of this project the right to relicense
my contributions under any license, for use in future versions of the project.
This does not affect the license of any previously released versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
