### PR TITLE
Add WebMCP tools for agent keymap editing

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -55,10 +55,11 @@ const config: Config = {
     "!src/main.tsx",
     "!src/vite-env.d.ts",
   ],
-  // @keyboard-hub packages ship untranspiled ESM TypeScript sources, so they
-  // have to go through the transform like the ZMK client packages do.
+  // These packages ship ESM sources, so they have to go through the transform
+  // for Jest's CommonJS test runtime. The WebMCP polyfill pulls in the other
+  // two scopes as runtime dependencies.
   transformIgnorePatterns: [
-    "node_modules/(?!(@cormoran|@zmkfirmware|@keyboard-hub)/)",
+    "node_modules/(?!(@cormoran|@zmkfirmware|@keyboard-hub|@mcp-b|@cfworker|@standard-schema)/)",
   ],
   transform: {
     "^.+\\.(js|jsx|ts|tsx)$": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@keyboard-hub/abyss-client": "^0.0.1",
         "@keyboard-hub/adapter-common": "^0.0.1",
         "@keyboard-hub/adapter-zmk": "^0.0.1",
+        "@mcp-b/webmcp-polyfill": "^4.0.0",
         "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-popover": "^1.1.23",
         "@radix-ui/react-switch": "^1.2.6",
@@ -845,6 +846,12 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/@cfworker/json-schema": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@cfworker/json-schema/-/json-schema-4.1.1.tgz",
+      "integrity": "sha512-gAmrUZSGtKc3AiBL71iNWxDsyUC5uMaKKGdvzYsBoTW/xi42JQHl7eKV2OYzCUqvc+D2RCcf7EXY2iCyFIk6og==",
+      "license": "MIT"
     },
     "node_modules/@cormoran/zmk-studio-react-hook": {
       "version": "0.0.4",
@@ -2626,6 +2633,26 @@
         "node": ">=12.0"
       }
     },
+    "node_modules/@mcp-b/webmcp-polyfill": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@mcp-b/webmcp-polyfill/-/webmcp-polyfill-4.0.0.tgz",
+      "integrity": "sha512-7M6WS3IcxaIEhidbS9N7wrrGjtJf474Vi4Fn1hGkFkmYFT5EoFw/kS/4CSdUR/KmlInO1kyluHRY6t3avMQfFw==",
+      "license": "MIT",
+      "dependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "@mcp-b/webmcp-types": "4.0.0",
+        "@standard-schema/spec": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@mcp-b/webmcp-types": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@mcp-b/webmcp-types/-/webmcp-types-4.0.0.tgz",
+      "integrity": "sha512-CUBBmiut1UBsiD3FAF6xrLKeKAuJkzd6/BlL1C/uo8sVpwY42NW4mls9rLcTxmLF/8Cj5/ZOwJiLzXl/T3GIQg==",
+      "license": "MIT"
+    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.1.tgz",
@@ -4063,6 +4090,12 @@
       "dependencies": {
         "@sinonjs/commons": "^3.0.0"
       }
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
     },
     "node_modules/@svgr/babel-plugin-add-jsx-attribute": {
       "version": "8.0.0",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@keyboard-hub/abyss-client": "^0.0.1",
     "@keyboard-hub/adapter-common": "^0.0.1",
     "@keyboard-hub/adapter-zmk": "^0.0.1",
+    "@mcp-b/webmcp-polyfill": "^4.0.0",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-popover": "^1.1.23",
     "@radix-ui/react-switch": "^1.2.6",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useContext, useCallback, useEffect, useState } from "react";
