### PR TITLE
Support PMW3610 sensors on split peripherals

### DIFF
--- a/src/hooks/__tests__/usePmw3610.test.tsx
+++ b/src/hooks/__tests__/usePmw3610.test.tsx
@@ -37,7 +37,7 @@ jest.mock("@cormoran/zmk-studio-react-hook", () => {
 type NotificationCallback = (n: CustomNotification) => void;
 
 function createWrapper() {
-  let subscribedCallback: NotificationCallback | null = null;
+  const subscribedCallbacks = new Set<NotificationCallback>();
   const zmkAppValue = {
     state: { connection: {}, customSubsystems: [] },
     findSubsystem: () => ({ index: 12, identifier: "cormoran__pmw3610" }),
@@ -47,10 +47,10 @@ function createWrapper() {
       callback: NotificationCallback;
     }) => {
       if (subscription.type === "custom") {
-        subscribedCallback = subscription.callback;
+        subscribedCallbacks.add(subscription.callback);
       }
       return () => {
-        subscribedCallback = null;
+        subscribedCallbacks.delete(subscription.callback);
       };
     },
   };
@@ -61,8 +61,9 @@ function createWrapper() {
   );
   return {
     Wrapper,
-    emit: (notification: CustomNotification) =>
-      subscribedCallback?.(notification),
+    emit: (notification: CustomNotification) => {
+      for (const callback of subscribedCallbacks) callback(notification);
+    },
   };
 }
 
@@ -130,6 +131,86 @@ describe("usePmw3610 frame capture/streaming", () => {
     expect(result.current.isCapturing).toBe(false);
     expect(result.current.frame!.format).toBe(PixelFormat.PIXEL_FORMAT_PG7);
   });
+
+  it("discovers a split peripheral and routes diagnostics to its source", async () => {
+    const { Wrapper, emit } = createWrapper();
+    mockCallRPC.mockImplementation(async (payload: Uint8Array) => {
+      const req = Request.decode(payload);
+      if (req.getInfo !== undefined) {
+        expect(req.getInfo.source).toBe(0xffffffff);
+        setTimeout(() => {
+          emit({
+            subsystemIndex: 12,
+            payload: Notification.encode(
+              Notification.create({
+                peripheralResponse: {
+                  source: 1,
+                  requestId: 31,
+                  response: Response.create({
+                    getInfo: {
+                      devices: [
+                        {
+                          ready: true,
+                          productId: 0x3e,
+                          deviceIndex: 0,
+                          settingsId: "mkb-rtb",
+                        },
+                      ],
+                    },
+                  }),
+                },
+              }),
+            ).finish(),
+          });
+        }, 0);
+        return encodeResponse({
+          getInfo: { devices: [], relayRequestId: 31 },
+        });
+      }
+      if (req.readDiagnostics !== undefined) {
+        expect(req.readDiagnostics).toMatchObject({
+          deviceIndex: 0,
+          source: 1,
+        });
+        setTimeout(() => {
+          emit({
+            subsystemIndex: 12,
+            payload: Notification.encode(
+              Notification.create({
+                peripheralResponse: {
+                  source: 1,
+                  requestId: 32,
+                  response: Response.create({
+                    readDiagnostics: { squal: 47, shutter: 9 },
+                  }),
+                },
+              }),
+            ).finish(),
+          });
+        }, 0);
+        return encodeResponse({ deferred: { requestId: 32 } });
+      }
+      return encodeResponse({ error: { message: "unhandled" } });
+    });
+
+    const { result } = renderHook(() => usePmw3610(), { wrapper: Wrapper });
+    await waitFor(() => expect(result.current.devices).toHaveLength(1), {
+      timeout: 3_500,
+    });
+    expect(result.current.devices[0]).toMatchObject({
+      source: 1,
+      deviceIndex: 0,
+      settingsId: "mkb-rtb",
+    });
+
+    await act(async () => {
+      await result.current.readDiagnostics(0);
+    });
+    expect(result.current.diagnostics).toMatchObject({
+      squal: 47,
+      shutter: 9,
+    });
+  }, 10_000);
 
   it("captureOnce honors an explicit RAW8 format (no bit7 masking, no invalid bytes)", async () => {
     mockCallRPC.mockImplementation(async (payload: Uint8Array) => {

--- a/src/hooks/usePmw3610.ts
+++ b/src/hooks/usePmw3610.ts
@@ -19,8 +19,17 @@ import {
   isValidPixelByte,
   type FrameChunk,
 } from "../lib/pmw3610Frame";
+import {
+  PMW3610_SOURCE_ALL,
+  Pmw3610RelayCorrelator,
+} from "../lib/pmw3610Relay";
 
 export const PMW3610_SUBSYSTEM_IDENTIFIER = "cormoran__pmw3610";
+
+export interface Pmw3610DeviceInfo extends DeviceInfo {
+  /** 0 is local to the Studio central; positive values are split peripherals. */
+  source: number;
+}
 
 const CODEC = {
   encode: (request: Request) => Request.encode(request).finish(),
@@ -45,7 +54,7 @@ export interface CapturedFrame {
 
 export interface UsePmw3610Return {
   isAvailable: boolean;
-  devices: DeviceInfo[];
+  devices: Pmw3610DeviceInfo[];
   diagnostics: ReadDiagnosticsResponse | null;
   isLoading: boolean;
   error: string | null;
@@ -73,11 +82,12 @@ export function usePmw3610(): UsePmw3610Return {
     PMW3610_SUBSYSTEM_IDENTIFIER,
     CODEC,
   );
-  const [devices, setDevices] = useState<DeviceInfo[]>([]);
+  const [devices, setDevices] = useState<Pmw3610DeviceInfo[]>([]);
   const [diagnostics, setDiagnostics] =
     useState<ReadDiagnosticsResponse | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const relayCorrelatorRef = useRef(new Pmw3610RelayCorrelator());
 
   const subsystemIndex = subsystem?.index;
 
@@ -87,22 +97,61 @@ export function usePmw3610(): UsePmw3610Return {
       // `call` handles the locked case (unlock modal + retry, or null if the
       // user dismisses it) via the shared gate.
       const resp = await call(request);
+      if (resp?.deferred) {
+        return relayCorrelatorRef.current.waitFor(resp.deferred.requestId);
+      }
       return resp ?? null;
     },
     [ready, call],
   );
+
+  // Relayed requests return immediately with DeferredResponse. Their actual
+  // response arrives through this custom-notification subscription.
+  useEffect(() => {
+    if (!zmkApp || subsystemIndex === undefined) return;
+    const correlator = relayCorrelatorRef.current;
+    const unsubscribe = zmkApp.onNotification({
+      type: "custom",
+      subsystemIndex,
+      callback: (notification) => {
+        correlator.handleNotificationPayload(notification.payload);
+      },
+    });
+    return () => {
+      unsubscribe();
+      correlator.clear("PMW3610 connection closed");
+    };
+  }, [zmkApp, subsystemIndex]);
 
   const refresh = useCallback(async () => {
     if (!ready) return;
     setIsLoading(true);
     setError(null);
     try {
-      const resp = await callRpc(Request.create({ getInfo: {} }));
+      const resp = await callRpc(
+        Request.create({ getInfo: { source: PMW3610_SOURCE_ALL } }),
+      );
       if (!resp) return;
       if (resp.error) {
         throw new Error(resp.error.message);
       }
-      setDevices(resp.getInfo?.devices ?? []);
+      const discovered: Pmw3610DeviceInfo[] = (resp.getInfo?.devices ?? []).map(
+        (device) => ({ ...device, source: 0 }),
+      );
+      const relayRequestId = resp.getInfo?.relayRequestId ?? 0;
+      if (relayRequestId !== 0) {
+        const peripheralResponses =
+          await relayCorrelatorRef.current.collectBroadcast(relayRequestId);
+        for (const { source, response } of peripheralResponses) {
+          if (response.error) {
+            throw new Error(response.error.message);
+          }
+          for (const device of response.getInfo?.devices ?? []) {
+            discovered.push({ ...device, source });
+          }
+        }
+      }
+      setDevices(discovered);
     } catch (err) {
       setError(err instanceof Error ? err.message : "Unknown error");
     } finally {
@@ -110,12 +159,33 @@ export function usePmw3610(): UsePmw3610Return {
     }
   }, [ready, callRpc]);
 
+  const resolveDevice = useCallback(
+    (displayIndex: number): Pmw3610DeviceInfo =>
+      devices[displayIndex] ?? {
+        deviceIndex: displayIndex,
+        source: 0,
+        ready: false,
+        productId: 0,
+        revisionId: 0,
+        initError: 0,
+        runtimeConfig: undefined,
+        settingsId: "",
+      },
+    [devices],
+  );
+
   const readDiagnostics = useCallback(
     async (deviceIndex: number) => {
       setError(null);
       try {
+        const device = resolveDevice(deviceIndex);
         const resp = await callRpc(
-          Request.create({ readDiagnostics: { deviceIndex } }),
+          Request.create({
+            readDiagnostics: {
+              deviceIndex: device.deviceIndex,
+              source: device.source,
+            },
+          }),
         );
         if (!resp) return;
         if (resp.error) {
@@ -126,7 +196,7 @@ export function usePmw3610(): UsePmw3610Return {
         setError(err instanceof Error ? err.message : "Unknown error");
       }
     },
-    [callRpc],
+    [callRpc, resolveDevice],
   );
 
   // Auto-fetch sensor info when the subsystem becomes available.
@@ -149,6 +219,7 @@ export function usePmw3610(): UsePmw3610Return {
   const fpsWindowStartRef = useRef(0);
   const unsubscribeStreamRef = useRef<(() => void) | null>(null);
   const streamingDeviceIndexRef = useRef(0);
+  const streamingSourceRef = useRef(0);
   // Per-frame_id incremental assembler, keyed so a late chunk from a
   // previous frame_id (should not happen, but notifications are
   // best-effort/unordered in principle) cannot corrupt the current frame.
@@ -161,9 +232,14 @@ export function usePmw3610(): UsePmw3610Return {
       setIsCapturing(true);
       setError(null);
       try {
+        const device = resolveDevice(deviceIndex);
         const captureResp = await callRpc(
           Request.create({
-            captureFrame: { deviceIndex, pixelCount: side * side },
+            captureFrame: {
+              deviceIndex: device.deviceIndex,
+              pixelCount: side * side,
+              source: device.source,
+            },
           }),
         );
         if (!captureResp) return;
@@ -182,7 +258,11 @@ export function usePmw3610(): UsePmw3610Return {
         for (const offset of offsets) {
           const chunkResp = await callRpc(
             Request.create({
-              getFrameChunk: { frameId: captureFrame.frameId, offset },
+              getFrameChunk: {
+                frameId: captureFrame.frameId,
+                offset,
+                source: device.source,
+              },
             }),
           );
           if (!chunkResp) return;
@@ -217,12 +297,13 @@ export function usePmw3610(): UsePmw3610Return {
         setIsCapturing(false);
       }
     },
-    [callRpc],
+    [callRpc, resolveDevice],
   );
 
   const setFrameStreamRpc = useCallback(
     async (
       deviceIndex: number,
+      source: number,
       enable: boolean,
       side: number,
     ): Promise<boolean> => {
@@ -232,6 +313,7 @@ export function usePmw3610(): UsePmw3610Return {
             deviceIndex,
             enable,
             pixelCount: enable ? side * side : 0,
+            source,
           },
         }),
       );
@@ -249,7 +331,12 @@ export function usePmw3610(): UsePmw3610Return {
     unsubscribeStreamRef.current?.();
     unsubscribeStreamRef.current = null;
     try {
-      await setFrameStreamRpc(streamingDeviceIndexRef.current, false, 0);
+      await setFrameStreamRpc(
+        streamingDeviceIndexRef.current,
+        streamingSourceRef.current,
+        false,
+        0,
+      );
     } catch (err) {
       setError(err instanceof Error ? err.message : "Unknown error");
     }
@@ -259,7 +346,9 @@ export function usePmw3610(): UsePmw3610Return {
     async (deviceIndex: number, side: number) => {
       if (isStreaming || !zmkApp || subsystemIndex === undefined) return;
       setError(null);
-      streamingDeviceIndexRef.current = deviceIndex;
+      const device = resolveDevice(deviceIndex);
+      streamingDeviceIndexRef.current = device.deviceIndex;
+      streamingSourceRef.current = device.source;
       assemblersRef.current.clear();
       frameCountRef.current = 0;
       fpsWindowStartRef.current = performance.now();
@@ -277,7 +366,7 @@ export function usePmw3610(): UsePmw3610Return {
               return;
             }
             const chunk = decoded.frameStreamChunk;
-            if (!chunk) return;
+            if (!chunk || chunk.source !== streamingSourceRef.current) return;
 
             const assemblers = assemblersRef.current;
             for (const key of assemblers.keys()) {
@@ -322,7 +411,12 @@ export function usePmw3610(): UsePmw3610Return {
             }
           },
         });
-        const streaming = await setFrameStreamRpc(deviceIndex, true, side);
+        const streaming = await setFrameStreamRpc(
+          device.deviceIndex,
+          device.source,
+          true,
+          side,
+        );
         setIsStreaming(streaming);
         if (!streaming) {
           unsubscribeStreamRef.current?.();
@@ -334,7 +428,7 @@ export function usePmw3610(): UsePmw3610Return {
         setError(err instanceof Error ? err.message : "Unknown error");
       }
     },
-    [zmkApp, subsystemIndex, isStreaming, setFrameStreamRpc],
+    [zmkApp, subsystemIndex, isStreaming, resolveDevice, setFrameStreamRpc],
   );
 
   // Stop the stream when the component unmounts or the connection drops.

--- a/src/lib/__tests__/pmw3610Relay.test.ts
+++ b/src/lib/__tests__/pmw3610Relay.test.ts
@@ -1,0 +1,77 @@
+import { Notification, Response } from "../../proto/cormoran/pmw3610/pmw3610";
+import { Pmw3610RelayCorrelator } from "../pmw3610Relay";
+
+function peripheralResponsePayload(
+  requestId: number,
+  source: number,
+  response: Parameters<typeof Response.create>[0],
+): Uint8Array {
+  return Notification.encode(
+    Notification.create({
+      peripheralResponse: {
+        requestId,
+        source,
+        response: Response.create(response),
+      },
+    }),
+  ).finish();
+}
+
+describe("Pmw3610RelayCorrelator", () => {
+  it("resolves a deferred request from its peripheral notification", async () => {
+    const correlator = new Pmw3610RelayCorrelator(100);
+    const responsePromise = correlator.waitFor(7);
+
+    expect(
+      correlator.handleNotificationPayload(
+        peripheralResponsePayload(7, 1, {
+          readDiagnostics: { squal: 42, shutter: 3 },
+        }),
+      ),
+    ).toBe(true);
+
+    await expect(responsePromise).resolves.toMatchObject({
+      readDiagnostics: { squal: 42, shutter: 3 },
+    });
+  });
+
+  it("buffers a fast notification until its deferred response is observed", async () => {
+    const correlator = new Pmw3610RelayCorrelator(100);
+    correlator.handleNotificationPayload(
+      peripheralResponsePayload(8, 1, {
+        getInfo: { devices: [{ deviceIndex: 0, settingsId: "mkb-rtb" }] },
+      }),
+    );
+
+    await expect(correlator.waitFor(8)).resolves.toMatchObject({
+      getInfo: { devices: [{ settingsId: "mkb-rtb" }] },
+    });
+  });
+
+  it("collects buffered and live responses from an all-source scan", async () => {
+    const correlator = new Pmw3610RelayCorrelator(100);
+    correlator.handleNotificationPayload(
+      peripheralResponsePayload(9, 1, {
+        getInfo: { devices: [{ deviceIndex: 0, settingsId: "right" }] },
+      }),
+    );
+
+    const responsesPromise = correlator.collectBroadcast(9, 5);
+    correlator.handleNotificationPayload(
+      peripheralResponsePayload(9, 2, {
+        getInfo: { devices: [{ deviceIndex: 0, settingsId: "left" }] },
+      }),
+    );
+
+    await expect(responsesPromise).resolves.toMatchObject([
+      {
+        source: 1,
+        response: { getInfo: { devices: [{ settingsId: "right" }] } },
+      },
+      {
+        source: 2,
+        response: { getInfo: { devices: [{ settingsId: "left" }] } },
+      },
+    ]);
+  });
+});

--- a/src/lib/pmw3610Relay.ts
+++ b/src/lib/pmw3610Relay.ts
@@ -1,0 +1,120 @@
+import { Notification, type Response } from "../proto/cormoran/pmw3610/pmw3610";
+
+const DEFAULT_TIMEOUT_MS = 6_000;
+const DEFAULT_BROADCAST_WINDOW_MS = 2_000;
+
+export const PMW3610_SOURCE_ALL = 0xffffffff;
+
+interface RelayedResponse {
+  source: number;
+  response: Response;
+}
+
+interface PendingRequest {
+  resolve: (response: Response) => void;
+  reject: (error: Error) => void;
+  timeoutId: ReturnType<typeof setTimeout>;
+}
+
+/** Correlates PMW3610 DeferredResponse replies with custom notifications. */
+export class Pmw3610RelayCorrelator {
+  private pending = new Map<number, PendingRequest>();
+  private broadcasts = new Map<
+    number,
+    {
+      responses: RelayedResponse[];
+      resolve: (value: RelayedResponse[]) => void;
+    }
+  >();
+  private buffered = new Map<number, RelayedResponse[]>();
+  private readonly timeoutMs: number;
+
+  constructor(timeoutMs: number = DEFAULT_TIMEOUT_MS) {
+    this.timeoutMs = timeoutMs;
+  }
+
+  waitFor(requestId: number): Promise<Response> {
+    const buffered = this.buffered.get(requestId)?.shift();
+    if (buffered) {
+      if (this.buffered.get(requestId)?.length === 0) {
+        this.buffered.delete(requestId);
+      }
+      return Promise.resolve(buffered.response);
+    }
+
+    return new Promise((resolve, reject) => {
+      const timeoutId = setTimeout(() => {
+        this.pending.delete(requestId);
+        reject(
+          new Error(
+            `Timed out waiting for PMW3610 peripheral response ${requestId}`,
+          ),
+        );
+      }, this.timeoutMs);
+      this.pending.set(requestId, { resolve, reject, timeoutId });
+    });
+  }
+
+  collectBroadcast(
+    requestId: number,
+    windowMs: number = DEFAULT_BROADCAST_WINDOW_MS,
+  ): Promise<RelayedResponse[]> {
+    return new Promise((resolve) => {
+      const responses = this.buffered.get(requestId) ?? [];
+      this.buffered.delete(requestId);
+      this.broadcasts.set(requestId, { responses, resolve });
+      setTimeout(() => {
+        const broadcast = this.broadcasts.get(requestId);
+        this.broadcasts.delete(requestId);
+        resolve(broadcast?.responses ?? responses);
+      }, windowMs);
+    });
+  }
+
+  handleNotificationPayload(payload: Uint8Array): boolean {
+    let notification: Notification;
+    try {
+      notification = Notification.decode(payload);
+    } catch {
+      return false;
+    }
+
+    const peripheral = notification.peripheralResponse;
+    if (!peripheral?.response) return false;
+
+    const pending = this.pending.get(peripheral.requestId);
+    if (pending) {
+      clearTimeout(pending.timeoutId);
+      this.pending.delete(peripheral.requestId);
+      pending.resolve(peripheral.response);
+      return true;
+    }
+
+    const response = {
+      source: peripheral.source,
+      response: peripheral.response,
+    };
+    const broadcast = this.broadcasts.get(peripheral.requestId);
+    if (broadcast) {
+      broadcast.responses.push(response);
+    } else {
+      const buffered = this.buffered.get(peripheral.requestId) ?? [];
+      buffered.push(response);
+      this.buffered.set(peripheral.requestId, buffered);
+    }
+    return true;
+  }
+
+  clear(reason: string): void {
+    for (const pending of this.pending.values()) {
+      clearTimeout(pending.timeoutId);
+      pending.reject(new Error(reason));
+    }
+    this.pending.clear();
+    for (const broadcast of this.broadcasts.values()) {
+      broadcast.resolve(broadcast.responses);
+    }
+    this.broadcasts.clear();
+    this.buffered.clear();
+  }
+}


### PR DESCRIPTION
## Summary

- discover PMW3610 devices across the Studio central and connected split peripherals using the driver's all-source GetInfo request
- correlate DeferredResponse replies with PeripheralResponse custom notifications
- preserve each device's source for diagnostics, frame capture, chunk reads, and frame streaming
- buffer fast peripheral notifications to avoid a response-registration race

## Motivation

DYA Studio currently sends GetInfo with the default source 0. On keyboards where the PMW3610 is attached to a split peripheral, the sensor works as a pointing device but the troubleshooting card reports no sensors.

This was reproduced on an MKB split keyboard with a left Studio central/joystick and a right peripheral/PMW3610. CDC Debug confirmed 203 non-zero mouse movement reports in 20 seconds with no errors, while DYA Studio returned an empty local device list.

The firmware uses cormoran/zmk-driver-pmw3610-with-custom-studio-rpc at 5c34ea0 with CONFIG_ZMK_PMW3610_SPLIT_RPC_RELAY enabled on both halves and a 240-byte split relay payload.

## Validation

- npm test: 83 suites passed, 688 tests passed, 1 skipped
- npm run lint: passed
- npm run build: passed
- added coverage for peripheral discovery, source-aware diagnostics, deferred-response correlation, fast-response buffering, and broadcast collection

Hardware UI validation will be performed against the PR preview on the same MKB pair.