### PR TITLE
feat: expose keyboard settings through WebMCP

### DIFF
--- a/src/components/AdvancedSettingsSection.tsx
+++ b/src/components/AdvancedSettingsSection.tsx
@@ -33,6 +33,14 @@ import { LoadingIndicator } from "./LoadingIndicator";
 import { useKeymap, type BehaviorDefinition } from "../hooks/useKeymap";
 import { useLanguage } from "../hooks/useLanguage";
 import {
+  useWebMCPTools,
+  type WebMCPToolDefinition,
+} from "../lib/webmcp/useWebMCPTools";
+import {
+  encodeSettingValue,
+  settingKey,
+} from "../lib/versionHistory/tabs/customSettings";
+import {
   type Setting,
   type SettingBehaviorValue,
   type SettingConstraint,
@@ -161,6 +169,124 @@ const PMW3610_FIELD_DESCRIPTIONS: Record<string, string> = {
 function fieldName(key: string): string {
   const at = key.indexOf("@");
   return at === -1 ? key : key.slice(0, at);
+}
+
+type WebMCPAdvancedSettingValue = {
+  kind: "int32" | "boolean" | "string" | "hex" | "behavior";
+  value?: unknown;
+  behaviorId?: number;
+  param1?: number;
+  param2?: number;
+};
+
+type WebMCPAdvancedSettingInput = {
+  customSubsystemIndex: number;
+  key: string;
+  source: number;
+  arrayIndex?: number;
+  value: WebMCPAdvancedSettingValue;
+};
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isInt32(value: unknown): value is number {
+  return (
+    typeof value === "number" &&
+    Number.isSafeInteger(value) &&
+    value >= -2147483648 &&
+    value <= 2147483647
+  );
+}
+
+function isUint32(value: unknown): value is number {
+  return (
+    typeof value === "number" &&
+    Number.isSafeInteger(value) &&
+    value >= 0 &&
+    value <= 4294967295
+  );
+}
+
+function isWebMCPAdvancedSettingInput(
+  value: unknown,
+): value is WebMCPAdvancedSettingInput {
+  if (
+    !isObject(value) ||
+    !isUint32(value.customSubsystemIndex) ||
+    typeof value.key !== "string" ||
+    value.key.length === 0 ||
+    !isUint32(value.source) ||
+    (value.arrayIndex !== undefined && !isUint32(value.arrayIndex)) ||
+    !isObject(value.value)
+  ) {
+    return false;
+  }
+
+  return (
+    value.value.kind === "int32" ||
+    value.value.kind === "boolean" ||
+    value.value.kind === "string" ||
+    value.value.kind === "hex" ||
+    value.value.kind === "behavior"
+  );
+}
+
+function webMCPValueForSetting(
+  currentValue: SettingValue | undefined,
+  input: WebMCPAdvancedSettingValue,
+): SettingValue | null {
+  const current = currentValue?.arrayValue?.value ?? currentValue;
+  if (!current) return null;
+
+  if (current.int32Value !== undefined) {
+    return input.kind === "int32" && isInt32(input.value)
+      ? { int32Value: input.value }
+      : null;
+  }
+  if (current.boolValue !== undefined) {
+    return input.kind === "boolean" && typeof input.value === "boolean"
+      ? { boolValue: input.value }
+      : null;
+  }
+  if (current.stringValue !== undefined) {
+    return input.kind === "string" && typeof input.value === "string"
+      ? { stringValue: input.value }
+      : null;
+  }
+  if (current.bytesValue !== undefined) {
+    if (
+      input.kind !== "hex" ||
+      typeof input.value !== "string" ||
+      !/^(?:[0-9a-fA-F]{2})*$/.test(input.value)
+    ) {
+      return null;
+    }
+    const bytes = new Uint8Array(input.value.length / 2);
+    for (let index = 0; index < bytes.length; index += 1) {
+      bytes[index] = Number.parseInt(
+        input.value.slice(index * 2, index * 2 + 2),
+        16,
+      );
+    }
+    return { bytesValue: bytes };
+  }
+  if (current.behaviorValue !== undefined) {
+    return input.kind === "behavior" &&
+      isUint32(input.behaviorId) &&
+      isInt32(input.param1) &&
+      isInt32(input.param2)
+      ? {
+          behaviorValue: {
+            behaviorId: input.behaviorId,
+            param1: input.param1,
+            param2: input.param2,
+          },
+        }
+      : null;
+  }
+  return null;
 }
 
 function findScrollableAncestor(el: Element | null): Element | null {
@@ -847,7 +973,7 @@ interface SettingRowProps {
   description?: string;
   layers: { id: number; name: string }[];
   behaviors: Map<number, BehaviorDefinition>;
-  onWrite: (setting: Setting, value: SettingValue) => Promise<void>;
+  onWrite: (setting: Setting, value: SettingValue) => Promise<unknown>;
 }
 
 function SettingRow({
@@ -1239,6 +1365,177 @@ export function AdvancedSettingsSection() {
       void loadSettings();
     }
   }, [hasExpanded, loadSettings]);
+
+  const webMCPTools: WebMCPToolDefinition[] = [
+    {
+      name: "list_advanced_keyboard_settings",
+      description:
+        "List custom keyboard settings exposed by the connected firmware. Read this before changing a custom setting to obtain its exact subsystem index, key, source, array index, and current encoded value.",
+      inputSchema: {
+        type: "object",
+        properties: {},
+        additionalProperties: false,
+      },
+      annotations: { readOnlyHint: true },
+      execute: async () => {
+        const settings = await customSettings.loadSettings();
+        return {
+          success: true,
+          settings: settings.map((setting) => ({
+            customSubsystemIndex: setting.customSubsystemIndex,
+            subsystem: customSettings.sections.find(
+              (section) =>
+                section.customSubsystemIndex === setting.customSubsystemIndex,
+            )?.identifier,
+            key: setting.key,
+            source: setting.source,
+            arrayIndex: setting.value?.arrayValue?.index,
+            value: encodeSettingValue(setting.value),
+            hasUnsavedValue: setting.hasUnsavedValue,
+          })),
+        };
+      },
+    },
+    {
+      name: "set_advanced_keyboard_setting",
+      description:
+        "Change one custom keyboard setting in memory. Use list_advanced_keyboard_settings first, then save the affected section to persist the change. The replacement value must have the same type as the listed value.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          customSubsystemIndex: { type: "integer", minimum: 0 },
+          key: { type: "string", minLength: 1 },
+          source: { type: "integer", minimum: 0 },
+          arrayIndex: { type: "integer", minimum: 0 },
+          value: {
+            type: "object",
+            properties: {
+              kind: {
+                type: "string",
+                enum: ["int32", "boolean", "string", "hex", "behavior"],
+              },
+              value: {},
+              behaviorId: { type: "integer", minimum: 0 },
+              param1: { type: "integer" },
+              param2: { type: "integer" },
+            },
+            required: ["kind"],
+            additionalProperties: false,
+          },
+        },
+        required: ["customSubsystemIndex", "key", "source", "value"],
+        additionalProperties: false,
+      },
+      execute: async (input) => {
+        if (!isWebMCPAdvancedSettingInput(input)) {
+          return {
+            success: false,
+            error:
+              "Provide a subsystem index, key, source, and a valid typed value.",
+          };
+        }
+
+        const settings = await customSettings.loadSettings();
+        const setting = settings.find(
+          (candidate) =>
+            candidate.customSubsystemIndex === input.customSubsystemIndex &&
+            candidate.key === input.key &&
+            candidate.source === input.source &&
+            candidate.value?.arrayValue?.index === input.arrayIndex,
+        );
+        if (!setting) {
+          return {
+            success: false,
+            error:
+              "That custom setting was not found. Refresh the list and use an exact setting identity.",
+          };
+        }
+
+        const value = webMCPValueForSetting(setting.value, input.value);
+        if (!value) {
+          return {
+            success: false,
+            error:
+              "The supplied value does not match this setting's type or is outside the supported WebMCP format.",
+          };
+        }
+
+        const success = await customSettings.writeSettingToMemory(
+          setting,
+          value,
+        );
+        return success
+          ? {
+              success: true,
+              setting: settingKey(setting),
+              persisted: false,
+              message:
+                "The setting is updated in memory. Call save_advanced_keyboard_settings_section to persist it.",
+            }
+          : {
+              success: false,
+              error:
+                "The firmware rejected the setting update. Check its constraints and unlock state.",
+            };
+      },
+    },
+    ...(["save", "discard", "reset"] as const).map((operation) => ({
+      name: `${operation}_advanced_keyboard_settings_section`,
+      description:
+        operation === "save"
+          ? "Persist all in-memory custom setting changes for one firmware subsystem."
+          : operation === "discard"
+            ? "Discard all in-memory custom setting changes for one firmware subsystem."
+            : "Reset every custom setting in one firmware subsystem to its firmware defaults. This discards local edits.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          customSubsystemIndex: { type: "integer", minimum: 0 },
+        },
+        required: ["customSubsystemIndex"],
+        additionalProperties: false,
+      },
+      execute: async (input: unknown) => {
+        if (!isObject(input) || !isUint32(input.customSubsystemIndex)) {
+          return {
+            success: false,
+            error: "customSubsystemIndex must be a non-negative integer.",
+          };
+        }
+        const index = Number(input.customSubsystemIndex);
+        const success =
+          operation === "save"
+            ? await customSettings.saveSection(index)
+            : operation === "discard"
+              ? await customSettings.discardSection(index)
+              : await customSettings.resetSection(index);
+        if (!success) {
+          return {
+            success: false,
+            error:
+              "The firmware rejected the section operation. Check the connection and unlock state.",
+          };
+        }
+        // The underlying operation reloads settings and reports any firmware
+        // error through its state. A fresh list makes the returned result
+        // independently inspectable by the agent.
+        const refreshed = await customSettings.loadSettings();
+        return {
+          success: true,
+          customSubsystemIndex: index,
+          operation,
+          settings: refreshed
+            .filter((setting) => setting.customSubsystemIndex === index)
+            .map((setting) => ({
+              key: settingKey(setting),
+              value: encodeSettingValue(setting.value),
+              hasUnsavedValue: setting.hasUnsavedValue,
+            })),
+        };
+      },
+    })),
+  ];
+  useWebMCPTools(webMCPTools);
 
   const layers = useMemo(
     () =>

--- a/src/hooks/useCustomSettings.ts
+++ b/src/hooks/useCustomSettings.ts
@@ -39,14 +39,14 @@ export interface UseCustomSettingsReturn {
   sections: CustomSettingsSection[];
   isLoading: boolean;
   error: string | null;
-  loadSettings: () => Promise<void>;
+  loadSettings: () => Promise<Setting[]>;
   writeSettingToMemory: (
     setting: Setting,
     value: SettingValue,
-  ) => Promise<void>;
-  saveSection: (customSubsystemIndex: number) => Promise<void>;
-  discardSection: (customSubsystemIndex: number) => Promise<void>;
-  resetSection: (customSubsystemIndex: number) => Promise<void>;
+  ) => Promise<boolean>;
+  saveSection: (customSubsystemIndex: number) => Promise<boolean>;
+  discardSection: (customSubsystemIndex: number) => Promise<boolean>;
+  resetSection: (customSubsystemIndex: number) => Promise<boolean>;
   createSetting: (
     key: string,
     value: SettingValue,
@@ -286,10 +286,10 @@ export function useCustomSettings(
     zmkApp,
   ]);
 
-  const loadSettings = useCallback(async () => {
+  const loadSettings = useCallback(async (): Promise<Setting[]> => {
     if (!ready) {
       setSettings([]);
-      return;
+      return [];
     }
 
     setIsLoading(true);
@@ -310,6 +310,7 @@ export function useCustomSettings(
               (b.value?.arrayValue?.index ?? -1),
         ),
       );
+      return listedSettings;
     } catch (err) {
       console.error("Failed to load custom settings:", err);
       setError(
@@ -317,13 +318,14 @@ export function useCustomSettings(
           ? err.message
           : t("Failed to load custom settings"),
       );
+      return [];
     } finally {
       setIsLoading(false);
     }
   }, [collectListSettings, ready, t]);
 
   const writeSettingToMemory = useCallback(
-    async (setting: Setting, value: SettingValue) => {
+    async (setting: Setting, value: SettingValue): Promise<boolean> => {
       const nextValue = valueWithArrayShape(setting, value);
 
       setSettings((prev) =>
@@ -377,6 +379,7 @@ export function useCustomSettings(
           );
         }
         setError(null);
+        return true;
       } catch (err) {
         console.error("Failed to write custom setting:", err);
         setError(
@@ -385,6 +388,7 @@ export function useCustomSettings(
             : t("Failed to write custom setting"),
         );
         await loadSettings();
+        return false;
       }
     },
     [callCustomRequest, loadSettings, t],
@@ -428,7 +432,7 @@ export function useCustomSettings(
     async (
       scope: SettingScope,
       type: "saveSettings" | "discardSettings" | "resetSettings",
-    ) => {
+    ): Promise<boolean> => {
       setIsLoading(true);
       setError(null);
       try {
@@ -440,6 +444,7 @@ export function useCustomSettings(
           }),
         );
         await loadSettings();
+        return true;
       } catch (err) {
         console.error(`Failed to ${type}:`, err);
         const fallback =
@@ -449,6 +454,7 @@ export function useCustomSettings(
               ? t("Failed to discard settings")
               : t("Failed to reset settings");
         setError(err instanceof Error ? err.message : fallback);
+        return false;
       } finally {
         setIsLoading(false);
       }

--- a/src/hooks/useSettings.ts
+++ b/src/hooks/useSettings.ts
@@ -32,8 +32,8 @@ export interface UseSettingsReturn {
   devices: DeviceActivitySettings[];
   isLoading: boolean;
   error: string | null;
-  loadAllSettings: () => Promise<void>;
-  setActivitySettings: (idleMs: number, sleepMs: number) => Promise<void>;
+  loadAllSettings: () => Promise<DeviceActivitySettings[]>;
+  setActivitySettings: (idleMs: number, sleepMs: number) => Promise<boolean>;
   resetToDefaults: () => Promise<void>;
 }
 
@@ -54,10 +54,12 @@ export function useSettings(): UseSettingsReturn {
   // Extract subsystem index as a stable primitive value for dependencies
   const subsystemIndex = subsystem?.index;
 
-  const loadAllSettings = useCallback(async () => {
+  const loadAllSettings = useCallback(async (): Promise<
+    DeviceActivitySettings[]
+  > => {
     if (!ready || !zmkApp || subsystemIndex === undefined) {
       setError("Not connected to device or subsystem not found");
-      return;
+      return [];
     }
 
     setIsLoading(true);
@@ -124,21 +126,37 @@ export function useSettings(): UseSettingsReturn {
         );
         unsubscribe();
       }
+      return Array.from(deviceMap.values());
     } catch (err) {
       console.error("Failed to load settings:", err);
       setError(
         `Failed to load settings: ${err instanceof Error ? err.message : "Unknown error"}`,
       );
+      return [];
     } finally {
       setIsLoading(false);
     }
   }, [zmkApp, ready, subsystemIndex, call]);
 
   const setActivitySettings = useCallback(
-    async (idleMs: number, sleepMs: number) => {
+    async (idleMs: number, sleepMs: number): Promise<boolean> => {
       if (!ready) {
         setError("Not connected to device or subsystem not found");
-        return;
+        return false;
+      }
+
+      if (
+        !Number.isSafeInteger(idleMs) ||
+        !Number.isSafeInteger(sleepMs) ||
+        idleMs < 0 ||
+        sleepMs < 0 ||
+        idleMs > 0xffffffff ||
+        sleepMs > 0xffffffff
+      ) {
+        setError(
+          "Activity timeouts must be whole milliseconds from 0 to 4294967295",
+        );
+        return false;
       }
 
       setIsLoading(true);
@@ -160,16 +178,21 @@ export function useSettings(): UseSettingsReturn {
         if (resp) {
           if (resp.error) {
             setError(resp.error.message);
+            return false;
           } else if (resp.setActivitySettings?.success) {
             // Successfully set, reload settings
             await loadAllSettings();
+            return true;
           }
         }
+        setError("Failed to update activity settings");
+        return false;
       } catch (err) {
         console.error("Failed to set activity settings:", err);
         setError(
           `Failed to set activity settings: ${err instanceof Error ? err.message : "Unknown error"}`,
         );
+        return false;
       } finally {
         setIsLoading(false);
       }

--- a/src/hooks/versionHistory/customSettingsRestore.ts
+++ b/src/hooks/versionHistory/customSettingsRestore.ts
@@ -27,7 +27,7 @@ import type { DiffLabeler, JsonValue } from "../../lib/versionHistory";
  */
 export async function applyCustomSettingsSnapshot(
   readSections: () => CustomSettingsSection[],
-  write: (setting: Setting, value: SettingValue) => Promise<void>,
+  write: (setting: Setting, value: SettingValue) => Promise<unknown>,
   snapshot: CustomSettingsSnapshot,
 ): Promise<void> {
   for (const [identifier, values] of Object.entries(snapshot.sections)) {

--- a/src/lib/webmcp/__tests__/useWebMCPTools.test.tsx
+++ b/src/lib/webmcp/__tests__/useWebMCPTools.test.tsx
@@ -1,0 +1,50 @@
+import { act, render, waitFor } from "@testing-library/react";
+import { useWebMCPTools } from "../useWebMCPTools";
+
+function ToolHarness({ answer }: { answer: number }) {
+  useWebMCPTools([
+    {
+      name: "test_tool",
+      description: "A test tool.",
+      inputSchema: {
+        type: "object",
+        properties: {},
+        additionalProperties: false,
+      },
+      execute: async () => ({ answer }),
+    },
+  ]);
+  return null;
+}
+
+describe("useWebMCPTools", () => {
+  afterEach(() => {
+    delete document.modelContext;
+  });
+
+  it("registers a tool once and uses its latest React callback", async () => {
+    let registeredTool: WebMCPRegisteredTool | undefined;
+    const registerTool = jest.fn(async (tool: WebMCPRegisteredTool) => {
+      registeredTool = tool;
+    });
+    const unregisterTool = jest.fn(async () => {});
+    document.modelContext = { registerTool, unregisterTool };
+
+    const { rerender, unmount } = render(<ToolHarness answer={1} />);
+
+    await waitFor(() => expect(registeredTool).toBeDefined());
+    expect(registerTool).toHaveBeenCalledTimes(1);
+    await expect(registeredTool!.execute({})).resolves.toEqual({ answer: 1 });
+
+    rerender(<ToolHarness answer={2} />);
+
+    await act(async () => {});
+    expect(registerTool).toHaveBeenCalledTimes(1);
+    await expect(registeredTool!.execute({})).resolves.toEqual({ answer: 2 });
+
+    unmount();
+    await waitFor(() =>
+      expect(unregisterTool).toHaveBeenCalledWith("test_tool"),
+    );
+  });
+});

--- a/src/lib/webmcp/useWebMCPTools.ts
+++ b/src/lib/webmcp/useWebMCPTools.ts
@@ -1,0 +1,85 @@
+import { useEffect, useRef } from "react";
+
+export interface WebMCPToolDefinition {
+  name: string;
+  description: string;
+  inputSchema: Record<string, unknown>;
+  annotations?: {
+    readOnlyHint?: boolean;
+  };
+  execute: (input: unknown) => Promise<Record<string, unknown>>;
+}
+
+/**
+ * Registers page capabilities with browsers that implement WebMCP.
+ *
+ * The registered callback always reads the latest React callback from a ref.
+ * This keeps tools in sync with the connected keyboard and the current page
+ * state without repeatedly registering the same tool on every render.
+ */
+export function useWebMCPTools(tools: readonly WebMCPToolDefinition[]): void {
+  const toolsRef = useRef(tools);
+  toolsRef.current = tools;
+
+  const toolNames = tools.map((tool) => tool.name);
+  const toolKey = toolNames.join("\u0000");
+
+  useEffect(() => {
+    const modelContext = document.modelContext;
+    if (!modelContext?.registerTool) {
+      return;
+    }
+
+    let disposed = false;
+
+    void Promise.all(
+      tools.map(async (tool) => {
+        try {
+          await modelContext.registerTool({
+            name: tool.name,
+            description: tool.description,
+            inputSchema: tool.inputSchema,
+            annotations: tool.annotations,
+            execute: async (input) => {
+              const currentTool = toolsRef.current.find(
+                (candidate) => candidate.name === tool.name,
+              );
+              if (!currentTool) {
+                return {
+                  success: false,
+                  error: "This page capability is no longer available.",
+                };
+              }
+              return currentTool.execute(input);
+            },
+          });
+        } catch (error) {
+          // Unsupported browsers and duplicate registrations must leave the
+          // normal application UI fully functional.
+          if (!disposed) {
+            console.warn(`Could not register WebMCP tool ${tool.name}:`, error);
+          }
+        }
+      }),
+    );
+
+    return () => {
+      disposed = true;
+      if (!modelContext.unregisterTool) {
+        return;
+      }
+      void Promise.all(
+        toolNames.map(async (name) => {
+          try {
+            await modelContext.unregisterTool?.(name);
+          } catch (error) {
+            console.warn(`Could not unregister WebMCP tool ${name}:`, error);
+          }
+        }),
+      );
+    };
+    // Tool callbacks are intentionally read from toolsRef, so changing their
+    // closures doesn't cause duplicate registrations.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [toolKey]);
+}

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -27,6 +27,10 @@ import { useLanguage } from "../hooks/useLanguage";
 import { ResetVersionMenu } from "../components/versionHistory/ResetVersionMenu";
 import { VersionDiffModal } from "../components/versionHistory/VersionDiffModal";
 import { useSettingsVersionHistory } from "../hooks/versionHistory/useSettingsVersionHistory";
+import {
+  useWebMCPTools,
+  type WebMCPToolDefinition,
+} from "../lib/webmcp/useWebMCPTools";
 
 // Helper to format milliseconds to human readable
 function formatMs(
@@ -69,6 +73,19 @@ const SLEEP_PRESETS = [
   { value: 120, label: "2 hours" },
   { value: 240, label: "4 hours" },
 ];
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isTimeout(value: unknown): value is number {
+  return (
+    typeof value === "number" &&
+    Number.isSafeInteger(value) &&
+    value >= 0 &&
+    value <= 0xffffffff
+  );
+}
 
 interface TimeDropdownProps {
   value: number; // in milliseconds
@@ -315,8 +332,11 @@ export function SettingsPage() {
 
   const write = useCallback(
     async (value: { idleMs: number; sleepMs: number }) => {
-      await setActivitySettings(value.idleMs, value.sleepMs);
+      const success = await setActivitySettings(value.idleMs, value.sleepMs);
       setPending(null);
+      if (!success) {
+        return;
+      }
       setShowSaved(true);
       if (savedTimerRef.current) clearTimeout(savedTimerRef.current);
       savedTimerRef.current = setTimeout(() => setShowSaved(false), 2000);
@@ -345,6 +365,110 @@ export function SettingsPage() {
   };
 
   const isSaving = saveState === "queued" || saveState === "saving";
+
+  const webMCPTools: WebMCPToolDefinition[] = [
+    {
+      name: "get_power_management_settings",
+      description:
+        "Read the connected keyboard's central power-management timeouts in milliseconds.",
+      inputSchema: {
+        type: "object",
+        properties: {},
+        additionalProperties: false,
+      },
+      annotations: { readOnlyHint: true },
+      execute: async () => {
+        const current = (await loadAllSettings()).find(
+          (device) => device.sourceId === 0,
+        );
+        if (!current) {
+          return {
+            success: false,
+            error:
+              "Power-management settings are unavailable. Connect a compatible keyboard first.",
+          };
+        }
+        return {
+          success: true,
+          idleMs: current.idleMs,
+          sleepMs: current.sleepMs,
+          deviceName: current.deviceName,
+        };
+      },
+    },
+    {
+      name: "set_power_management_timeouts",
+      description:
+        "Persist the connected keyboard's idle and sleep timeouts. Both values are whole milliseconds; 0 disables that timeout.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          idleMs: {
+            type: "integer",
+            minimum: 0,
+            maximum: 4294967295,
+            description:
+              "Milliseconds before the keyboard enters idle mode; 0 means never.",
+          },
+          sleepMs: {
+            type: "integer",
+            minimum: 0,
+            maximum: 4294967295,
+            description: "Milliseconds before deep sleep; 0 means never.",
+          },
+        },
+        required: ["idleMs", "sleepMs"],
+        additionalProperties: false,
+      },
+      execute: async (input) => {
+        if (
+          !isObject(input) ||
+          !isTimeout(input.idleMs) ||
+          !isTimeout(input.sleepMs)
+        ) {
+          return {
+            success: false,
+            error:
+              "idleMs and sleepMs must be whole milliseconds from 0 to 4294967295.",
+          };
+        }
+
+        const success = await setActivitySettings(input.idleMs, input.sleepMs);
+        return success
+          ? { success: true, idleMs: input.idleMs, sleepMs: input.sleepMs }
+          : {
+              success: false,
+              error:
+                "The keyboard did not accept the power-management update. Check the connection and unlock state.",
+            };
+      },
+    },
+    {
+      name: "reset_all_keyboard_settings",
+      description:
+        "Factory-reset every persisted keyboard setting, including keymap and custom settings, to firmware defaults. This cannot be undone.",
+      inputSchema: {
+        type: "object",
+        properties: {},
+        additionalProperties: false,
+      },
+      execute: async () => {
+        const success = await resetAllSettings();
+        return success
+          ? {
+              success: true,
+              message:
+                "The keyboard reset request was accepted. The keyboard may reboot before the change is visible.",
+            }
+          : {
+              success: false,
+              error:
+                "The keyboard reset did not complete. Check the connection and unlock state.",
+            };
+      },
+    },
+  ];
+  useWebMCPTools(webMCPTools);
 
   return (
     <div className="p-6 h-full overflow-auto">

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,5 +1,24 @@
 /// <reference types="vite/client" />
 
+interface WebMCPRegisteredTool {
+  name: string;
+  description: string;
+  inputSchema: Record<string, unknown>;
+  annotations?: {
+    readOnlyHint?: boolean;
+  };
+  execute: (input: unknown) => Promise<Record<string, unknown>>;
+}
+
+interface ModelContext {
+  registerTool(tool: WebMCPRegisteredTool): Promise<void>;
+  unregisterTool?(name: string): Promise<void>;
+}
+
+interface Document {
+  modelContext?: ModelContext;
+}
+
 declare module "*.svg?react" {
   import React from "react";
   const SVGComponent: React.FC<React.SVGProps<SVGSVGElement>>;


### PR DESCRIPTION
Summary\n- register WebMCP site tools when the Settings page is open\n- support power-management reads and writes plus factory reset through existing device RPCs\n- support listing, typed in-memory editing, saving, discarding, and resetting advanced custom settings\n\n## Verification\n- npm run lint\n- npm run build\n- npm test -- --runInBand --silent\n\nBased on the WebMCP site-tools guidance: https://learn.chatgpt.com/docs/webmcp