+import { useContext, useCallback, useEffect, useMemo, useState } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import {
   IconCloudUpload,
@@ -46,6 +46,7 @@ import { useUrlTab, pathnameFromTabId } from "./hooks/useUrlTab";
 import { useDevtool } from "./hooks/useDevtool";
 import { DevtoolWindow } from "./components/DevtoolWindow";
 import { trackPageView } from "./lib/analytics";
+import { requireString, useWebMcpTools, type WebMcpTool } from "./lib/webMcp";
 import { DeveloperGuidePage } from "./components/developerGuide";
 import {
   DEVELOPER_GUIDE_PATH,
@@ -169,7 +170,7 @@ function AppContent() {
   const connection = useContext(ConnectionContext);
   const { t } = useLanguage();
   const [urlTab, navigateToTab] = useUrlTab();
-  const tabs = getTabs(t);
+  const tabs = useMemo(() => getTabs(t), [t]);
   const { isAvailable: isDevtoolAvailable } = useDevtool();
   const [devtoolOpen, setDevtoolOpen] = useState(false);
   const activeTab = tabs.some((tab) => tab.id === urlTab) ? urlTab : "home";
@@ -226,6 +227,73 @@ function AppContent() {
     },
     [navigateToTab, tabs],
   );
+
+  const webMcpTools = useMemo<readonly WebMcpTool[]>(() => {
+    const availableTabs = tabs.map(({ id, label }) => ({ id, label }));
+    const availableTabIds = availableTabs.map(({ id }) => id);
+
+    return [
+      {
+        name: "dya_get_app_state",
+        title: "Get DYA Studio state",
+        description:
+          "Get the keyboard connection state, connected device name, active tab, and tabs available in DYA Studio.",
+        inputSchema: {
+          type: "object",
+          properties: {},
+          additionalProperties: false,
+        },
+        annotations: { readOnlyHint: true, openWorldHint: false },
+        execute: () => ({
+          connected: connection.isConnected,
+          deviceName: connection.deviceName ?? null,
+          activeTab,
+          availableTabs,
+        }),
+      },
+      {
+        name: "dya_switch_tab",
+        title: "Switch DYA Studio tab",
+        description:
+          "Switch the visible DYA Studio tab. Use dya_get_app_state to inspect available tabs and the current tab.",
+        inputSchema: {
+          type: "object",
+          properties: {
+            tab: {
+              type: "string",
+              enum: availableTabIds,
+              description: "ID of the tab to show.",
+            },
+          },
+          required: ["tab"],
+          additionalProperties: false,
+        },
+        annotations: {
+          readOnlyHint: false,
+          destructiveHint: false,
+          idempotentHint: true,
+          openWorldHint: false,
+        },
+        execute: (input) => {
+          const tab = requireString(input, "tab");
+          if (!availableTabIds.includes(tab)) {
+            throw new RangeError(`Unknown tab: ${tab}`);
+          }
+          // Keep navigation, URL updates, and analytics on the same path as a
+          // human tab click; WebMCP must not grow a second navigation flow.
+          setActiveTabWithTracking(tab);
+          return { activeTab: tab };
+        },
+      },
+    ];
+  }, [
+    activeTab,
+    connection.isConnected,
+    connection.deviceName,
+    tabs,
+    setActiveTabWithTracking,
+  ]);
+  useWebMcpTools(webMcpTools);
 
   // Both standalone routes return before the connection gate: the user lands on
   // the OAuth callback with no keyboard connected whenever the popup was

--- a/src/__tests__/App.test.tsx
+++ b/src/__tests__/App.test.tsx
@@ -7,11 +7,12 @@
  * before the callback page could read it — a failure that only shows up as
  * "login silently does nothing". These tests pin that down.
  */
-import { render, screen, waitFor } from "@testing-library/react";
+import { act, render, screen, waitFor } from "@testing-library/react";
 import App from "../App";
 import { DEVELOPER_GUIDE_PATH } from "../content/developerGuide";
 import { OAUTH_CALLBACK_PATH } from "../lib/abyss/abyssOAuth";
 import { RELEASE_NOTES_PATH } from "../pages/ReleaseNotesPage";
+import type { WebMcpTool } from "../lib/webMcp";
 
 // The standalone pages are rendered by App directly; stub them so these tests
 // stay about routing rather than page internals.
@@ -88,5 +89,42 @@ describe("App routing", () => {
     render(<App />);
 
     await waitFor(() => expect(window.location.pathname).toBe("/"));
+  });
+});
+
+describe("App WebMCP navigation", () => {
+  afterEach(() => {
+    Object.defineProperty(document, "modelContext", {
+      configurable: true,
+      value: undefined,
+    });
+  });
+
+  it("registers app tools and switches tabs through the tracked navigation path", async () => {
+    const registered: WebMcpTool[] = [];
+    Object.defineProperty(document, "modelContext", {
+      configurable: true,
+      value: {
+        registerTool: (tool: WebMcpTool) => {
+          registered.push(tool);
+        },
+      },
+    });
+    goTo("/");
+
+    render(<App />);
+    await waitFor(() =>
+      expect(registered.some((tool) => tool.name === "dya_switch_tab")).toBe(
+        true,
+      ),
+    );
+    const switchTab = registered.find((tool) => tool.name === "dya_switch_tab");
+    if (!switchTab) throw new Error("dya_switch_tab was not registered");
+
+    await act(async () => {
+      await switchTab.execute({ tab: "keymap" });
+    });
+
+    expect(window.location.pathname).toBe("/keymap");
   });
 });

