### PR TITLE
fix: support split PMW3610 diagnostics

### DIFF
--- a/src/components/troubleshooting/Pmw3610FrameViewer.tsx
+++ b/src/components/troubleshooting/Pmw3610FrameViewer.tsx
@@ -58,6 +58,7 @@ function renderFrame(
 
 export interface Pmw3610FrameViewerProps {
   pmw3610: UsePmw3610Return;
+  source: number;
   deviceIndex: number;
   side: number;
   onSideChange: (side: number) => void;
@@ -65,6 +66,7 @@ export interface Pmw3610FrameViewerProps {
 
 export function Pmw3610FrameViewer({
   pmw3610,
+  source,
   deviceIndex,
   side,
   onSideChange,
@@ -122,7 +124,7 @@ export function Pmw3610FrameViewer({
           type="button"
           className="btn-ghost text-sm"
           disabled={isCapturing || isStreaming}
-          onClick={() => void captureOnce(deviceIndex, side)}
+          onClick={() => void captureOnce(source, deviceIndex, side)}
         >
           {isCapturing ? t("Capturing…") : t("Capture Once")}
         </button>
@@ -140,7 +142,7 @@ export function Pmw3610FrameViewer({
             type="button"
             className="btn-electric text-sm"
             disabled={isCapturing}
-            onClick={() => void startStreaming(deviceIndex, side)}
+            onClick={() => void startStreaming(source, deviceIndex, side)}
           >
             {t("Start Streaming")}
           </button>

--- a/src/components/troubleshooting/Pmw3610Section.tsx
+++ b/src/components/troubleshooting/Pmw3610Section.tsx
@@ -107,9 +107,15 @@ export function Pmw3610Section({ pmw3610 }: { pmw3610: UsePmw3610Return }) {
             </p>
           )}
 
-          {devices.map((device, index) => (
-            <div key={index} className="mb-3">
+          {devices.map((device) => (
+            <div
+              key={`${device.source}:${device.deviceIndex}`}
+              className="mb-3"
+            >
               <div className="flex flex-wrap gap-4 text-xs text-[var(--color-text-secondary)]">
+                <span>
+                  {t("Source")}: <strong>{device.source}</strong>
+                </span>
                 <span>
                   {t("Ready")}:{" "}
                   <strong
@@ -148,7 +154,9 @@ export function Pmw3610Section({ pmw3610 }: { pmw3610: UsePmw3610Return }) {
                 )}
               </div>
               <button
-                onClick={() => void readDiagnostics(index)}
+                onClick={() =>
+                  void readDiagnostics(device.source, device.deviceIndex)
+                }
                 disabled={isLoading}
                 className="btn-ghost text-sm mt-2"
               >
@@ -180,7 +188,8 @@ export function Pmw3610Section({ pmw3610 }: { pmw3610: UsePmw3610Return }) {
           {devices.length > 0 && (
             <Pmw3610FrameViewer
               pmw3610={pmw3610}
-              deviceIndex={0}
+              source={devices[0].source}
+              deviceIndex={devices[0].deviceIndex}
               side={frameSide}
               onSideChange={setFrameSide}
             />

--- a/src/components/troubleshooting/__tests__/Pmw3610Section.test.tsx
+++ b/src/components/troubleshooting/__tests__/Pmw3610Section.test.tsx
@@ -13,6 +13,8 @@ function basePmw3610(
     isAvailable: true,
     devices: [
       {
+        source: 2,
+        deviceIndex: 0,
         ready: true,
         productId: 0x3610,
         revisionId: 1,
@@ -48,6 +50,8 @@ describe("Pmw3610Section", () => {
         pmw3610={basePmw3610({
           devices: [
             {
+              source: 2,
+              deviceIndex: 0,
               ready: false,
               productId: 0x3610,
               revisionId: 1,
@@ -81,7 +85,7 @@ describe("Pmw3610Section", () => {
     );
 
     fireEvent.click(screen.getByText("Capture Once"));
-    expect(captureOnce).toHaveBeenCalledWith(0, 22);
+    expect(captureOnce).toHaveBeenCalledWith(2, 0, 22);
   });
 
   it("disables Capture Once while streaming", () => {
@@ -132,7 +136,7 @@ describe("Pmw3610Section", () => {
     );
 
     fireEvent.click(screen.getByText("Start Streaming"));
-    expect(startStreaming).toHaveBeenCalledWith(0, 22);
+    expect(startStreaming).toHaveBeenCalledWith(2, 0, 22);
 
     rerender(
       <Pmw3610Section

--- a/src/hooks/__tests__/usePmw3610.test.tsx
+++ b/src/hooks/__tests__/usePmw3610.test.tsx
@@ -37,7 +37,7 @@ jest.mock("@cormoran/zmk-studio-react-hook", () => {
 type NotificationCallback = (n: CustomNotification) => void;
 
 function createWrapper() {
-  let subscribedCallback: NotificationCallback | null = null;
+  const subscribedCallbacks = new Set<NotificationCallback>();
   const zmkAppValue = {
     state: { connection: {}, customSubsystems: [] },
     findSubsystem: () => ({ index: 12, identifier: "cormoran__pmw3610" }),
@@ -47,10 +47,10 @@ function createWrapper() {
       callback: NotificationCallback;
     }) => {
       if (subscription.type === "custom") {
-        subscribedCallback = subscription.callback;
+        subscribedCallbacks.add(subscription.callback);
       }
       return () => {
-        subscribedCallback = null;
+        subscribedCallbacks.delete(subscription.callback);
       };
     },
   };
@@ -61,8 +61,9 @@ function createWrapper() {
   );
   return {
     Wrapper,
-    emit: (notification: CustomNotification) =>
-      subscribedCallback?.(notification),
+    emit: (notification: CustomNotification) => {
+      for (const callback of subscribedCallbacks) callback(notification);
+    },
   };
 }
 
@@ -118,7 +119,7 @@ describe("usePmw3610 frame capture/streaming", () => {
     await waitFor(() => expect(result.current.isAvailable).toBe(true));
 
     await act(async () => {
-      await result.current.captureOnce(0, 2);
+      await result.current.captureOnce(0, 0, 2);
     });
 
     expect(result.current.frame).not.toBeNull();
@@ -168,7 +169,7 @@ describe("usePmw3610 frame capture/streaming", () => {
     await waitFor(() => expect(result.current.isAvailable).toBe(true));
 
     await act(async () => {
-      await result.current.captureOnce(0, 2);
+      await result.current.captureOnce(0, 0, 2);
     });
 
     expect(result.current.frame).not.toBeNull();
@@ -197,7 +198,7 @@ describe("usePmw3610 frame capture/streaming", () => {
     await waitFor(() => expect(result.current.isAvailable).toBe(true));
 
     await act(async () => {
-      await result.current.startStreaming(0, 2);
+      await result.current.startStreaming(0, 0, 2);
     });
     expect(result.current.isStreaming).toBe(true);
 
@@ -242,7 +243,7 @@ describe("usePmw3610 frame capture/streaming", () => {
     await waitFor(() => expect(result.current.isAvailable).toBe(true));
 
     await act(async () => {
-      await result.current.startStreaming(0, 2);
+      await result.current.startStreaming(0, 0, 2);
     });
     expect(result.current.isStreaming).toBe(true);
 
@@ -292,7 +293,7 @@ describe("usePmw3610 frame capture/streaming", () => {
     await waitFor(() => expect(result.current.isAvailable).toBe(true));
 
     await act(async () => {
-      await result.current.startStreaming(0, 2);
+      await result.current.startStreaming(0, 0, 2);
     });
     expect(result.current.isStreaming).toBe(true);
 
@@ -309,6 +310,102 @@ describe("usePmw3610 frame capture/streaming", () => {
     const lastCall = setFrameStreamCalls[setFrameStreamCalls.length - 1];
     const lastReq = Request.decode(lastCall[0] as Uint8Array);
     expect(lastReq.setFrameStream?.enable).toBe(false);
+  });
+
+  it("discovers a peripheral sensor and routes diagnostics to its source", async () => {
+    jest.useFakeTimers();
+    mockCallRPC.mockImplementation(async (payload: Uint8Array) => {
+      const req = Request.decode(payload);
+      if (req.getInfo !== undefined) {
+        return encodeResponse({ getInfo: { devices: [], relayRequestId: 40 } });
+      }
+      if (req.readDiagnostics !== undefined) {
+        expect(req.readDiagnostics.source).toBe(2);
+        return encodeResponse({ deferred: { requestId: 41 } });
+      }
+      return encodeResponse({ error: { message: "unhandled" } });
+    });
+
+    const { Wrapper, emit } = createWrapper();
+    const { result } = renderHook(() => usePmw3610(), { wrapper: Wrapper });
+    await act(async () => Promise.resolve());
+
+    act(() => {
+      for (const [source, devices] of [
+        [1, []],
+        [
+          2,
+          [
+            {
+              ready: true,
+              productId: 0x3e,
+              revisionId: 1,
+              initError: 0,
+              deviceIndex: 0,
+            },
+          ],
+        ],
+      ] as const) {
+        emit({
+          subsystemIndex: 12,
+          payload: Notification.encode(
+            Notification.create({
+              peripheralResponse: {
+                source,
+                requestId: 40,
+                response: Response.create({ getInfo: { devices } }),
+              },
+            }),
+          ).finish(),
+        });
+      }
+    });
+    await act(async () => jest.advanceTimersByTimeAsync(2000));
+
+    expect(result.current.devices).toHaveLength(1);
+    expect(result.current.devices[0]).toMatchObject({
+      source: 2,
+      deviceIndex: 0,
+      productId: 0x3e,
+    });
+
+    let diagnosticsPromise: Promise<void>;
+    act(() => {
+      diagnosticsPromise = result.current.readDiagnostics(2, 0);
+    });
+    await act(async () => Promise.resolve());
+    act(() => {
+      emit({
+        subsystemIndex: 12,
+        payload: Notification.encode(
+          Notification.create({
+            peripheralResponse: {
+              source: 1,
+              requestId: 41,
+              response: Response.create({ error: { message: "left" } }),
+            },
+          }),
+        ).finish(),
+      });
+      emit({
+        subsystemIndex: 12,
+        payload: Notification.encode(
+          Notification.create({
+            peripheralResponse: {
+              source: 2,
+              requestId: 41,
+              response: Response.create({
+                readDiagnostics: { squal: 37 },
+              }),
+            },
+          }),
+        ).finish(),
+      });
+    });
+    await act(async () => diagnosticsPromise!);
+
+    expect(result.current.diagnostics?.squal).toBe(37);
+    jest.useRealTimers();
   });
 });
 

--- a/src/hooks/usePmw3610.ts
+++ b/src/hooks/usePmw3610.ts
@@ -19,6 +19,10 @@ import {
   isValidPixelByte,
   type FrameChunk,
 } from "../lib/pmw3610Frame";
+import {
+  PMW3610_SOURCE_ALL,
+  Pmw3610RelayCorrelator,
+} from "../lib/pmw3610Relay";
 
 export const PMW3610_SUBSYSTEM_IDENTIFIER = "cormoran__pmw3610";
 
@@ -43,14 +47,18 @@ export interface CapturedFrame {
   format: PixelFormat;
 }
 
+export interface SourcedPmw3610Device extends DeviceInfo {
+  source: number;
+}
+
 export interface UsePmw3610Return {
   isAvailable: boolean;
-  devices: DeviceInfo[];
+  devices: SourcedPmw3610Device[];
   diagnostics: ReadDiagnosticsResponse | null;
   isLoading: boolean;
   error: string | null;
   refresh: () => Promise<void>;
-  readDiagnostics: (deviceIndex: number) => Promise<void>;
+  readDiagnostics: (source: number, deviceIndex: number) => Promise<void>;
   /** Latest completed frame (one-shot capture or a completed streamed
    * frame), or null before any capture. */
   frame: CapturedFrame | null;
@@ -59,8 +67,16 @@ export interface UsePmw3610Return {
   /** Frames-per-second measured over ~1s windows while streaming; null
    * otherwise. */
   fps: number | null;
-  captureOnce: (deviceIndex: number, side: number) => Promise<void>;
-  startStreaming: (deviceIndex: number, side: number) => Promise<void>;
+  captureOnce: (
+    source: number,
+    deviceIndex: number,
+    side: number,
+  ) => Promise<void>;
+  startStreaming: (
+    source: number,
+    deviceIndex: number,
+    side: number,
+  ) => Promise<void>;
   stopStreaming: () => Promise<void>;
 }
 
@@ -73,13 +89,14 @@ export function usePmw3610(): UsePmw3610Return {
     PMW3610_SUBSYSTEM_IDENTIFIER,
     CODEC,
   );
-  const [devices, setDevices] = useState<DeviceInfo[]>([]);
+  const [devices, setDevices] = useState<SourcedPmw3610Device[]>([]);
   const [diagnostics, setDiagnostics] =
     useState<ReadDiagnosticsResponse | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   const subsystemIndex = subsystem?.index;
+  const relayRef = useRef(new Pmw3610RelayCorrelator());
 
   const callRpc = useCallback(
     async (request: Request): Promise<Response | null> => {
@@ -92,17 +109,41 @@ export function usePmw3610(): UsePmw3610Return {
     [ready, call],
   );
 
+  const callRpcAwaitingRelay = useCallback(
+    async (request: Request, source: number): Promise<Response | null> => {
+      const response = await callRpc(request);
+      if (!response?.deferred) return response;
+      return relayRef.current.waitFor(response.deferred.requestId, source);
+    },
+    [callRpc],
+  );
+
   const refresh = useCallback(async () => {
     if (!ready) return;
     setIsLoading(true);
     setError(null);
     try {
-      const resp = await callRpc(Request.create({ getInfo: {} }));
+      const resp = await callRpc(
+        Request.create({ getInfo: { source: PMW3610_SOURCE_ALL } }),
+      );
       if (!resp) return;
       if (resp.error) {
         throw new Error(resp.error.message);
       }
-      setDevices(resp.getInfo?.devices ?? []);
+      const found: SourcedPmw3610Device[] = (resp.getInfo?.devices ?? []).map(
+        (device) => ({ ...device, source: 0 }),
+      );
+      const requestId = resp.getInfo?.relayRequestId ?? 0;
+      if (requestId) {
+        const peripheralResponses =
+          await relayRef.current.collectBroadcast(requestId);
+        for (const { source, response } of peripheralResponses) {
+          for (const device of response.getInfo?.devices ?? []) {
+            found.push({ ...device, source });
+          }
+        }
+      }
+      setDevices(found);
     } catch (err) {
       setError(err instanceof Error ? err.message : "Unknown error");
     } finally {
@@ -111,11 +152,12 @@ export function usePmw3610(): UsePmw3610Return {
   }, [ready, callRpc]);
 
   const readDiagnostics = useCallback(
-    async (deviceIndex: number) => {
+    async (source: number, deviceIndex: number) => {
       setError(null);
       try {
-        const resp = await callRpc(
-          Request.create({ readDiagnostics: { deviceIndex } }),
+        const resp = await callRpcAwaitingRelay(
+          Request.create({ readDiagnostics: { source, deviceIndex } }),
+          source,
         );
         if (!resp) return;
         if (resp.error) {
@@ -126,8 +168,24 @@ export function usePmw3610(): UsePmw3610Return {
         setError(err instanceof Error ? err.message : "Unknown error");
       }
     },
-    [callRpc],
+    [callRpcAwaitingRelay],
   );
+
+  useEffect(() => {
+    if (!zmkApp || subsystemIndex === undefined) return;
+    const relay = relayRef.current;
+    const unsubscribe = zmkApp.onNotification({
+      type: "custom",
+      subsystemIndex,
+      callback: (notification) => {
+        relay.handle(notification.payload);
+      },
+    });
+    return () => {
+      unsubscribe();
+      relay.clear();
+    };
+  }, [zmkApp, subsystemIndex]);
 
   // Auto-fetch sensor info when the subsystem becomes available.
   useEffect(() => {
@@ -149,6 +207,7 @@ export function usePmw3610(): UsePmw3610Return {
   const fpsWindowStartRef = useRef(0);
   const unsubscribeStreamRef = useRef<(() => void) | null>(null);
   const streamingDeviceIndexRef = useRef(0);
+  const streamingSourceRef = useRef(0);
   // Per-frame_id incremental assembler, keyed so a late chunk from a
   // previous frame_id (should not happen, but notifications are
   // best-effort/unordered in principle) cannot corrupt the current frame.
@@ -157,14 +216,15 @@ export function usePmw3610(): UsePmw3610Return {
   );
 
   const captureOnce = useCallback(
-    async (deviceIndex: number, side: number) => {
+    async (source: number, deviceIndex: number, side: number) => {
       setIsCapturing(true);
       setError(null);
       try {
-        const captureResp = await callRpc(
+        const captureResp = await callRpcAwaitingRelay(
           Request.create({
-            captureFrame: { deviceIndex, pixelCount: side * side },
+            captureFrame: { source, deviceIndex, pixelCount: side * side },
           }),
+          source,
         );
         if (!captureResp) return;
         if (captureResp.error) {
@@ -180,10 +240,15 @@ export function usePmw3610(): UsePmw3610Return {
         const offsets = chunkOffsets(totalLength, chunkSize);
         const chunks: FrameChunk[] = [];
         for (const offset of offsets) {
-          const chunkResp = await callRpc(
+          const chunkResp = await callRpcAwaitingRelay(
             Request.create({
-              getFrameChunk: { frameId: captureFrame.frameId, offset },
+              getFrameChunk: {
+                source,
+                frameId: captureFrame.frameId,
+                offset,
+              },
             }),
+            source,
           );
           if (!chunkResp) return;
           if (chunkResp.error) {
@@ -217,23 +282,26 @@ export function usePmw3610(): UsePmw3610Return {
         setIsCapturing(false);
       }
     },
-    [callRpc],
+    [callRpcAwaitingRelay],
   );
 
   const setFrameStreamRpc = useCallback(
     async (
+      source: number,
       deviceIndex: number,
       enable: boolean,
       side: number,
     ): Promise<boolean> => {
-      const resp = await callRpc(
+      const resp = await callRpcAwaitingRelay(
         Request.create({
           setFrameStream: {
+            source,
             deviceIndex,
             enable,
             pixelCount: enable ? side * side : 0,
           },
         }),
+        source,
       );
       if (!resp) return false;
       if (resp.error) {
@@ -241,7 +309,7 @@ export function usePmw3610(): UsePmw3610Return {
       }
       return resp.setFrameStream?.streaming ?? false;
     },
-    [callRpc],
+    [callRpcAwaitingRelay],
   );
 
   const stopStreaming = useCallback(async () => {
@@ -249,16 +317,22 @@ export function usePmw3610(): UsePmw3610Return {
     unsubscribeStreamRef.current?.();
     unsubscribeStreamRef.current = null;
     try {
-      await setFrameStreamRpc(streamingDeviceIndexRef.current, false, 0);
+      await setFrameStreamRpc(
+        streamingSourceRef.current,
+        streamingDeviceIndexRef.current,
+        false,
+        0,
+      );
     } catch (err) {
       setError(err instanceof Error ? err.message : "Unknown error");
     }
   }, [setFrameStreamRpc]);
 
   const startStreaming = useCallback(
-    async (deviceIndex: number, side: number) => {
+    async (source: number, deviceIndex: number, side: number) => {
       if (isStreaming || !zmkApp || subsystemIndex === undefined) return;
       setError(null);
+      streamingSourceRef.current = source;
       streamingDeviceIndexRef.current = deviceIndex;
       assemblersRef.current.clear();
       frameCountRef.current = 0;
@@ -277,7 +351,7 @@ export function usePmw3610(): UsePmw3610Return {
               return;
             }
             const chunk = decoded.frameStreamChunk;
-            if (!chunk) return;
+            if (!chunk || chunk.source !== source) return;
 
             const assemblers = assemblersRef.current;
             for (const key of assemblers.keys()) {
@@ -322,7 +396,12 @@ export function usePmw3610(): UsePmw3610Return {
             }
           },
         });
-        const streaming = await setFrameStreamRpc(deviceIndex, true, side);
+        const streaming = await setFrameStreamRpc(
+          source,
+          deviceIndex,
+          true,
+          side,
+        );
         setIsStreaming(streaming);
         if (!streaming) {
           unsubscribeStreamRef.current?.();

--- a/src/lib/__tests__/pmw3610Relay.test.ts
+++ b/src/lib/__tests__/pmw3610Relay.test.ts
@@ -1,0 +1,38 @@
+import { Notification, Response } from "../../proto/cormoran/pmw3610/pmw3610";
+import { Pmw3610RelayCorrelator } from "../pmw3610Relay";
+
+function peripheralResponse(
+  source: number,
+  requestId: number,
+  response: Parameters<typeof Response.create>[0],
+) {
+  return Notification.encode(
+    Notification.create({
+      peripheralResponse: {
+        source,
+        requestId,
+        response: Response.create(response),
+      },
+    }),
+  ).finish();
+}
+
+it("waits for the requested peripheral when both halves respond", async () => {
+  const correlator = new Pmw3610RelayCorrelator();
+  const result = correlator.waitFor(7, 2);
+
+  expect(
+    correlator.handle(peripheralResponse(1, 7, { error: { message: "left" } })),
+  ).toBe(false);
+  expect(
+    correlator.handle(
+      peripheralResponse(2, 7, {
+        readDiagnostics: { squal: 42 },
+      }),
+    ),
+  ).toBe(true);
+
+  await expect(result).resolves.toMatchObject({
+    readDiagnostics: { squal: 42 },
+  });
+});

--- a/src/lib/pmw3610Relay.ts
+++ b/src/lib/pmw3610Relay.ts
@@ -1,0 +1,83 @@
+import { Notification, Response } from "../proto/cormoran/pmw3610/pmw3610";
+
+const RELAY_TIMEOUT_MS = 6000;
+const BROADCAST_WINDOW_MS = 2000;
+
+export const PMW3610_SOURCE_ALL = 0xffffffff;
+
+interface PendingRequest {
+  source: number;
+  resolve: (response: Response) => void;
+  reject: (error: Error) => void;
+  timeout: ReturnType<typeof setTimeout>;
+}
+
+export class Pmw3610RelayCorrelator {
+  private pending = new Map<number, PendingRequest>();
+  private broadcasts = new Map<
+    number,
+    Array<{ source: number; response: Response }>
+  >();
+
+  waitFor(requestId: number, source: number): Promise<Response> {
+    return new Promise((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        this.pending.delete(requestId);
+        reject(new Error(`Peripheral ${source} did not respond.`));
+      }, RELAY_TIMEOUT_MS);
+      this.pending.set(requestId, { source, resolve, reject, timeout });
+    });
+  }
+
+  collectBroadcast(
+    requestId: number,
+  ): Promise<Array<{ source: number; response: Response }>> {
+    const responses: Array<{ source: number; response: Response }> = [];
+    this.broadcasts.set(requestId, responses);
+    return new Promise((resolve) => {
+      setTimeout(() => {
+        this.broadcasts.delete(requestId);
+        resolve(responses);
+      }, BROADCAST_WINDOW_MS);
+    });
+  }
+
+  handle(payload: Uint8Array): boolean {
+    let notification: Notification;
+    try {
+      notification = Notification.decode(payload);
+    } catch {
+      return false;
+    }
+
+    const peripheral = notification.peripheralResponse;
+    if (!peripheral?.response) return false;
+
+    const pending = this.pending.get(peripheral.requestId);
+    if (pending?.source === peripheral.source) {
+      clearTimeout(pending.timeout);
+      this.pending.delete(peripheral.requestId);
+      pending.resolve(peripheral.response);
+      return true;
+    }
+
+    const responses = this.broadcasts.get(peripheral.requestId);
+    if (responses) {
+      responses.push({
+        source: peripheral.source,
+        response: peripheral.response,
+      });
+      return true;
+    }
+    return false;
+  }
+
+  clear(): void {
+    for (const pending of this.pending.values()) {
+      clearTimeout(pending.timeout);
+      pending.reject(new Error("PMW3610 relay disconnected."));
+    }
+    this.pending.clear();
+    this.broadcasts.clear();
+  }
+}


### PR DESCRIPTION
Support PMW3610 devices hosted on split peripherals. The hook now discovers all sources, correlates deferred responses by both request ID and source, and routes diagnostics/frame requests to the selected source. Includes regression coverage for two peripheral responses sharing a request ID. Validation: 83 Jest suites passed (686 tests, 1 skipped), npm run lint passed, and npm run build passed.