### PR TITLE
Improve DOM accessibility for agent-friendly keymap editing

### DIFF
--- a/src/components/KeyboardLayout.tsx
+++ b/src/components/KeyboardLayout.tsx
@@ -77,6 +77,8 @@ interface KeyboardLayoutProps {
   highlightedKeys?: ReadonlySet<number>;
   /** Runtime macro summaries for macro behavior display */
   runtimeMacros?: Array<{ slot: number; name?: string }>;
+  /** Accessible name for the keyboard preview region */
+  ariaLabel?: string;
 }
 
 type LayoutGeometry = Pick<
@@ -132,6 +134,7 @@ export function KeyboardLayout({
   modules = [],
   highlightedKeys,
   runtimeMacros = [],
+  ariaLabel,
 }: KeyboardLayoutProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const [scale, setScale] = useState(1.0);
@@ -302,7 +305,12 @@ export function KeyboardLayout({
   );
 
   return (
-    <div ref={containerRef} className="relative overflow-auto w-full">
+    <div
+      ref={containerRef}
+      className="relative overflow-auto w-full"
+      role="group"
+      aria-label={ariaLabel}
+    >
       <div
         className="relative mx-auto"
         style={{

--- a/src/components/PhysicalKey.tsx
+++ b/src/components/PhysicalKey.tsx
@@ -65,6 +65,7 @@ interface PhysicalKeyProps {
 
 export function PhysicalKey({
   attrs,
+  keyPosition,
   isModified,
   isOriginalKnown = true,
   isChangedFromDefault = false,
@@ -82,6 +83,10 @@ export function PhysicalKey({
 }: PhysicalKeyProps) {
   const { t } = useLanguage();
   const [isHovered, setIsHovered] = useState(false);
+  const accessibleName = t("Key position {{position}}: {{binding}}", {
+    position: keyPosition,
+    binding: longDisplayName || displayName || t("No binding"),
+  });
 
   // Calculate dimensions and position with scale
   // ZMK uses centimils (1/100 of a key unit) for dimensions
@@ -120,10 +125,12 @@ export function PhysicalKey({
 
   // Key content
   const keyContent = (
-    <div
+    <button
+      type="button"
       className={`
-        absolute rounded-lg border cursor-pointer transition-all duration-150
+        relative w-full h-full rounded-lg border cursor-pointer transition-all duration-150
         flex flex-col items-center justify-center p-1.5 overflow-hidden
+        focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-electric)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--color-background)]
         ${
           isHighlighted
             ? "bg-amber-400/20 border-amber-300 shadow-[0_0_14px_rgba(251,191,36,0.45)]"
@@ -136,10 +143,11 @@ export function PhysicalKey({
                   : "bg-[var(--color-surface)] border-[var(--color-border)] hover:border-[var(--color-electric)]/50 hover:bg-[var(--color-electric)]/5"
         }
       `}
-      style={style}
       onClick={onClick}
-      onMouseEnter={() => setIsHovered(true)}
-      onMouseLeave={() => setIsHovered(false)}
+      aria-label={accessibleName}
+      aria-current={isSelected ? "true" : undefined}
+      data-key-position={keyPosition}
+      data-binding-label={longDisplayName || displayName}
     >
       {/* Display Name */}
       <span
@@ -174,19 +182,95 @@ export function PhysicalKey({
       {isHighlighted && (
         <div className="absolute inset-0 rounded-lg border-2 border-amber-200/70 pointer-events-none animate-pulse" />
       )}
+    </button>
+  );
 
-      {/* Reset button on hover when modified. When the original is known it
-          reverts to that saved value; when it's unknown (e.g. after a tab
-          switch lost it) it reverts to the hard-coded default instead — and is
-          only shown if a default is available to revert to. */}
+  // Always wrap with tooltip to show binding info
+  return (
+    <div
+      className="absolute"
+      style={style}
+      onMouseEnter={() => setIsHovered(true)}
+      onMouseLeave={() => setIsHovered(false)}
+    >
+      <Tooltip.Provider delayDuration={200} disableHoverableContent>
+        <Tooltip.Root>
+          <Tooltip.Trigger asChild>{keyContent}</Tooltip.Trigger>
+          <Tooltip.Portal>
+            <Tooltip.Content
+              className="px-3 py-2 rounded bg-[var(--color-surface-elevated)] border border-[var(--color-border)] text-xs text-[var(--color-text-secondary)] shadow-lg z-50 max-w-xs"
+              sideOffset={5}
+            >
+              <div className="space-y-1">
+                {/* Always show displayName */}
+                <div>
+                  <span className="font-medium">
+                    {longDisplayName || displayName}
+                  </span>
+                </div>
+                {/* Show binding description only if different from displayName */}
+                {bindingDescription &&
+                  bindingDescription !== displayName &&
+                  longDisplayName !== bindingDescription && (
+                    <div>
+                      <span className="text-[var(--color-text-muted)]">
+                        {t("Binding")}:{" "}
+                      </span>
+                      <span>{bindingDescription}</span>
+                    </div>
+                  )}
+                {/* Original binding info when modified and still known */}
+                {isModified && isOriginalKnown && originalDisplayName && (
+                  <div>
+                    <span className="text-[var(--color-text-muted)]">
+                      {t("Original")}:{" "}
+                    </span>
+                    <span>{originalDisplayName}</span>
+                  </div>
+                )}
+                {/* Original lost (e.g. after a tab switch): we can't recover the
+                  saved value, so say so and fall back to the default below. */}
+                {isModified && !isOriginalKnown && (
+                  <div>
+                    <span className="text-[var(--color-text-muted)]">
+                      {t("Original")}:{" "}
+                    </span>
+                    <span>{t("Unknown")}</span>
+                  </div>
+                )}
+                {/* Default binding: shown when the persisted value differs from it
+                  (changed-from-default), or as the fall-back reference for a
+                  modified key whose original is unknown. */}
+                {((isChangedFromDefault && !isModified) ||
+                  (isModified && !isOriginalKnown)) &&
+                  defaultDisplayName && (
+                    <div>
+                      <span className="text-[var(--color-text-muted)]">
+                        {t("Default")}:{" "}
+                      </span>
+                      <span className="text-[var(--color-electric)]">
+                        {defaultDisplayName}
+                      </span>
+                    </div>
+                  )}
+              </div>
+              <Tooltip.Arrow className="fill-[var(--color-surface-elevated)]" />
+            </Tooltip.Content>
+          </Tooltip.Portal>
+        </Tooltip.Root>
+      </Tooltip.Provider>
+
+      {/* Keep reset actions as siblings of the main key button so the DOM
+          never contains an invalid nested button. */}
       {isModified && isHovered && isOriginalKnown && (
         <button
+          type="button"
           className="absolute bottom-1 right-1 p-0.5 rounded bg-[var(--color-surface)]/80 hover:bg-[var(--color-surface)] border border-[var(--color-border)]"
-          onClick={(e) => {
-            e.stopPropagation();
-            onReset();
-          }}
+          onClick={onReset}
           title={t("Reset to original")}
+          aria-label={t("Reset key position {{position}} to original", {
+            position: keyPosition,
+          })}
         >
           <IconRotateClockwise
             size={12}
@@ -194,108 +278,33 @@ export function PhysicalKey({
           />
         </button>
       )}
-
-      {/* Modified but the original is unknown: revert to the hard-coded default
-          instead (only when one is available). */}
       {isModified && isHovered && !isOriginalKnown && onResetToDefault && (
         <button
+          type="button"
           className="absolute bottom-1 right-1 p-0.5 rounded bg-[var(--color-surface)]/80 hover:bg-[var(--color-surface)] border border-[var(--color-border)]"
-          onClick={(e) => {
-            e.stopPropagation();
-            onResetToDefault();
-          }}
+          onClick={onResetToDefault}
           title={t("Reset to default")}
+          aria-label={t("Reset key position {{position}} to default", {
+            position: keyPosition,
+          })}
         >
           <IconHistory size={12} className="text-[var(--color-electric)]" />
         </button>
       )}
-
-      {/* Reset-to-default button on hover when changed from default (and not
-          currently modified — that state shows the reset-to-original button
-          above instead) */}
       {isChangedFromDefault && !isModified && isHovered && onResetToDefault && (
         <button
+          type="button"
           className="absolute bottom-1 right-1 p-0.5 rounded bg-[var(--color-surface)]/80 hover:bg-[var(--color-surface)] border border-[var(--color-border)]"
-          onClick={(e) => {
-            e.stopPropagation();
-            onResetToDefault();
-          }}
+          onClick={onResetToDefault}
           title={t("Reset to default")}
+          aria-label={t("Reset key position {{position}} to default", {
+            position: keyPosition,
+          })}
         >
           <IconHistory size={12} className="text-[var(--color-electric)]" />
         </button>
       )}
     </div>
-  );
-
-  // Always wrap with tooltip to show binding info
-  return (
-    <Tooltip.Provider delayDuration={200} disableHoverableContent>
-      <Tooltip.Root>
-        <Tooltip.Trigger asChild>{keyContent}</Tooltip.Trigger>
-        <Tooltip.Portal>
-          <Tooltip.Content
-            className="px-3 py-2 rounded bg-[var(--color-surface-elevated)] border border-[var(--color-border)] text-xs text-[var(--color-text-secondary)] shadow-lg z-50 max-w-xs"
-            sideOffset={5}
-          >
-            <div className="space-y-1">
-              {/* Always show displayName */}
-              <div>
-                <span className="font-medium">
-                  {longDisplayName || displayName}
-                </span>
-              </div>
-              {/* Show binding description only if different from displayName */}
-              {bindingDescription &&
-                bindingDescription !== displayName &&
-                longDisplayName !== bindingDescription && (
-                  <div>
-                    <span className="text-[var(--color-text-muted)]">
-                      {t("Binding")}:{" "}
-                    </span>
-                    <span>{bindingDescription}</span>
-                  </div>
-                )}
-              {/* Original binding info when modified and still known */}
-              {isModified && isOriginalKnown && originalDisplayName && (
-                <div>
-                  <span className="text-[var(--color-text-muted)]">
-                    {t("Original")}:{" "}
-                  </span>
-                  <span>{originalDisplayName}</span>
-                </div>
-              )}
-              {/* Original lost (e.g. after a tab switch): we can't recover the
-                  saved value, so say so and fall back to the default below. */}
-              {isModified && !isOriginalKnown && (
-                <div>
-                  <span className="text-[var(--color-text-muted)]">
-                    {t("Original")}:{" "}
-                  </span>
-                  <span>{t("Unknown")}</span>
-                </div>
-              )}
-              {/* Default binding: shown when the persisted value differs from it
-                  (changed-from-default), or as the fall-back reference for a
-                  modified key whose original is unknown. */}
-              {((isChangedFromDefault && !isModified) ||
-                (isModified && !isOriginalKnown)) &&
-                defaultDisplayName && (
-                  <div>
-                    <span className="text-[var(--color-text-muted)]">
-                      {t("Default")}:{" "}
-                    </span>
-                    <span className="text-[var(--color-electric)]">
-                      {defaultDisplayName}
-                    </span>
-                  </div>
-                )}
-            </div>
-            <Tooltip.Arrow className="fill-[var(--color-surface-elevated)]" />
-          </Tooltip.Content>
-        </Tooltip.Portal>
-      </Tooltip.Root>
-    </Tooltip.Provider>
   );
 }
 

--- a/src/components/TabNavigation.tsx
+++ b/src/components/TabNavigation.tsx
@@ -48,6 +48,7 @@ export function TabNavigation({
           <Tabs.Trigger
             key={tab.id}
             value={tab.id}
+            aria-label={tab.label}
             className="tab-trigger flex items-center gap-2 whitespace-nowrap"
           >
             <span className="opacity-70">{tab.icon}</span>

--- a/src/components/__tests__/PhysicalKey.test.tsx
+++ b/src/components/__tests__/PhysicalKey.test.tsx
@@ -3,7 +3,8 @@
  * (the hover reset-to-default button). Other states (modified, selected,
  * highlighted) are exercised indirectly through KeymapPage.
  */
-import { render, screen, fireEvent } from "@testing-library/react";
+import { act, render, screen, fireEvent } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { PhysicalKey } from "../PhysicalKey";
 
 const attrs = { width: 100, height: 100, x: 0, y: 0, r: 0, rx: 0, ry: 0 };
@@ -56,5 +57,43 @@ describe("PhysicalKey — changed from default", () => {
     // The modified state shows the reset-to-original button instead.
     expect(screen.queryByTitle("Reset to default")).not.toBeInTheDocument();
     expect(screen.getByTitle("Reset to original")).toBeInTheDocument();
+  });
+});
+
+describe("PhysicalKey — accessible interaction", () => {
+  it("exposes the key position and binding as a native button name", () => {
+    renderKey({ keyPosition: 12, longDisplayName: "Keyboard A" });
+
+    const key = screen.getByRole("button", {
+      name: "Key position 12: Keyboard A",
+    });
+    expect(key).toHaveAttribute("data-key-position", "12");
+    expect(key).toHaveAttribute("data-binding-label", "Keyboard A");
+  });
+
+  it("can be activated from the keyboard", async () => {
+    const user = userEvent.setup();
+    const onClick = jest.fn();
+    renderKey({ onClick });
+
+    const key = screen.getByRole("button", { name: "Key position 0: A" });
+    act(() => key.focus());
+    await user.keyboard("{Enter}");
+
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the reset action as a separately named button", () => {
+    renderKey({ isModified: true });
+
+    fireEvent.mouseEnter(
+      screen.getByRole("button", { name: "Key position 0: A" }).parentElement!,
+    );
+
+    expect(
+      screen.getByRole("button", {
+        name: "Reset key position 0 to original",
+      }),
+    ).toBeInTheDocument();
   });
 });

--- a/src/components/__tests__/TabNavigation.test.tsx
+++ b/src/components/__tests__/TabNavigation.test.tsx
@@ -45,6 +45,22 @@ function renderTabs(tabs: TabItem[], initialTab = tabs[0].id) {
 }
 
 describe("TabNavigation", () => {
+  test("tabs keep an accessible name when their visible label is hidden", () => {
+    renderTabs([
+      {
+        id: "first",
+        label: "First",
+        icon: null,
+        content: <div>first body</div>,
+      },
+    ]);
+
+    expect(screen.getByRole("tab", { name: "First" })).toHaveAttribute(
+      "aria-label",
+      "First",
+    );
+  });
+
   test("a visited tab keeps its state after switching away and back", async () => {
     const user = userEvent.setup();
     const onMountFirst = jest.fn();

--- a/src/i18n/translations.ts
+++ b/src/i18n/translations.ts
@@ -127,6 +127,14 @@ const ja: Record<string, string> = {
     "すべての変更を破棄しますか？",
   "Are you sure you want to delete this layer?": "このレイヤーを削除しますか？",
   "Layer {{id}}": "レイヤー {{id}}",
+  "Keymap layers": "キーマップのレイヤー",
+  "Keyboard layout for {{layer}}": "{{layer}} のキーボード配列",
+  "Key position {{position}}: {{binding}}":
+    "キー位置 {{position}}: {{binding}}",
+  "Reset key position {{position}} to original":
+    "キー位置 {{position}} を元の割り当てに戻す",
+  "Reset key position {{position}} to default":
+    "キー位置 {{position}} をデフォルトに戻す",
   Sort: "並び替え",
   "Move layer up (higher priority)": "レイヤーを上へ移動（優先度を上げる）",
   "Move layer down (lower priority)": "レイヤーを下へ移動（優先度を下げる）",

--- a/src/pages/KeymapPage.tsx
+++ b/src/pages/KeymapPage.tsx
@@ -532,13 +532,19 @@ export function KeymapPage() {
 
         {/* Error State (unlock errors are handled by the shared unlock modal) */}
         {keymap.error && (
-          <div className="glass-card p-4 mb-4 border-red-500/20 bg-red-500/10 flex items-center gap-3">
+          <div
+            role="alert"
+            className="glass-card p-4 mb-4 border-red-500/20 bg-red-500/10 flex items-center gap-3"
+          >
             <IconAlertCircle size={20} className="text-red-400" />
             <p className="text-sm text-red-400">{t(keymap.error)}</p>
           </div>
         )}
         {inputStream.error && (
-          <div className="glass-card p-4 mb-4 border-red-500/20 bg-red-500/10 flex items-center gap-3">
+          <div
+            role="alert"
+            className="glass-card p-4 mb-4 border-red-500/20 bg-red-500/10 flex items-center gap-3"
+          >
             <IconAlertCircle size={20} className="text-red-400" />
             <p className="text-sm text-red-400">{t(inputStream.error)}</p>
             <button
@@ -564,7 +570,11 @@ export function KeymapPage() {
           <>
             {/* Layer Tabs */}
             <div className="flex flex-wrap items-center gap-2 mb-6">
-              <div className="flex gap-2 flex-1 overflow-x-auto pb-2 basis-full sm:basis-auto">
+              <div
+                className="flex gap-2 flex-1 overflow-x-auto pb-2 basis-full sm:basis-auto"
+                role="group"
+                aria-label={t("Keymap layers")}
+              >
                 {keymap.keymap.layers.map((layer, index) => (
                   <button
                     key={layer.id}
@@ -574,6 +584,7 @@ export function KeymapPage() {
                         : "text-[var(--color-text-muted)] hover:text-[var(--color-text-secondary)] hover:bg-[var(--color-border)]"
                     }`}
                     onClick={() => setSelectedLayerIndex(index)}
+                    aria-pressed={index === selectedLayerIndex}
                   >
                     {layer.name || t("Layer {{id}}", { id: index })}
                   </button>
@@ -809,10 +820,14 @@ export function KeymapPage() {
               {keymap.physicalLayouts &&
                 keymap.physicalLayouts.layouts.length > 1 && (
                   <div className="flex items-center gap-2">
-                    <span className="text-xs text-[var(--color-text-muted)]">
+                    <label
+                      htmlFor="keymap-physical-layout"
+                      className="text-xs text-[var(--color-text-muted)]"
+                    >
                       {t("Physical Layout")}:
-                    </span>
+                    </label>
                     <select
+                      id="keymap-physical-layout"
                       value={keymap.physicalLayouts.activeLayoutIndex}
                       onChange={(e) =>
                         keymap.setActiveLayout(Number(e.target.value))
@@ -830,10 +845,14 @@ export function KeymapPage() {
 
               {/* Keyboard Layout Selector */}
               <div className="flex items-center gap-2">
-                <span className="text-xs text-[var(--color-text-muted)]">
+                <label
+                  htmlFor="keymap-os-layout"
+                  className="text-xs text-[var(--color-text-muted)]"
+                >
                   {t("OS Layout")}:
-                </span>
+                </label>
                 <select
+                  id="keymap-os-layout"
                   value={keyboardLayoutContext.layout}
                   onChange={(e) =>
                     keyboardLayoutContext.setLayout(
@@ -897,6 +916,9 @@ export function KeymapPage() {
                     customized-from-default (electric/blue), or saved-and-stock
                     (muted). */}
                 <div
+                  role="status"
+                  aria-live="polite"
+                  aria-atomic="true"
                   className="absolute top-3 right-3 z-10 flex items-center gap-1.5 px-2 py-1 rounded-full border border-[var(--color-border)] bg-[var(--color-surface)]/70 text-xs"
                   title={
                     !keymap.hasUnsavedChanges &&
@@ -952,6 +974,11 @@ export function KeymapPage() {
                       : []
                   }
                   highlightedKeys={inputStream.highlightedKeys}
+                  ariaLabel={t("Keyboard layout for {{layer}}", {
+                    layer:
+                      currentLayer.name ||
+                      t("Layer {{id}}", { id: selectedLayerIndex }),
+                  })}
                 />
               </div>
             )}

--- a/src/pages/__tests__/KeymapPage.test.tsx
+++ b/src/pages/__tests__/KeymapPage.test.tsx
@@ -274,6 +274,35 @@ describe("KeymapPage", () => {
       expect(screen.getByText("Lower")).toBeInTheDocument();
     });
 
+    it("exposes the keymap controls with names and selection state", () => {
+      renderComponent(
+        { isConnected: true },
+        {
+          keymap: mockKeymap,
+          physicalLayouts: mockPhysicalLayouts,
+          behaviors: mockBehaviors,
+        },
+      );
+
+      const layers = screen.getByRole("group", { name: "Keymap layers" });
+      expect(
+        within(layers).getByRole("button", { name: "Base" }),
+      ).toHaveAttribute("aria-pressed", "true");
+      expect(
+        within(layers).getByRole("button", { name: "Lower" }),
+      ).toHaveAttribute("aria-pressed", "false");
+      expect(
+        screen.getByRole("combobox", { name: "OS Layout:" }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("group", { name: "Keyboard layout for Base" }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getAllByRole("button", { name: /Key position \d+:/ }),
+      ).toHaveLength(3);
+      expect(screen.getByRole("status")).toHaveTextContent("Saved");
+    });
+
     it("should show unsaved changes indicator", () => {
       renderComponent(
         { isConnected: true },


### PR DESCRIPTION
## Summary

- render physical keyboard keys as native, keyboard-operable buttons with stable accessible names and key-position metadata
- expose keymap layers, keyboard preview, layout selectors, save state, and errors with appropriate DOM/a11y semantics
- preserve tab names at responsive breakpoints and keep per-key reset actions as valid sibling buttons
- add focused accessibility and keyboard-interaction tests

## Agent workflow

The accessibility tree now exposes a direct path from the Keymap tab to a named layer group, a named keyboard-layout group, and buttons such as `Key position 0: A`. Activating a key opens the existing named key-binding dialog, without relying on WebMCP or an agent-specific API.

## Verification

- `npm test -- --runInBand` — 82 suites passed, 683 passed / 1 skipped
- `npm run lint`
- `npm run build`
- browser verification in demo mode for the accessibility tree and key-binding dialog
- `git diff --check`

`npm run format:check` still reports the three pre-existing, untouched files `e2e/renode/bridge.mjs`, `e2e/renode/serve.mjs`, and `src/index.css`; all changed files were formatted.