--- a/src/hooks/__tests__/useKeymapWebMcpTools.test.ts
+++ b/src/hooks/__tests__/useKeymapWebMcpTools.test.ts
@@ -1,0 +1,163 @@
+import type { UseKeymapReturn } from "../useKeymap";
+import { createKeymapWebMcpTools } from "../useKeymapWebMcpTools";
+
+function createKeymap(overrides: Partial<UseKeymapReturn> = {}) {
+  const value = {
+    keymap: {
+      layers: [
+        {
+          id: 3,
+          name: "Base",
+          bindings: [{ behaviorId: 1, param1: 4, param2: 0 }],
+        },
+      ],
+      availableLayers: 0,
+      maxLayerNameLength: 32,
+    },
+    behaviors: new Map([
+      [1, { id: 1, displayName: "Key press", metadata: [] }],
+      [2, { id: 2, displayName: "Layer tap", metadata: [] }],
+    ]),
+    isLoading: false,
+    isFullyLoaded: true,
+    error: null,
+    hasUnsavedChanges: true,
+    getBindingDisplayName: jest.fn(() => "A"),
+    setBinding: jest.fn().mockResolvedValue(true),
+    saveChanges: jest.fn().mockResolvedValue(true),
+    discardChanges: jest.fn().mockResolvedValue(true),
+    ...overrides,
+  };
+  return value as unknown as UseKeymapReturn;
+}
+
+function findTool(keymap: UseKeymapReturn, name: string) {
+  const tool = createKeymapWebMcpTools(keymap).find(
+    (candidate) => candidate.name === name,
+  );
+  if (!tool) throw new Error(`Missing test tool: ${name}`);
+  return tool;
+}
+
+describe("keymap WebMCP tools", () => {
+  it("returns layers, bindings, behaviors, and edit state", async () => {
+    const keymap = createKeymap();
+    const result = await findTool(keymap, "dya_get_keymap_state").execute({});
+
+    expect(result).toMatchObject({
+      loading: false,
+      fullyLoaded: true,
+      unsaved: true,
+      layers: [
+        {
+          id: 3,
+          bindings: [
+            { keyPosition: 0, behaviorId: 1, param1: 4, displayName: "A" },
+          ],
+        },
+      ],
+      availableBehaviors: [
+        { id: 1, displayName: "Key press" },
+        { id: 2, displayName: "Layer tap" },
+      ],
+    });
+  });
+
+  it("validates and stages a binding with useKeymap.setBinding", async () => {
+    const keymap = createKeymap();
+    const result = await findTool(keymap, "dya_set_keymap_binding").execute({
+      layerId: 3,
+      keyPosition: 0,
+      behaviorId: 2,
+      param1: 7,
+      param2: 8,
+    });
+
+    expect(keymap.setBinding).toHaveBeenCalledWith(3, 0, {
+      behaviorId: 2,
+      param1: 7,
+      param2: 8,
+    });
+    expect(result).toEqual({ edited: true, layerId: 3, keyPosition: 0 });
+  });
+
+  it("rejects invalid IDs, positions, unloaded state, and device failures", async () => {
+    const keymap = createKeymap();
+    const edit = findTool(keymap, "dya_set_keymap_binding");
+
+    await expect(
+      edit.execute({
+        layerId: 99,
+        keyPosition: 0,
+        behaviorId: 2,
+        param1: 0,
+        param2: 0,
+      }),
+    ).rejects.toThrow("Unknown layer ID");
+    await expect(
+      edit.execute({
+        layerId: 3,
+        keyPosition: 99,
+        behaviorId: 2,
+        param1: 0,
+        param2: 0,
+      }),
+    ).rejects.toThrow("Invalid key position");
+    await expect(
+      edit.execute({
+        layerId: 3,
+        keyPosition: 0,
+        behaviorId: 99,
+        param1: 0,
+        param2: 0,
+      }),
+    ).rejects.toThrow("Unknown behavior ID");
+
+    const unloaded = createKeymap({ keymap: null });
+    await expect(
+      findTool(unloaded, "dya_set_keymap_binding").execute({
+        layerId: 3,
+        keyPosition: 0,
+        behaviorId: 2,
+        param1: 0,
+        param2: 0,
+      }),
+    ).rejects.toThrow("has not been loaded");
+
+    const failed = createKeymap({
+      setBinding: jest.fn().mockResolvedValue(false),
+    });
+    await expect(
+      findTool(failed, "dya_set_keymap_binding").execute({
+        layerId: 3,
+        keyPosition: 0,
+        behaviorId: 2,
+        param1: 0,
+        param2: 0,
+      }),
+    ).rejects.toThrow("rejected the binding edit");
+  });
+
+  it("uses useKeymap save and discard methods and exposes failures", async () => {
+    const keymap = createKeymap();
+    await expect(
+      findTool(keymap, "dya_save_keymap").execute({}),
+    ).resolves.toEqual({ saved: true });
+    await expect(
+      findTool(keymap, "dya_discard_keymap_changes").execute({}),
+    ).resolves.toEqual({ discarded: true });
+    expect(keymap.saveChanges).toHaveBeenCalledTimes(1);
+    expect(keymap.discardChanges).toHaveBeenCalledTimes(1);
+
+    const failed = createKeymap({
+      saveChanges: jest.fn().mockResolvedValue(false),
+      discardChanges: jest.fn().mockResolvedValue(false),
+    });
+    await expect(
+      findTool(failed, "dya_save_keymap").execute({}),
+    ).rejects.toThrow("failed to save");
+    await expect(
+      findTool(failed, "dya_discard_keymap_changes").execute({}),
+    ).rejects.toThrow("failed to discard");
+  });
+});

