### PR TITLE
fix(electron): attach installers to release created by release.yml

### DIFF
--- a/.github/workflows/electron.yml
+++ b/.github/workflows/electron.yml
@@ -1,9 +1,19 @@
 name: Build Desktop App
 
+# Desktop builds are sliced off the release that `release.yml` just published,
+# so the tag must already exist before this workflow can attach installers to
+# it. Triggering on `release: published` (instead of `push: tags: v*`) means
+# this workflow fires once per version, in lock-step with `release.yml`, and it
+# uploads installers onto the *same* GitHub Release that `release.yml` created
+# with `gh release create` (date-based versions like `2026.08.11.1`, tagged
+# `v2026.08.11.1`).
+#
+# `workflow_dispatch` is kept so an installer-only build can be triggered
+# manually; in that case the `attach-release` job is skipped (no release to
+# attach to) and the artifacts are still available for download.
 on:
-  push:
-    tags:
-      - "v*"
+  release:
+    types: [published]
   workflow_dispatch:
 
 jobs:
@@ -72,7 +82,7 @@ jobs:
   release:
     needs: build
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/v')
+    if: github.event_name == 'release'
     permissions:
       contents: write
     steps:
@@ -82,12 +92,15 @@ jobs:
           pattern: "*-installer"
           merge-multiple: true
 
-      - name: Create Release
-        uses: softprops/action-gh-release@v2
-        with:
-          files: |
-            release/*.dmg
-            release/*.exe
-          generate_release_notes: true
+      - name: Attach installers to the existing release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # The release was already created (with --notes pointing at the in-app
+          # release-notes page) by `.github/workflows/release.yml`; we only
+          # upload the macOS .dmg and Windows .exe artifacts onto it.
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          gh release upload "$RELEASE_TAG" \
+            release/*.dmg \
+            release/*.exe \
+            --clobber


### PR DESCRIPTION
## Description

`electron.yml` was creating a duplicate, orphan GitHub Release for every
desktop build: it triggered on `push: tags: v*` and ran
`softprops/action-gh-release@v2`, which created a second release entry for
the same tag with auto-generated notes, separate from the one
`release.yml` had just produced with `gh release create` (pointing at the
in-app release-notes page).

The two workflows now coordinate:

- **`release.yml`** keeps doing what it did: tag the commit `vYYYY.MM.DD.N`,
  deploy the web build, and `gh release create` the GitHub Release.
- **`electron.yml`** switches its trigger from `push: tags: v*` to
  `release: published` and replaces the duplicate create-release step with
  `gh release upload "$RELEASE_TAG" release/*.dmg release/*.exe --clobber`,
  which attaches the macOS `.dmg` and Windows `.exe` to the existing
  release.

Result: one GitHub Release per version, with both the release-notes link
(from `release.yml`) and the desktop installers (from `electron.yml`),
and no orphan release.

`workflow_dispatch` is kept for manual installer-only builds; the attach
job is gated on `github.event_name == 'release'` so manual runs still
produce the installer artifacts without breaking anything.

## Release notes

- [x] Added an `upcoming` release notes entry, or this change is internal-only

Internal-only change to the desktop build workflow; no user-visible
behavior change beyond no longer creating an empty/orphan release entry
on GitHub.

## CLA (Contributor License Agreement)

By submitting this pull request, I agree that my contributions
are licensed under the project's current license.

I also grant the maintainer(s) of this project the right to relicense
my contributions under any license, for use in future versions of the project.
This does not affect the license of any previously released versions.