--- a/src/hooks/useKeymapWebMcpTools.ts
+++ b/src/hooks/useKeymapWebMcpTools.ts
@@ -1,0 +1,227 @@
+import { useMemo } from "react";
+import type { UseKeymapReturn } from "./useKeymap";
+import { requireInteger, useWebMcpTools, type WebMcpTool } from "../lib/webMcp";
+
+const EMPTY_INPUT_SCHEMA = {
+  type: "object",
+  properties: {},
+  additionalProperties: false,
+} as const;
+
+function requireUint32(
+  input: Parameters<typeof requireInteger>[0],
+  name: string,
+) {
+  const value = requireInteger(input, name);
+  if (value < 0 || value > 0xffffffff) {
+    throw new RangeError(`${name} must be between 0 and 4294967295`);
+  }
+  return value;
+}
+
+type KeymapWebMcpApi = Pick<
+  UseKeymapReturn,
+  | "behaviors"
+  | "discardChanges"
+  | "error"
+  | "getBindingDisplayName"
+  | "hasUnsavedChanges"
+  | "isFullyLoaded"
+  | "isLoading"
+  | "keymap"
+  | "saveChanges"
+  | "setBinding"
+>;
+
+export function createKeymapWebMcpTools(
+  keymap: KeymapWebMcpApi,
+): readonly WebMcpTool[] {
+  const requireLoadedKeymap = () => {
+    if (keymap.isLoading) {
+      throw new Error("The keymap is still loading");
+    }
+    if (!keymap.keymap) {
+      throw new Error(
+        keymap.error
+          ? `The keymap is unavailable: ${keymap.error}`
+          : "The keymap has not been loaded",
+      );
+    }
+    return keymap.keymap;
+  };
+
+  return [
+    {
+      name: "dya_get_keymap_state",
+      title: "Get keymap state",
+      description:
+        "Get keymap loading, error, unsaved-change, layer binding, and available behavior information. Behavior parameter metadata describes valid parameter choices.",
+      inputSchema: EMPTY_INPUT_SCHEMA,
+      annotations: { readOnlyHint: true, openWorldHint: false },
+      execute: () => ({
+        loading: keymap.isLoading,
+        fullyLoaded: keymap.isFullyLoaded,
+        error: keymap.error,
+        unsaved: keymap.hasUnsavedChanges,
+        layers:
+          keymap.keymap?.layers.map((layer) => ({
+            id: layer.id,
+            name: layer.name,
+            bindings: layer.bindings.map((binding, keyPosition) => ({
+              keyPosition,
+              behaviorId: binding.behaviorId,
+              param1: binding.param1,
+              param2: binding.param2,
+              displayName: keymap.getBindingDisplayName(binding),
+            })),
+          })) ?? [],
+        availableBehaviors: Array.from(keymap.behaviors.values()).map(
+          (behavior) => ({
+            id: behavior.id,
+            displayName: behavior.displayName,
+            parameterSets: behavior.metadata,
+          }),
+        ),
+      }),
+    },
+    {
+      name: "dya_set_keymap_binding",
+      title: "Edit a key binding",
+      description:
+        "Stage a binding edit for one key. The edit remains unsaved until dya_save_keymap is called. Choose a behavior and parameters from dya_get_keymap_state.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          layerId: { type: "integer", minimum: 0 },
+          keyPosition: { type: "integer", minimum: 0 },
+          behaviorId: { type: "integer", minimum: 0 },
+          param1: { type: "integer", minimum: 0, maximum: 0xffffffff },
+          param2: { type: "integer", minimum: 0, maximum: 0xffffffff },
+        },
+        required: ["layerId", "keyPosition", "behaviorId", "param1", "param2"],
+        additionalProperties: false,
+      },
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
+      execute: async (input) => {
+        const current = requireLoadedKeymap();
+        const layerId = requireUint32(input, "layerId");
+        const keyPosition = requireUint32(input, "keyPosition");
+        const behaviorId = requireUint32(input, "behaviorId");
+        const param1 = requireUint32(input, "param1");
+        const param2 = requireUint32(input, "param2");
+        const layer = current.layers.find(
+          (candidate) => candidate.id === layerId,
+        );
+        if (!layer) throw new RangeError(`Unknown layer ID: ${layerId}`);
+        if (keyPosition >= layer.bindings.length) {
+          throw new RangeError(
+            `Invalid key position ${keyPosition} for layer ${layerId}`,
+          );
+        }
+        if (!keymap.behaviors.has(behaviorId)) {
+          throw new RangeError(`Unknown behavior ID: ${behaviorId}`);
+        }
+
+        const ok = await keymap.setBinding(layerId, keyPosition, {
+          behaviorId,
+          param1,
+          param2,
+        });
+        if (!ok) throw new Error("The keyboard rejected the binding edit");
+        return { edited: true, layerId, keyPosition };
+      },
+    },
+    {
+      name: "dya_save_keymap",
+      title: "Save keymap",
+      description:
+        "Persist all staged keymap changes to the connected keyboard.",
+      inputSchema: EMPTY_INPUT_SCHEMA,
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
+      execute: async () => {
+        requireLoadedKeymap();
+        if (!(await keymap.saveChanges())) {
+          throw new Error("The keyboard failed to save keymap changes");
+        }
+        return { saved: true };
+      },
+    },
+    {
+      name: "dya_discard_keymap_changes",
+      title: "Discard keymap changes",
+      description:
+        "Discard every staged, unsaved keymap change and reload the persisted keymap from the keyboard.",
+      inputSchema: EMPTY_INPUT_SCHEMA,
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: true,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
+      execute: async () => {
+        requireLoadedKeymap();
+        if (!(await keymap.discardChanges())) {
+          throw new Error("The keyboard failed to discard keymap changes");
+        }
+        return { discarded: true };
+      },
+    },
+  ];
+}
+
+/** Register keymap tools only while the keymap tab is visible. */
+export function useKeymapWebMcpTools(
+  keymap: UseKeymapReturn,
+  enabled: boolean,
+): void {
+  const {
+    behaviors,
+    discardChanges,
+    error,
+    getBindingDisplayName,
+    hasUnsavedChanges,
+    isFullyLoaded,
+    isLoading,
+    keymap: keymapState,
+    saveChanges,
+    setBinding,
+  } = keymap;
+  const tools = useMemo(
+    () =>
+      createKeymapWebMcpTools({
+        behaviors,
+        discardChanges,
+        error,
+        getBindingDisplayName,
+        hasUnsavedChanges,
+        isFullyLoaded,
+        isLoading,
+        keymap: keymapState,
+        saveChanges,
+        setBinding,
+      }),
+    [
+      behaviors,
+      discardChanges,
+      error,
+      getBindingDisplayName,
+      hasUnsavedChanges,
+      isFullyLoaded,
+      isLoading,
+      keymapState,
+      saveChanges,
+      setBinding,
+    ],
+  );
+  useWebMcpTools(tools, enabled);
+}

--- a/src/i18n/releaseNotes.json
+++ b/src/i18n/releaseNotes.json
@@ -6,7 +6,12 @@
       "changes": {
         "major": [],
         "minor": [],
-        "patch": []
+        "patch": [
+          {
+            "en": "Added WebMCP tools so AI agents can inspect DYA Studio, switch tabs, and edit, save, or discard keymap changes.",
+            "ja": "AI エージェントが DYA Studio の状態確認・タブ切り替え・キーマップの編集、保存、破棄を行える WebMCP ツールを追加しました。"
+          }
+        ]
       }
     },
     {

--- a/src/i18n/releaseNotes.json
+++ b/src/i18n/releaseNotes.json
@@ -8,8 +8,8 @@
         "minor": [],
         "patch": [
           {
-            "en": "Added WebMCP tools so AI agents can inspect DYA Studio, switch tabs, and edit, save, or discard keymap changes.",
-            "ja": "AI エージェントが DYA Studio の状態確認・タブ切り替え・キーマップの編集、保存、破棄を行える WebMCP ツールを追加しました。"
+            "en": "Added WebMCP tools, including a polyfill for unsupported browsers, so AI agents can inspect DYA Studio, switch tabs, and edit, save, or discard keymap changes.",
+            "ja": "非対応ブラウザ向け polyfill を含む WebMCP ツールを追加し、AI エージェントが DYA Studio の状態確認・タブ切り替え・キーマップの編集、保存、破棄を行えるようにしました。"
           }
         ]
       }

--- a/src/lib/__tests__/installWebMcpPolyfill.test.ts
+++ b/src/lib/__tests__/installWebMcpPolyfill.test.ts
@@ -1,0 +1,48 @@
+import { cleanupWebMCPPolyfill } from "@mcp-b/webmcp-polyfill";
+import { installWebMcpPolyfill } from "../installWebMcpPolyfill";
+
+type ModelContextOwner = { modelContext?: unknown };
+type TestingOwner = { modelContextTesting?: unknown };
+
+function removeModelContext(owner: Document | Navigator): void {
+  delete (owner as typeof owner & ModelContextOwner).modelContext;
+}
+
+describe("installWebMcpPolyfill", () => {
+  beforeEach(() => {
+    cleanupWebMCPPolyfill();
+    removeModelContext(document);
+    removeModelContext(navigator);
+    delete (navigator as Navigator & TestingOwner).modelContextTesting;
+  });
+
+  afterEach(() => {
+    cleanupWebMCPPolyfill();
+    removeModelContext(document);
+    removeModelContext(navigator);
+    delete (navigator as Navigator & TestingOwner).modelContextTesting;
+  });
+
+  it("installs document.modelContext in an unsupported browser", () => {
+    installWebMcpPolyfill();
+
+    const documentContext = (document as Document & ModelContextOwner)
+      .modelContext;
+
+    expect(documentContext).toBeDefined();
+  });
+
+  it("preserves a native document.modelContext implementation", () => {
+    const nativeContext = { registerTool: jest.fn() };
+    Object.defineProperty(document, "modelContext", {
+      configurable: true,
+      value: nativeContext,
+    });
+
+    installWebMcpPolyfill();
+
+    expect((document as Document & ModelContextOwner).modelContext).toBe(
+      nativeContext,
+    );
+  });
+});

--- a/src/lib/__tests__/webMcp.test.tsx
+++ b/src/lib/__tests__/webMcp.test.tsx
@@ -1,0 +1,86 @@
+import { renderHook } from "@testing-library/react";
+import {
+  getWebMcpModelContext,
+  useWebMcpTools,
+  type WebMcpTool,
+} from "../webMcp";
+
+const tool: WebMcpTool = {
+  name: "dya_test",
+  description: "Test tool",
+  inputSchema: { type: "object", properties: {} },
+  execute: () => ({ ok: true }),
+};
+
+function setModelContext(owner: Document | Navigator, value: unknown) {
+  Object.defineProperty(owner, "modelContext", {
+    configurable: true,
+    value,
+  });
+}
+
+describe("WebMCP registration", () => {
+  afterEach(() => {
+    setModelContext(document, undefined);
+    setModelContext(navigator, undefined);
+    jest.restoreAllMocks();
+  });
+
+  it("prefers document.modelContext and aborts registrations on cleanup", () => {
+    const documentRegister = jest.fn();
+    const navigatorRegister = jest.fn();
+    setModelContext(document, { registerTool: documentRegister });
+    setModelContext(navigator, { registerTool: navigatorRegister });
+
+    const { unmount } = renderHook(() => useWebMcpTools([tool]));
+
+    expect(getWebMcpModelContext()).not.toBeNull();
+    expect(documentRegister).toHaveBeenCalledWith(
+      tool,
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+    expect(navigatorRegister).not.toHaveBeenCalled();
+    const signal = documentRegister.mock.calls[0][1].signal as AbortSignal;
+    expect(signal.aborted).toBe(false);
+    unmount();
+    expect(signal.aborted).toBe(true);
+  });
+
+  it("falls back to navigator.modelContext", () => {
+    const registerTool = jest.fn();
+    setModelContext(document, undefined);
+    setModelContext(navigator, { registerTool });
+
+    renderHook(() => useWebMcpTools([tool]));
+
+    expect(registerTool).toHaveBeenCalledTimes(1);
+  });
+
+  it("is a safe no-op when WebMCP is unavailable or disabled", () => {
+    setModelContext(document, undefined);
+    setModelContext(navigator, undefined);
+
+    expect(() => renderHook(() => useWebMcpTools([tool]))).not.toThrow();
+
+    const registerTool = jest.fn();
+    setModelContext(document, { registerTool });
+    renderHook(() => useWebMcpTools([tool], false));
+    expect(registerTool).not.toHaveBeenCalled();
+  });
+
+  it("observes asynchronous registration failures", async () => {
+    const warning = jest.spyOn(console, "warn").mockImplementation(() => {});
+    setModelContext(document, {
+      registerTool: () => Promise.reject(new Error("duplicate")),
+    });
+
+    renderHook(() => useWebMcpTools([tool]));
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(warning).toHaveBeenCalledWith(
+      "Failed to register WebMCP tool dya_test:",
+      expect.any(Error),
+    );
+  });
+});

--- a/src/lib/installWebMcpPolyfill.ts
+++ b/src/lib/installWebMcpPolyfill.ts
@@ -1,0 +1,10 @@
+import { initializeWebMCPPolyfill } from "@mcp-b/webmcp-polyfill";
+
+/**
+ * Install the strict WebMCP core API when the browser does not provide it.
+ * The package preserves a native document.modelContext implementation and is
+ * safe to initialize more than once.
+ */
+export function installWebMcpPolyfill(): void {
+  initializeWebMCPPolyfill();
+}

--- a/src/lib/webMcp.ts
+++ b/src/lib/webMcp.ts
@@ -1,0 +1,102 @@
+import { useEffect } from "react";
+
+export type WebMcpInput = Readonly<Record<string, unknown>>;
+
+export interface WebMcpToolAnnotations {
+  readOnlyHint?: boolean;
+  destructiveHint?: boolean;
+  idempotentHint?: boolean;
+  openWorldHint?: boolean;
+  untrustedContentHint?: boolean;
+}
+
+export interface WebMcpTool {
+  name: string;
+  title?: string;
+  description: string;
+  inputSchema: Readonly<Record<string, unknown>>;
+  annotations?: WebMcpToolAnnotations;
+  execute: (input: WebMcpInput) => unknown | Promise<unknown>;
+}
+
+interface WebMcpModelContext {
+  registerTool: (
+    tool: WebMcpTool,
+    options?: { signal?: AbortSignal },
+  ) => unknown | Promise<unknown>;
+}
+
+type ModelContextOwner = { modelContext?: WebMcpModelContext };
+
+/** Returns the current WebMCP implementation, preferring the standard API. */
+export function getWebMcpModelContext(): WebMcpModelContext | null {
+  const documentContext = (document as Document & ModelContextOwner)
+    .modelContext;
+  if (documentContext) return documentContext;
+
+  // Chrome exposed the API on Navigator before it moved to Document. Keep the
+  // old location as a compatibility fallback while clients migrate.
+  return (navigator as Navigator & ModelContextOwner).modelContext ?? null;
+}
+
+/**
+ * Register a set of tools for the lifetime of a component (or active tab).
+ * Unsupported browsers safely do nothing. Aborting the shared signal removes
+ * every tool, per the current WebMCP API.
+ */
+export function useWebMcpTools(
+  tools: readonly WebMcpTool[],
+  enabled = true,
+): void {
+  useEffect(() => {
+    if (!enabled) return;
+
+    const modelContext = getWebMcpModelContext();
+    if (!modelContext) return;
+
+    const controller = new AbortController();
+    for (const tool of tools) {
+      try {
+        // registerTool is async in the current draft. Explicitly observe its
+        // rejection so unsupported schemas/duplicate names never become an
+        // unhandled promise rejection during a React render cycle.
+        void Promise.resolve(
+          modelContext.registerTool(tool, { signal: controller.signal }),
+        ).catch((error: unknown) => {
+          if (!controller.signal.aborted) {
+            console.warn(`Failed to register WebMCP tool ${tool.name}:`, error);
+          }
+        });
+      } catch (error: unknown) {
+        // Older implementations can throw synchronously.
+        console.warn(`Failed to register WebMCP tool ${tool.name}:`, error);
+      }
+    }
+
+    return () => controller.abort();
+  }, [enabled, tools]);
+}
+
+export function requireNumber(input: WebMcpInput, property: string): number {
+  const value = input[property];
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    throw new TypeError(`${property} must be a finite number`);
+  }
+  return value;
+}
+
+export function requireInteger(input: WebMcpInput, property: string): number {
+  const value = requireNumber(input, property);
+  if (!Number.isInteger(value)) {
+    throw new TypeError(`${property} must be an integer`);
+  }
+  return value;
+}
+
+export function requireString(input: WebMcpInput, property: string): string {
+  const value = input[property];
+  if (typeof value !== "string") {
+    throw new TypeError(`${property} must be a string`);
+  }
+  return value;
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,6 +2,9 @@ import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import "./index.css";
 import App from "./App.tsx";
+import { installWebMcpPolyfill } from "./lib/installWebMcpPolyfill";
+
+installWebMcpPolyfill();
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>

--- a/src/pages/KeymapPage.tsx
+++ b/src/pages/KeymapPage.tsx
@@ -46,6 +46,7 @@ import { ResetVersionMenu } from "../components/versionHistory/ResetVersionMenu"
 import { VersionDiffModal } from "../components/versionHistory/VersionDiffModal";
 import { useKeymapVersionHistory } from "../hooks/versionHistory/useKeymapVersionHistory";
 import { useIsTabActive } from "../hooks/useIsTabActive";
+import { useKeymapWebMcpTools } from "../hooks/useKeymapWebMcpTools";
 
 export function KeymapPage() {
   const { t } = useLanguage();
@@ -63,6 +64,7 @@ export function KeymapPage() {
   // "restore a previous version" flow behind the reset dropdown.
   const versionHistory = useKeymapVersionHistory(keymap, t);
   const isTabActive = useIsTabActive();
+  useKeymapWebMcpTools(keymap, isTabActive);
   // Proactive lock state: the fast-keymap subsystem is unsecured, so the keymap
   // is viewable while Studio is locked. We use this to (a) show a lock badge in
   // place of Save/Reset and (b) prompt for unlock the moment the user tries to


### PR DESCRIPTION
## Description

Add an AI-agent-friendly WebMCP surface to DYA Studio without duplicating existing UI or device logic.

- add a shared WebMCP registration hook that prefers `document.modelContext`, supports the legacy `navigator.modelContext`, and unregisters tools with `AbortSignal`
- install `@mcp-b/webmcp-polyfill` at app startup so the same strict core API is available when the browser has no native WebMCP implementation, without replacing native support
- expose app state and tracked tab navigation as always-available tools
- expose active-tab keymap tools for inspecting layers/behaviors, staging binding edits, saving changes, and discarding staged changes
- route every keymap mutation through the existing `useKeymap` API so UI state, unlock handling, RPCs, and errors stay unified
- add English and Japanese release notes

This establishes the per-tab tool-registration pattern; additional tabs can add their own tools through the same shared hook.

## Validation

- `npm test` — 85 suites, 690 passed, 1 skipped
- `npm run lint`
- `npm run build`
- focused WebMCP/App tests — 15 passed
- changed-file Prettier check
- `git diff --check`

`npm run format:check` still reports three pre-existing, untouched files (`e2e/renode/bridge.mjs`, `e2e/renode/serve.mjs`, and `src/index.css`), so this PR deliberately does not mix unrelated formatting changes.

## Release notes

- [x] Added an `upcoming` release notes entry

## CLA

By submitting this pull request, I agree that my contributions are licensed under the project's current license. I also grant the maintainer(s) of this project the right to relicense my contributions for use in future versions of the project.